### PR TITLE
[ODS-144] 전역 레이아웃에서 세로 스크롤바 크기만큼 가로 스크롤바가 생기는 현상 수정

### DIFF
--- a/src/app.component/layout/app-layout-shell.tsx
+++ b/src/app.component/layout/app-layout-shell.tsx
@@ -367,7 +367,7 @@ export default function AppLayoutShell({
         isRightSidebarCollapsed: false,
       }}
     >
-      <div className="flex min-h-screen w-screen flex-col bg-white">
+      <div className="flex min-h-screen w-full flex-col bg-white">
         {showHeader ? (
           <header className="sticky top-0 z-30 shrink-0 bg-white px-4 pt-3">
             <AppHeader


### PR DESCRIPTION
## 📌 Summary

<!-- 간단한 설명 -->

전역 레이아웃에서 세로 스크롤바 크기만큼 가로 스크롤바가 생기는 현상을 수정했습니다.

- asis
<img width="1876" height="939" alt="image" src="https://github.com/user-attachments/assets/fa24d074-37fc-4799-b871-df9af16ab273" />

- tobe
<img width="1875" height="939" alt="image" src="https://github.com/user-attachments/assets/6f80ab45-fe1f-43cb-b7b7-4634ab5ce80e" />


## ✅ 작업 내용

- AppLayoutShell의 가로 속성을 w-screen(100vw)에서 w-full(100%)로 변경하였습니다.

## 📎 기타

- 기타 사항이 있다면 작성하거나 첨부해 주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted root layout container width styling to improve responsive behavior across different viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->