### PR TITLE
[ODS-158] feat: feat: 회원가입 부분 리팩토링 및 토큰 관련 리팩토링

### DIFF
--- a/src/app.feature/auth/screen/sign-up-screen.tsx
+++ b/src/app.feature/auth/screen/sign-up-screen.tsx
@@ -140,7 +140,7 @@ export function SignUpScreen(): React.ReactElement {
   };
 
   return (
-    <div className="flex min-h-screen w-full flex-col bg-gray-50 lg:h-screen lg:overflow-hidden">
+    <div className="flex min-h-screen w-full flex-col bg-gray-50 lg:overflow-y-auto">
       <Dialog open={showExitDialog} onOpenChange={setShowExitDialog}>
         <DialogContent className="gap-6 px-8 py-6 sm:max-w-[380px] sm:px-6">
           <DialogHeader className="items-center text-center sm:text-center">

--- a/src/app.feature/diary/detail/screen/diary-detail-screen.tsx
+++ b/src/app.feature/diary/detail/screen/diary-detail-screen.tsx
@@ -15,7 +15,7 @@ import { getCategoryLabel } from '@constants/categories';
 import { ChallengeListItem } from '@feature/challenge/shared/components/challenge-list-item';
 import { formatChallengeTypeLabel } from '@feature/challenge/shared/utils/challenge-display';
 import { normalizeApiError } from '@module/api/error';
-import { authStorage, getCurrentMemberId } from '@module/utils/auth';
+import { authStorage } from '@module/utils/auth';
 import {
   CalendarDays,
   Edit3,
@@ -430,12 +430,10 @@ function DiaryDetailView({
 }): React.ReactElement {
   const router = useRouter();
   const { data: sidebarData } = useSidebar();
-  const currentMemberId = getCurrentMemberId();
-  const currentSidebarMemberId = useMemo(
+  const currentMemberId = useMemo(
     () => resolveSidebarMemberId(sidebarData),
     [sidebarData]
   );
-  const effectiveCurrentMemberId = currentMemberId ?? currentSidebarMemberId;
   const currentUserNickname = useMemo(
     () => sidebarData?.nickname?.trim() ?? null,
     [sidebarData?.nickname]
@@ -494,15 +492,15 @@ function DiaryDetailView({
           profileImageUrl: comment.author.profileImage ?? undefined,
         },
         isAuthor:
-          (effectiveCurrentMemberId !== null &&
-            comment.author.id === effectiveCurrentMemberId) ||
-          (effectiveCurrentMemberId === null &&
+          (currentMemberId !== null &&
+            comment.author.id === currentMemberId) ||
+          (currentMemberId === null &&
             Boolean(authorNickname) &&
             Boolean(currentUserNickname) &&
             authorNickname === currentUserNickname),
       };
     },
-    [currentUserNickname, effectiveCurrentMemberId]
+    [currentUserNickname, currentMemberId]
   );
 
   const threadComments = useMemo<CommentNode[]>(
@@ -909,8 +907,8 @@ function DiaryDetailView({
               <CommentThread
                 comments={threadComments}
                 currentUserId={
-                  effectiveCurrentMemberId !== null
-                    ? String(effectiveCurrentMemberId)
+                  currentMemberId !== null
+                    ? String(currentMemberId)
                     : undefined
                 }
                 onReplySubmit={handleReplySubmit}

--- a/src/app.feature/member/hooks/use-member-queries.ts
+++ b/src/app.feature/member/hooks/use-member-queries.ts
@@ -3,7 +3,6 @@ import { isUnauthorizedError } from '@module/api/error';
 import { requestData } from '@module/api/request';
 import { authStorage } from '@module/utils/auth';
 import { isServer, useQuery, UseQueryResult } from '@tanstack/react-query';
-import axios from 'axios';
 
 import { memberApi } from '../api/member-api';
 import { MEMBER_QUERY_KEYS } from '../consts/query-keys';
@@ -12,6 +11,7 @@ import type { MemberProfileData, MyPageData, SidebarData } from '../type/member'
 const SIDEBAR_CACHE_KEY = '1d1s:sidebar';
 const MEMBER_INFO_STALE_TIME = Number.POSITIVE_INFINITY;
 const MEMBER_INFO_GC_TIME = Number.POSITIVE_INFINITY;
+const SIDEBAR_MAX_RETRIES = 2;
 
 function getCachedSidebar(): SidebarData | undefined {
   if (typeof window === 'undefined') {
@@ -37,14 +37,48 @@ export function clearCachedSidebar(): void {
   localStorage.removeItem(SIDEBAR_CACHE_KEY);
 }
 
-const isRefreshFailure = (error: unknown): boolean =>
-  axios.isAxiosError(error) &&
-  (error.response?.status === 401 || error.response?.status === 302);
-
-const logoutAndClearSidebar = (): void => {
+/** 백엔드 로그아웃 API 호출 + 로컬 인증 상태 정리 */
+async function forceLogout(): Promise<void> {
+  try {
+    await tokenClient.post('/auth/logout');
+  } catch {
+    // 로그아웃 API 실패는 무시하고 로컬 상태만 정리
+  }
   clearCachedSidebar();
   authStorage.clearTokens();
-};
+}
+
+async function fetchSidebar(): Promise<SidebarData> {
+  return requestData<SidebarData>(silentAuthClient, {
+    url: '/member/side-bar',
+    method: 'GET',
+  });
+}
+
+/**
+ * 사이드바 데이터 요청 (최대 3회 시도)
+ * - 401: 즉시 포기 → 강제 로그아웃
+ * - 기타 오류: 2번 더 재시도 → 모두 실패 시 강제 로그아웃
+ */
+async function fetchSidebarWithRetry(): Promise<SidebarData | null> {
+  for (let attempt = 0; attempt <= SIDEBAR_MAX_RETRIES; attempt++) {
+    try {
+      const data = await fetchSidebar();
+      return data ?? null;
+    } catch (error) {
+      if (isUnauthorizedError(error)) {
+        await forceLogout();
+        return null;
+      }
+      // 마지막 시도에서도 실패하면 강제 로그아웃
+      if (attempt === SIDEBAR_MAX_RETRIES) {
+        await forceLogout();
+        return null;
+      }
+    }
+  }
+  return null;
+}
 
 export function useSidebar(): UseQueryResult<SidebarData | null, Error> {
   const cachedSidebar = getCachedSidebar();
@@ -52,42 +86,15 @@ export function useSidebar(): UseQueryResult<SidebarData | null, Error> {
   return useQuery({
     queryKey: MEMBER_QUERY_KEYS.sidebar(),
     queryFn: async () => {
-      // accessToken(또는 devAccessToken)이 없으면 리프레시 선시도
-      if (!authStorage.getAccessToken()) {
-        try {
-          await tokenClient.get('/auth/token');
-        } catch (refreshError) {
-          if (isRefreshFailure(refreshError)) {
-            logoutAndClearSidebar();
-            return null;
-          }
-          // 네트워크 오류 등은 무시하고 계속 진행
-        }
-      }
-
-      try {
-        // silentAuthClient: 401에서 리다이렉트/토스트 없이 조용히 처리
-        // withCredentials로 백엔드 쿠키를 자동 전송 → 응답 결과로 인증 상태 판단
-        const data = await requestData<SidebarData>(silentAuthClient, {
-          url: '/member/side-bar',
-          method: 'GET',
-        });
-        if (!data) {
-          return null;
-        }
+      const data = await fetchSidebarWithRetry();
+      if (data) {
         authStorage.markAuthenticated();
         setCachedSidebar(data);
-        return data;
-      } catch (error) {
-        if (isUnauthorizedError(error)) {
-          // 세션 없음 - 조용히 null 반환 (리다이렉트 없음)
-          authStorage.clearTokens();
-          return null;
-        }
-        throw error;
       }
+      return data;
     },
-    enabled: !isServer, // 서버에서는 실행 안 함 (쿠키 없어 401 → 매 SSR마다 불필요한 API 호출)
+    retry: false, // queryFn 내부에서 직접 재시도 처리
+    enabled: !isServer,
     placeholderData: cachedSidebar ?? null,
     staleTime: MEMBER_INFO_STALE_TIME,
     gcTime: MEMBER_INFO_GC_TIME,

--- a/src/app.module/api/client.ts
+++ b/src/app.module/api/client.ts
@@ -1,9 +1,4 @@
-import { authStorage } from '@module/utils/auth';
-import axios, {
-  AxiosHeaders,
-  type AxiosInstance,
-  type InternalAxiosRequestConfig,
-} from 'axios';
+import axios, { type AxiosInstance } from 'axios';
 
 import { API_BASE_URL } from './config';
 import { attachInterceptors, type ClientOptions } from './interceptors';
@@ -20,12 +15,10 @@ const createClient = (options: ClientOptions): AxiosInstance =>
   );
 
 export const apiClient = createClient({
-  withAuthToken: true,
   handleUnauthorized: true,
 });
 
 export const publicApiClient = createClient({
-  withAuthToken: false,
   handleUnauthorized: false,
 });
 
@@ -45,36 +38,11 @@ export const silentAuthClient: AxiosInstance = (() => {
     withCredentials: true,
   });
 
-  instance.interceptors.request.use(
-    (config: InternalAxiosRequestConfig) => {
-      if (typeof window === 'undefined') {
-        return config;
-      }
-
-      const accessToken = authStorage.getAccessToken();
-      if (!accessToken) {
-        return config;
-      }
-
-      const authorizationValue = accessToken.startsWith('Bearer ')
-        ? accessToken
-        : `Bearer ${accessToken}`;
-
-      const headers = AxiosHeaders.from(config.headers);
-      if (!headers.has('Authorization')) {
-        headers.set('Authorization', authorizationValue);
-        config.headers = headers;
-      }
-
-      return config;
-    }
-  );
-
   instance.interceptors.response.use(
     (response) => response,
     async (error) => {
       const status = error?.response?.status;
-      const config = error?.config as InternalAxiosRequestConfig & {
+      const config = error?.config as import('axios').InternalAxiosRequestConfig & {
         _retried?: boolean;
       };
 
@@ -85,16 +53,7 @@ export const silentAuthClient: AxiosInstance = (() => {
           await tokenClient.get('/auth/token');
           return instance.request(config);
         } catch {
-          // 재발급 실패 → 로그아웃 처리 후 인증 상태 초기화
-          try {
-            await tokenClient.post('/auth/logout');
-          } catch {
-            // 로그아웃 API 실패는 무시하고 로컬 상태만 정리
-          }
-          authStorage.clearTokens();
-          if (typeof window !== 'undefined') {
-            localStorage.removeItem('1d1s:sidebar');
-          }
+          // 재발급 실패는 호출부에서 처리
         }
       }
 

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -134,10 +134,9 @@ export const handleAuthError = (error: unknown): void => {
     return;
   }
 
+  // 토큰 없음/만료 시 조용히 로그아웃 처리 (토스트 표시하지 않음)
   authStorage.clearTokens();
   localStorage.removeItem('1d1s:sidebar');
-
-  notifyApiError(error);
 
   if (!isRedirecting && isProtectedRoute(window.location.pathname)) {
     isRedirecting = true;

--- a/src/app.module/api/interceptors.ts
+++ b/src/app.module/api/interceptors.ts
@@ -8,7 +8,6 @@ import { API_BASE_URL } from './config';
 import { handleAuthError, isUnauthorizedError, notifyApiError } from './error';
 
 export interface ClientOptions {
-  withAuthToken: boolean;
   handleUnauthorized: boolean;
 }
 
@@ -50,14 +49,8 @@ const refreshAccessToken = async (): Promise<void> => {
 
 export const attachInterceptors = (
   client: AxiosInstance,
-  { withAuthToken, handleUnauthorized }: ClientOptions
+  { handleUnauthorized }: ClientOptions
 ): AxiosInstance => {
-  if (withAuthToken) {
-    client.interceptors.request.use(
-      (config: InternalAxiosRequestConfig) => config
-    );
-  }
-
   client.interceptors.response.use(
     async (response) => {
       if (!handleUnauthorized) {

--- a/src/app.module/utils/auth.ts
+++ b/src/app.module/utils/auth.ts
@@ -1,23 +1,9 @@
 import Cookies from 'js-cookie';
 
-import {
-  ACCESS_TOKEN_COOKIE_CANDIDATES,
-  REFRESH_TOKEN_COOKIE_CANDIDATES,
-} from './token-cookie';
-
 const AUTH_SESSION_KEY = '1d1s:isAuthenticated';
 // 서브도메인 간 인증 상태 공유를 위한 힌트 쿠키 (토큰 값 아님, httpOnly 아님)
 const AUTH_HINT_COOKIE = '1d1s:hasSession';
 const AUTH_HINT_COOKIE_DOMAIN = '.1day1streak.com';
-const INVALID_COOKIE_VALUES = new Set(['', 'undefined', 'null']);
-
-function normalizeCookieValue(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed || INVALID_COOKIE_VALUES.has(trimmed)) {
-    return undefined;
-  }
-  return trimmed;
-}
 
 export const authStorage = {
   markAuthenticated: (): void => {
@@ -34,64 +20,8 @@ export const authStorage = {
     });
   },
 
-  // 액세스 토큰 저장
-  setAccessToken: (token: string): void => {
-    void token;
-    // 백엔드 Set-Cookie(HTTP-only) 인증으로 전환되어 토큰은 프론트에서 저장하지 않음
-    authStorage.markAuthenticated();
-  },
-
-  // 리프레시 토큰 저장
-  setRefreshToken: (token: string): void => {
-    void token;
-    // 백엔드 Set-Cookie(HTTP-only) 인증으로 전환되어 토큰은 프론트에서 저장하지 않음
-    authStorage.markAuthenticated();
-  },
-
-  // 액세스 토큰 조회
-  getAccessToken: (): string | undefined => {
-    for (const cookieName of ACCESS_TOKEN_COOKIE_CANDIDATES) {
-      const token = normalizeCookieValue(Cookies.get(cookieName));
-      if (token) {
-        return token;
-      }
-    }
-    return undefined;
-  },
-
-  // 리프레시 토큰 조회
-  getRefreshToken: (): string | undefined => {
-    for (const cookieName of REFRESH_TOKEN_COOKIE_CANDIDATES) {
-      const token = normalizeCookieValue(Cookies.get(cookieName));
-      if (token) {
-        return token;
-      }
-    }
-    return undefined;
-  },
-
-  // 액세스 토큰 제거
-  removeAccessToken: (): void => {
-    for (const cookieName of ACCESS_TOKEN_COOKIE_CANDIDATES) {
-      Cookies.remove(cookieName);
-    }
-  },
-
-  // 리프레시 토큰 제거
-  removeRefreshToken: (): void => {
-    for (const cookieName of REFRESH_TOKEN_COOKIE_CANDIDATES) {
-      Cookies.remove(cookieName);
-    }
-  },
-
-  // 모든 토큰 제거
+  // 인증 상태 플래그 제거 (실제 토큰은 백엔드 Set-Cookie/HTTP-only로 관리)
   clearTokens: (): void => {
-    for (const cookieName of ACCESS_TOKEN_COOKIE_CANDIDATES) {
-      Cookies.remove(cookieName);
-    }
-    for (const cookieName of REFRESH_TOKEN_COOKIE_CANDIDATES) {
-      Cookies.remove(cookieName);
-    }
     if (typeof window !== 'undefined') {
       localStorage.removeItem(AUTH_SESSION_KEY);
     }
@@ -112,68 +42,3 @@ export const authStorage = {
     );
   },
 };
-
-function decodeJwtPayload(token: string): Record<string, unknown> | null {
-  try {
-    const [, payload] = token.split('.');
-    if (!payload) {
-      return null;
-    }
-
-    const normalizedPayload = payload.replace(/-/g, '+').replace(/_/g, '/');
-    const paddedPayload = normalizedPayload.padEnd(
-      normalizedPayload.length + ((4 - (normalizedPayload.length % 4)) % 4),
-      '='
-    );
-
-    const decodedPayload =
-      typeof window !== 'undefined'
-        ? window.atob(paddedPayload)
-        : Buffer.from(paddedPayload, 'base64').toString('utf-8');
-
-    return JSON.parse(decodedPayload) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
-function parsePositiveNumber(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const parsedValue = Number(value);
-    if (Number.isInteger(parsedValue) && parsedValue > 0) {
-      return parsedValue;
-    }
-  }
-
-  return null;
-}
-
-export function getCurrentMemberId(): number | null {
-  const accessToken = authStorage.getAccessToken();
-  const payload = accessToken ? decodeJwtPayload(accessToken) : null;
-  if (!payload) {
-    return null;
-  }
-
-  const candidateKeys = [
-    'memberId',
-    'member_id',
-    'userId',
-    'user_id',
-    'id',
-    'sub',
-  ] as const;
-
-  for (const key of candidateKeys) {
-    const parsedValue = parsePositiveNumber(payload[key]);
-    if (parsedValue !== null) {
-      return parsedValue;
-    }
-  }
-
-  return null;
-}


### PR DESCRIPTION
## 📌 Summary

회원가입 페이지 스크롤 문제 수정 및 인증 관련 코드를 백엔드 set-cookie(HTTP-only) 방식 명세에 맞게 전면 리팩토링

## ✅ 작업 내용

- **회원가입 스크롤 수정**: `lg:h-screen lg:overflow-hidden` → `lg:overflow-y-auto`로 변경하여 뷰포트 높이가 줄어들어도 스크롤 가능하도록 수정
- **불필요한 쿠키 조작 코드 제거**: `auth.ts`에서 HTTP-only 쿠키를 JS로 읽기/쓰기/삭제하려는 함수들 제거 (`setAccessToken`, `getAccessToken`, `removeAccessToken` 등 6개 함수 + JWT 디코딩 관련 3개 함수)
- **silentAuthClient 단순화**: Authorization 헤더 수동 설정 request interceptor 제거 (`withCredentials: true`가 쿠키 자동 전송)
- **interceptors 정리**: 아무 동작도 하지 않는 빈 request interceptor 및 `withAuthToken` 옵션 제거
- **인증 실패 시 토스트 제거**: `handleAuthError()`에서 "로그인이 필요하거나 세션이 만료되었습니다." 토스트를 제거하고 조용히 로그아웃 처리만 수행
- **사이드바 데이터 재시도 로직 추가**: 사이드바 API 호출 실패 시 최대 3회 시도 (1회 + 2회 재시도), 401은 즉시 강제 로그아웃, 기타 오류는 재시도 후 최종 실패 시 강제 로그아웃 (백엔드 logout API 호출 + 캐시 제거)
- **diary-detail-screen 정리**: `getCurrentMemberId()` 의존 제거, sidebar 데이터 기반 memberId 조회로 단순화

## 📎 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sign-up screen scrolling behavior on large screens to allow vertical scrolling.
  * Improved logout process with retry logic for sidebar data fetching.

* **Changes**
  * Simplified authentication to rely on localStorage only (removed cookie-based token support).
  * Removed error toast notifications for unauthorized API responses.
  * Refined comment ownership identification in diary entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->