### PR TITLE
[ODS-132] feat: 유저 삭제 API 연결

### DIFF
--- a/src/app.feature/auth/screen/step-pages/step1.tsx
+++ b/src/app.feature/auth/screen/step-pages/step1.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import {
+  AvatarImagePicker,
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Text,
+  TextField,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@1d1s/design-system';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@component/ui/form';
+import { getDayOptions, getMonthOptions, getYearOptions } from '@module/utils/date';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import {
+  SIGN_UP_GENDER_OPTIONS,
+  SIGN_UP_OCCUPATION_OPTIONS,
+} from '../../consts/sign-up-options';
+import { SignupFormValues } from '../../hooks/use-sign-up-form';
+import type { GenderType } from '../../type/auth';
+
+const SIGN_UP_LEFT_VISUAL_SIZE = 200;
+
+interface Step1Props {
+  onNext(): void;
+}
+
+export function Step1({ onNext }: Step1Props): React.ReactElement {
+  const form = useFormContext<SignupFormValues>();
+  const [imgPreviewUrl, setImgPreviewUrl] = React.useState<
+    string | undefined
+  >();
+
+  const yearOptions = getYearOptions();
+  const monthOptions = getMonthOptions();
+  const dayOptions = getDayOptions();
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1080px] flex-1 items-stretch px-4 pb-5">
+      <div className="grid w-full gap-6 lg:min-h-0 lg:grid-cols-[0.9fr_1.1fr]">
+        <section className="flex min-h-0 flex-col pt-2 text-left">
+          <Text size="display2" weight="bold" className="text-gray-900">
+            나에 대해 알려주세요.
+          </Text>
+          <Text size="body2" weight="regular" className="mt-3 text-gray-600">
+            몇 가지 정보를 입력하고 맞춤 챌린지를 추천받아보세요.
+          </Text>
+
+          <div className="mt-6 flex justify-center lg:mt-8">
+            <FormField
+              control={form.control}
+              name="img"
+              render={({ field }) => (
+                <FormItem className="mb-5">
+                  <AvatarImagePicker
+                    size={SIGN_UP_LEFT_VISUAL_SIZE}
+                    defaultImageUrl={imgPreviewUrl}
+                    changeLabel="사진 추가"
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                      const file = event.target.files?.[0] || undefined;
+                      field.onChange(file);
+                      if (file) {
+                        setImgPreviewUrl(URL.createObjectURL(file));
+                      }
+                    }}
+                  />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </section>
+
+        <section className="rounded-4 flex min-h-0 flex-col border border-gray-200 bg-white p-5 shadow-[0_8px_20px_rgba(34,34,34,0.04)] lg:max-h-[620px] lg:self-start lg:overflow-y-auto lg:p-6">
+          <FormField
+            control={form.control}
+            name="nickname"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <TextField
+                    label="닉네임"
+                    placeholder="예: 챌린저123"
+                    id="nickname"
+                    className="w-full"
+                    value={field.value ?? ''}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    name={field.name}
+                    ref={field.ref}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="mt-5">
+            <Text size="body2" weight="bold" className="mb-1 text-gray-800">
+              생년월일
+            </Text>
+            <div className="grid grid-cols-3 gap-3">
+              <FormField
+                control={form.control}
+                name="year"
+                render={({ field }) => (
+                  <FormItem>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger className="w-full !min-w-0">
+                          <SelectValue placeholder="년" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {yearOptions.map((year) => (
+                          <SelectItem key={year} value={String(year)}>
+                            {year}년
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="month"
+                render={({ field }) => (
+                  <FormItem>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger className="w-full !min-w-0">
+                          <SelectValue placeholder="월" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {monthOptions.map((month) => (
+                          <SelectItem key={month} value={String(month)}>
+                            {month}월
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="day"
+                render={({ field }) => (
+                  <FormItem>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger className="w-full !min-w-0">
+                          <SelectValue placeholder="일" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {dayOptions.map((day) => (
+                          <SelectItem key={day} value={String(day)}>
+                            {day}일
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+
+          <div className="mt-5">
+            <Text size="body2" weight="bold" className="mb-1 text-gray-800">
+              성별
+            </Text>
+            <FormField
+              control={form.control}
+              name="gender"
+              render={({ field }) => (
+                <FormItem>
+                  <ToggleGroup
+                    type="single"
+                    value={field.value}
+                    onValueChange={(value) => {
+                      if (value) {
+                        field.onChange(value as GenderType);
+                      }
+                    }}
+                    className="grid grid-cols-3 gap-2"
+                  >
+                    {SIGN_UP_GENDER_OPTIONS.map((option) => (
+                      <ToggleGroupItem
+                        key={option.value}
+                        value={option.value}
+                        shape="square"
+                        className="h-10 w-full justify-center px-0"
+                      >
+                        {option.label}
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="mt-5">
+            <Text size="body2" weight="bold" className="mb-1 text-gray-800">
+              직업
+            </Text>
+            <FormField
+              control={form.control}
+              name="job"
+              render={({ field }) => (
+                <FormItem>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger className="w-full !min-w-0">
+                        <SelectValue placeholder="직업 선택" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {SIGN_UP_OCCUPATION_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="mt-5">
+            <Text size="body2" weight="bold" className="mb-1 text-gray-800">
+              프로필 공개
+            </Text>
+            <FormField
+              control={form.control}
+              name="isPublic"
+              render={({ field }) => (
+                <FormItem>
+                  <ToggleGroup
+                    type="single"
+                    value={field.value ? 'public' : 'private'}
+                    onValueChange={(value) => {
+                      if (value) {
+                        field.onChange(value === 'public');
+                      }
+                    }}
+                    className="grid grid-cols-2 gap-2"
+                  >
+                    <ToggleGroupItem
+                      value="public"
+                      shape="square"
+                      className="h-10 w-full justify-center px-0"
+                    >
+                      공개
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                      value="private"
+                      shape="square"
+                      className="h-10 w-full justify-center px-0"
+                    >
+                      비공개
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="mt-8 flex justify-end">
+            <Button type="button" size="medium" onClick={onNext}>
+              다음 단계
+            </Button>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/auth/screen/step-pages/step2.tsx
+++ b/src/app.feature/auth/screen/step-pages/step2.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { Button, CheckContainer, Text } from '@1d1s/design-system';
+import { FormField, FormItem, FormMessage } from '@component/ui/form';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { SIGN_UP_TOPIC_OPTIONS } from '../../consts/sign-up-options';
+import { SignupFormValues } from '../../hooks/use-sign-up-form';
+
+const SIGN_UP_LEFT_VISUAL_SLOT_HEIGHT = 280;
+
+interface Step2Props {
+  onPrev(): void;
+  onSubmit(): void;
+  isSubmitting: boolean;
+}
+
+export function Step2({
+  onPrev,
+  onSubmit,
+  isSubmitting,
+}: Step2Props): React.ReactElement {
+  const form = useFormContext<SignupFormValues>();
+  const selectedTopics = form.watch('topics') ?? [];
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1080px] flex-1 items-stretch px-4 pb-5">
+      <div className="grid w-full gap-6 lg:min-h-0 lg:grid-cols-[0.9fr_1.1fr]">
+        <section className="flex min-h-0 flex-col pt-2 text-left">
+          <Text size="display2" weight="bold" className="text-gray-900">
+            어떤 주제에 관심이 있나요?
+          </Text>
+          <Text size="body2" weight="regular" className="mt-3 text-gray-600">
+            도전하고 싶은 관심 주제를 선택해주세요.
+          </Text>
+          <div
+            aria-hidden
+            className="mt-6 hidden lg:mt-8 lg:block"
+            style={{ height: SIGN_UP_LEFT_VISUAL_SLOT_HEIGHT }}
+          />
+        </section>
+
+        <section className="rounded-4 flex min-h-0 flex-col border border-gray-200 bg-white p-5 shadow-[0_8px_20px_rgba(34,34,34,0.04)] lg:max-h-[620px] lg:self-start lg:overflow-y-auto lg:p-6">
+          <FormField
+            control={form.control}
+            name="topics"
+            render={({ field }) => (
+              <FormItem>
+                <Text
+                  size="body2"
+                  weight="regular"
+                  className="mb-3 text-gray-500"
+                >
+                  최대 3개까지 선택할 수 있어요.
+                </Text>
+                <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+                  {SIGN_UP_TOPIC_OPTIONS.map((option) => {
+                    const checked = Array.isArray(selectedTopics)
+                      ? selectedTopics.includes(option.value)
+                      : false;
+                    const isMaxReached = selectedTopics.length >= 3;
+
+                    return (
+                      <CheckContainer
+                        key={option.value}
+                        type="button"
+                        checked={checked}
+                        disabled={!checked && isMaxReached}
+                        onCheckedChange={(nextChecked) => {
+                          const currentTopics = Array.isArray(
+                            form.getValues('topics')
+                          )
+                            ? form.getValues('topics')
+                            : [];
+                          if (nextChecked && currentTopics.length >= 3) {
+                            return;
+                          }
+                          const nextTopics = nextChecked
+                            ? Array.from(
+                                new Set([...currentTopics, option.value])
+                              )
+                            : currentTopics.filter(
+                                (topic) => topic !== option.value
+                              );
+
+                          field.onChange(nextTopics);
+                        }}
+                        width="100%"
+                        height={96}
+                        showCheckIndicator
+                        className="rounded-3 w-full min-w-0 px-3"
+                      >
+                        <div className="flex w-full flex-col items-center justify-center gap-2">
+                          <span className="text-xl leading-none">
+                            {option.icon}
+                          </span>
+                          <Text
+                            size="body2"
+                            weight="medium"
+                            className="text-gray-700"
+                          >
+                            {option.label}
+                          </Text>
+                        </div>
+                      </CheckContainer>
+                    );
+                  })}
+                </div>
+                <div className="mt-4 text-left">
+                  <FormMessage />
+                </div>
+              </FormItem>
+            )}
+          />
+
+          <div className="mt-8 flex items-center justify-between gap-3">
+            <Button
+              type="button"
+              size="medium"
+              variant="outlined"
+              disabled={isSubmitting}
+              onClick={onPrev}
+            >
+              이전 단계
+            </Button>
+            <Button
+              type="button"
+              size="medium"
+              disabled={isSubmitting || selectedTopics.length === 0}
+              onClick={onSubmit}
+            >
+              {isSubmitting ? '처리 중...' : '가입 완료'}
+            </Button>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/member/api/member-api.ts
+++ b/src/app.feature/member/api/member-api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@module/api/client';
-import { requestData } from '@module/api/request';
+import { requestBody, requestData } from '@module/api/request';
 
 import type { MemberProfileData, MyPageData, SidebarData } from '../type/member';
 
@@ -51,4 +51,10 @@ export const memberApi = {
       data: { objectKey },
     });
   },
+
+  deleteMember: async (): Promise<{ message?: string }> =>
+    requestBody<{ message?: string }>(apiClient, {
+      url: '/member',
+      method: 'DELETE',
+    }),
 };

--- a/src/app.feature/member/hooks/use-member-mutations.ts
+++ b/src/app.feature/member/hooks/use-member-mutations.ts
@@ -1,3 +1,5 @@
+import { clearCachedSidebar } from '@feature/member/hooks/use-member-queries';
+import { authStorage } from '@module/utils/auth';
 import {
   useMutation,
   UseMutationResult,
@@ -35,6 +37,23 @@ export function useUpdateProfileImage(): UseMutationResult<void, Error, File> {
       void queryClient.invalidateQueries({
         queryKey: MEMBER_QUERY_KEYS.sidebar(),
       });
+    },
+  });
+}
+
+export function useDeleteMember(): UseMutationResult<
+  { message?: string },
+  Error,
+  void
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => memberApi.deleteMember(),
+    onSuccess: () => {
+      authStorage.clearTokens();
+      clearCachedSidebar();
+      queryClient.clear();
     },
   });
 }

--- a/src/app.feature/member/type/member.ts
+++ b/src/app.feature/member/type/member.ts
@@ -36,6 +36,9 @@ export interface MyPageStreak {
   currentMonthDiaryCount: number;
   currentMonthGoalCount: number;
   maxStreak: number;
+  longestGoalStreak?: Array<Record<string, number>>;
+  totalChallengeCount?: number;
+  completedFiniteChallengeCount?: number;
   calendar: StreakCalendarItem[];
 }
 
@@ -95,4 +98,5 @@ export interface MyPageData {
   streak: MyPageStreak;
   challengeList: MyPageChallenge[];
   diaryList: MyPageDiary[];
+  pageInfo?: MemberDiaryPageInfo;
 }

--- a/src/app.module/utils/date.ts
+++ b/src/app.module/utils/date.ts
@@ -1,0 +1,12 @@
+export function getYearOptions(length: number = 100): number[] {
+  const currentYear = new Date().getFullYear();
+  return Array.from({ length }, (_, i) => currentYear - i);
+}
+
+export function getMonthOptions(): number[] {
+  return Array.from({ length: 12 }, (_, i) => i + 1);
+}
+
+export function getDayOptions(): number[] {
+  return Array.from({ length: 31 }, (_, i) => i + 1);
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -20,6 +20,7 @@ import { authStorage } from '@module/utils/auth';
 import {
   CheckCircle2,
   FileText,
+  Flag,
   Flame,
   PencilLine,
   Plus,
@@ -82,6 +83,29 @@ function resolveDiaryImage(diary: DiaryItem): string {
   return '/images/default-card.png';
 }
 
+function getLongestGoalStreakSummary(
+  longestGoalStreak: Array<Record<string, number>> | undefined
+): { goalTitle: string; streakCount: number } {
+  const firstEntry = longestGoalStreak?.[0];
+
+  if (!firstEntry) {
+    return {
+      goalTitle: '아직 기록이 없어요',
+      streakCount: 0,
+    };
+  }
+
+  const [goalTitle, streakCount] = Object.entries(firstEntry)[0] ?? [
+    '아직 기록이 없어요',
+    0,
+  ];
+
+  return {
+    goalTitle,
+    streakCount,
+  };
+}
+
 export default function MyPage(): React.ReactElement | null {
   const router = useRouter();
   const hasMounted = useSyncExternalStore(
@@ -124,6 +148,9 @@ function MyPageContent(): React.ReactElement {
   }
 
   const { nickname, profileUrl, streak, challengeList } = data;
+  const longestGoalStreak = getLongestGoalStreakSummary(
+    streak.longestGoalStreak
+  );
 
   const handleDiaryLikeToggle = (diary: {
     id: number;
@@ -245,50 +272,51 @@ function MyPageContent(): React.ReactElement {
             <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
               <StatCard
                 icon={<Flame className="h-5 w-5" />}
-                title="현재 스트릭"
+                title="현재 일지 스트릭"
                 value={String(streak.currentStreak)}
                 unit="일"
               />
               <StatCard
                 icon={<Trophy className="h-5 w-5" />}
-                title="최장 스트릭"
+                title="일지 최장 스트릭"
                 value={String(streak.maxStreak)}
                 unit="일"
               />
               <StatCard
+                icon={<Target className="h-5 w-5" />}
+                title="목표 최장 스트릭"
+                value={String(longestGoalStreak.streakCount)}
+                unit="일"
+                iconTone="text-pink-600"
+                description={longestGoalStreak.goalTitle}
+              />
+              <StatCard
+                icon={<Flag className="h-5 w-5" />}
+                title="참여한 챌린지 수"
+                value={String(streak.totalChallengeCount ?? 0)}
+                unit="개"
+                iconTone="text-blue-600"
+              />
+              <StatCard
+                icon={<CheckCircle2 className="h-5 w-5" />}
+                title="완료한 단기 챌린지 수"
+                value={String(streak.completedFiniteChallengeCount ?? 0)}
+                unit="개"
+                iconTone="text-emerald-600"
+              />
+              <StatCard
                 icon={<FileText className="h-5 w-5" />}
-                title="전체 일지"
+                title="작성한 전체 일지 수"
                 value={String(streak.totalDiaryCount)}
                 unit="개"
                 iconTone="text-purple-600"
               />
               <StatCard
                 icon={<Target className="h-5 w-5" />}
-                title="전체 목표"
+                title="완료한 전체 목표 수"
                 value={String(streak.totalGoalCount)}
                 unit="개"
                 iconTone="text-pink-600"
-              />
-              <StatCard
-                icon={<CheckCircle2 className="h-5 w-5" />}
-                title="이번 달 일지"
-                value={String(streak.currentMonthDiaryCount)}
-                unit="개"
-                iconTone="text-emerald-600"
-              />
-              <StatCard
-                icon={<CheckCircle2 className="h-5 w-5" />}
-                title="이번 달 목표"
-                value={String(streak.currentMonthGoalCount)}
-                unit="개"
-                iconTone="text-blue-600"
-              />
-              <StatCard
-                icon={<Target className="h-5 w-5" />}
-                title="오늘의 목표"
-                value={String(streak.todayGoalCount)}
-                unit="개"
-                iconTone="text-main-800"
               />
             </div>
           </section>
@@ -422,12 +450,14 @@ function StatCard({
   value,
   unit,
   iconTone = 'text-main-800',
+  description,
 }: {
   icon: React.ReactNode;
   title: string;
   value: string;
   unit: string;
   iconTone?: string;
+  description?: string;
 }): React.ReactElement {
   return (
     <article className="rounded-3 border border-gray-200 bg-white p-4">
@@ -441,13 +471,23 @@ function StatCard({
           {title}
         </Text>
       </div>
-      <div className="mt-3 flex items-end gap-1">
+      <div className="mt-3 flex min-w-0 items-baseline gap-1.5">
         <Text size="display2" weight="bold" className="text-gray-900">
           {value}
         </Text>
-        <Text size="body1" weight="medium" className="pb-1 text-gray-500">
+        <Text size="body1" weight="medium" className="text-gray-500">
           {unit}
         </Text>
+        {description && (
+          <Text
+            size="body1"
+            weight="medium"
+            className="min-w-0 flex-1 truncate text-gray-500"
+            title={description}
+          >
+            - {description}
+          </Text>
+        )}
       </div>
     </article>
   );

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -294,11 +294,17 @@ function MyPageContent(): React.ReactElement {
           </section>
 
           <section>
-            <Text size="display2" weight="bold" className="mb-4 text-gray-900">
+            <Text size="display2" weight="bold" className="text-gray-900">
               활동 기록
             </Text>
 
-            <Streak data={buildYearStreak(streak.calendar)} size={14} gap={6} />
+            <div className="mt-4">
+              <Streak
+                data={buildYearStreak(streak.calendar)}
+                size={14}
+                gap={6}
+              />
+            </div>
           </section>
 
           <section>

--- a/src/app/mypage/settings/page.tsx
+++ b/src/app/mypage/settings/page.tsx
@@ -19,7 +19,7 @@ import {
 } from '@feature/member/hooks/use-member-mutations';
 import { useMyPage } from '@feature/member/hooks/use-member-queries';
 import { validateNickname } from '@module/utils/nickname';
-import { LogOut } from 'lucide-react';
+import { LogOut, UserMinus } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import React, { useState } from 'react';
@@ -57,6 +57,7 @@ export default function AccountSettingsPage(): React.ReactElement {
     string | undefined
   >();
   const [isLogoutDialogOpen, setIsLogoutDialogOpen] = useState(false);
+  const [isWithdrawDialogOpen, setIsWithdrawDialogOpen] = useState(false);
 
   const nickname = editedNickname ?? data?.nickname ?? '';
   const profilePreview = localProfilePreview ?? data?.profileUrl ?? '';
@@ -260,6 +261,19 @@ export default function AccountSettingsPage(): React.ReactElement {
                 {logout.isPending ? '로그아웃 중...' : '로그아웃'}
               </Text>
             </button>
+
+            <div className="h-px w-full bg-gray-100" />
+
+            <button
+              type="button"
+              onClick={() => setIsWithdrawDialogOpen(true)}
+              className="flex w-full items-center gap-3 px-5 py-4 text-gray-500 transition hover:bg-gray-50"
+            >
+              <UserMinus className="h-5 w-5" />
+              <Text size="body1" weight="medium" className="text-gray-600">
+                회원탈퇴
+              </Text>
+            </button>
           </section>
         </div>
       </section>
@@ -291,6 +305,31 @@ export default function AccountSettingsPage(): React.ReactElement {
               disabled={logout.isPending}
             >
               {logout.isPending ? '로그아웃 중...' : '로그아웃'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={isWithdrawDialogOpen}
+        onOpenChange={setIsWithdrawDialogOpen}
+      >
+        <DialogContent className="gap-6 px-8 py-6 sm:max-w-[380px] sm:px-6">
+          <DialogHeader className="items-center text-center sm:text-center">
+            <DialogTitle>회원탈퇴</DialogTitle>
+          </DialogHeader>
+
+          <DialogDescription className="block w-full text-center">
+            회원탈퇴 기능은 아직 준비 중입니다.
+          </DialogDescription>
+
+          <DialogFooter className="flex-row gap-2">
+            <Button
+              size="medium"
+              className="flex-1"
+              onClick={() => setIsWithdrawDialogOpen(false)}
+            >
+              확인
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/mypage/settings/page.tsx
+++ b/src/app/mypage/settings/page.tsx
@@ -107,7 +107,7 @@ export default function AccountSettingsPage(): React.ReactElement {
 
   return (
     <div className="flex min-h-screen w-full flex-col bg-white p-4">
-      <section className="rounded-3 w-full bg-white p-2">
+      <section className="rounded-3 mx-auto w-full max-w-[980px] bg-white p-2">
         <div className="flex items-start justify-between border-b border-gray-200 pb-5">
           <Text size="display1" weight="bold" className="text-gray-900">
             계정 설정

--- a/src/app/mypage/settings/page.tsx
+++ b/src/app/mypage/settings/page.tsx
@@ -14,15 +14,18 @@ import {
 } from '@1d1s/design-system';
 import { useLogout } from '@feature/auth/hooks/use-auth-mutations';
 import {
+  useDeleteMember,
   useUpdateNickname,
   useUpdateProfileImage,
 } from '@feature/member/hooks/use-member-mutations';
 import { useMyPage } from '@feature/member/hooks/use-member-queries';
+import { notifyApiError } from '@module/api/error';
 import { validateNickname } from '@module/utils/nickname';
 import { LogOut, UserMinus } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import React, { useState } from 'react';
+import { toast } from 'sonner';
 
 const PROVIDER_CONFIG = {
   KAKAO: {
@@ -64,6 +67,7 @@ export default function AccountSettingsPage(): React.ReactElement {
 
   const updateNickname = useUpdateNickname();
   const updateProfileImage = useUpdateProfileImage();
+  const deleteMember = useDeleteMember();
 
   const handleProfileImageChange = (
     event: React.ChangeEvent<HTMLInputElement>
@@ -101,6 +105,19 @@ export default function AccountSettingsPage(): React.ReactElement {
       onSettled: () => {
         setIsLogoutDialogOpen(false);
         router.replace('/login');
+      },
+    });
+  };
+
+  const confirmWithdraw = (): void => {
+    deleteMember.mutate(undefined, {
+      onSuccess: (response) => {
+        setIsWithdrawDialogOpen(false);
+        toast.success(response.message ?? '회원 탈퇴가 완료되었습니다.');
+        router.replace('/login');
+      },
+      onError: (error) => {
+        notifyApiError(error);
       },
     });
   };
@@ -253,7 +270,7 @@ export default function AccountSettingsPage(): React.ReactElement {
             <button
               type="button"
               onClick={() => setIsLogoutDialogOpen(true)}
-              disabled={logout.isPending}
+              disabled={logout.isPending || deleteMember.isPending}
               className="flex w-full items-center gap-3 px-5 py-4 text-red-500 transition hover:bg-red-50 disabled:opacity-50"
             >
               <LogOut className="h-5 w-5" />
@@ -267,6 +284,7 @@ export default function AccountSettingsPage(): React.ReactElement {
             <button
               type="button"
               onClick={() => setIsWithdrawDialogOpen(true)}
+              disabled={logout.isPending || deleteMember.isPending}
               className="flex w-full items-center gap-3 px-5 py-4 text-gray-500 transition hover:bg-gray-50"
             >
               <UserMinus className="h-5 w-5" />
@@ -294,7 +312,7 @@ export default function AccountSettingsPage(): React.ReactElement {
               variant="ghost"
               className="flex-1"
               onClick={() => setIsLogoutDialogOpen(false)}
-              disabled={logout.isPending}
+              disabled={logout.isPending || deleteMember.isPending}
             >
               취소
             </Button>
@@ -302,7 +320,7 @@ export default function AccountSettingsPage(): React.ReactElement {
               size="medium"
               className="flex-1"
               onClick={confirmLogout}
-              disabled={logout.isPending}
+              disabled={logout.isPending || deleteMember.isPending}
             >
               {logout.isPending ? '로그아웃 중...' : '로그아웃'}
             </Button>
@@ -316,20 +334,30 @@ export default function AccountSettingsPage(): React.ReactElement {
       >
         <DialogContent className="gap-6 px-8 py-6 sm:max-w-[380px] sm:px-6">
           <DialogHeader className="items-center text-center sm:text-center">
-            <DialogTitle>회원탈퇴</DialogTitle>
+            <DialogTitle>회원탈퇴 하시겠어요?</DialogTitle>
           </DialogHeader>
 
           <DialogDescription className="block w-full text-center">
-            회원탈퇴 기능은 아직 준비 중입니다.
+            회원 탈퇴 요청 후 계정 삭제는 7일 뒤 처리됩니다.
           </DialogDescription>
 
           <DialogFooter className="flex-row gap-2">
             <Button
               size="medium"
+              variant="ghost"
               className="flex-1"
               onClick={() => setIsWithdrawDialogOpen(false)}
+              disabled={deleteMember.isPending || logout.isPending}
             >
-              확인
+              취소
+            </Button>
+            <Button
+              size="medium"
+              className="flex-1"
+              onClick={confirmWithdraw}
+              disabled={deleteMember.isPending || logout.isPending}
+            >
+              {deleteMember.isPending ? '처리 중...' : '회원탈퇴'}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## 📌 Summary

<!-- 간단한 설명 -->

유저 삭제 API를 연결합니다.

## ✅ 작업 내용

- 유저 삭제 API와 싱크를 맞췄습니다.
- 삭제된 유저를 조회할 때, 없는 유저 조회할 떄와 동일하게 보여줍니다.

## 📎 기타

- 유저 삭제 요청 이후 다시 로그인하면 별다른 안내 없이 다시 로그인되는데, 실제로 삭제가 안 이루어지고 이용할 수 있는 것인지 궁금합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account withdrawal flow with confirmation dialog; completing withdrawal clears session and returns to login.
  * Expanded profile stats: goal longest streak, challenge participation and completed-challenge counts, plus updated stat labels.
  * Stat cards now show optional descriptive lines.
  * New signup wizard pages for avatar, personal info, and topic selection with selection limits.
  * Date picker helpers for year/month/day selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->