### PR TITLE
refactor: 워드 컨벤션 수정 및 라우트 가드 버그 수정

### DIFF
--- a/src/app.feature/challenge/board/api/challenge-board-api.ts
+++ b/src/app.feature/challenge/board/api/challenge-board-api.ts
@@ -64,7 +64,7 @@ export const challengeBoardApi = {
     );
   },
 
-  // 특정 멤버가 진행중인 챌린지 보기
+  // 특정 멤버가 진행 중인 챌린지 보기
   getMemberChallenges: async (
     params: MemberChallengesParams
   ): Promise<ChallengeListItem[]> => {

--- a/src/app.feature/challenge/board/screen/challenge-board-screen.tsx
+++ b/src/app.feature/challenge/board/screen/challenge-board-screen.tsx
@@ -195,14 +195,14 @@ export default function ChallengeBoardScreen(): React.ReactElement {
           <Button
             size="medium"
             onClick={() =>
-              requireAuth('챌린지 생성은 로그인 후 이용할 수 있습니다.', () =>
+              requireAuth('챌린지 만들기는 로그인 후 이용할 수 있습니다.', () =>
                 router.push('/challenge/create')
               )
             }
             className="whitespace-nowrap"
           >
             <span className="flex items-center gap-1">
-              <Icon name="Plus" size={16} />새 챌린지 생성
+              <Icon name="Plus" size={16} />새 챌린지 만들기
             </span>
           </Button>
         </div>

--- a/src/app.feature/challenge/detail/screen/challenge-detail-screen.tsx
+++ b/src/app.feature/challenge/detail/screen/challenge-detail-screen.tsx
@@ -511,7 +511,7 @@ export function ChallengeDetailScreen({
   const handleLeaveChallenge = (): void => {
     leaveChallenge.mutate(challengeId, {
       onSuccess: () => {
-        toast.success('챌린지에서 탈퇴했습니다.');
+        toast.success('챌린지에서 나갔습니다.');
       },
       onError: (error) => {
         notifyApiError(error);
@@ -830,7 +830,7 @@ export function ChallengeDetailScreen({
     <Dialog open={showFreeGoalModal} onOpenChange={setShowFreeGoalModal}>
       <DialogContent className="gap-5 px-6 py-6 sm:max-w-[460px]">
         <DialogHeader>
-          <DialogTitle>나의 목표 입력</DialogTitle>
+          <DialogTitle>내 목표 입력</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-3">
           <Text size="body2" weight="regular" className="text-gray-500">
@@ -859,7 +859,7 @@ export function ChallengeDetailScreen({
             disabled={joinChallenge.isPending}
             onClick={handleFreeGoalSubmit}
           >
-            {joinChallenge.isPending ? '처리 중...' : '신청하기'}
+            {joinChallenge.isPending ? '처리 중...' : '참여 신청'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/app.feature/challenge/shared/components/challenge-card.tsx
+++ b/src/app.feature/challenge/shared/components/challenge-card.tsx
@@ -1,5 +1,5 @@
 import { cn, ImagePlaceholder, Tag, Text } from '@1d1s/design-system';
-import { UserRound, Users } from 'lucide-react';
+import { Target, Users } from 'lucide-react';
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 
@@ -42,7 +42,7 @@ export function ChallengeCard({
     maxUserCount <= 1 ? '개인' : `${currentUserCount} / ${maxUserCount}`;
 
   const hasEnded = isInfiniteChallenge ? isEarlyEnded : isEnded;
-  const statusLabel = hasEnded ? '종료됨' : isOngoing ? '진행중' : '모집중';
+  const statusLabel = hasEnded ? '종료됨' : isOngoing ? '진행 중' : '모집 중';
   const statusClassName = hasEnded
     ? 'bg-gray-500'
     : isOngoing
@@ -102,7 +102,7 @@ export function ChallengeCard({
 
         <div className="mt-2 flex w-full items-center justify-between sm:mt-3">
           <div className="flex items-center gap-1.5">
-            <UserRound className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5" />
+            <Target className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5" />
             <Text
               size="caption2"
               weight="medium"

--- a/src/app.feature/challenge/shared/components/challenge-list-item.tsx
+++ b/src/app.feature/challenge/shared/components/challenge-list-item.tsx
@@ -1,5 +1,5 @@
 import { cn, ImagePlaceholder, Tag, Text } from '@1d1s/design-system';
-import { UserRound, Users } from 'lucide-react';
+import { Target } from 'lucide-react';
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 
@@ -41,7 +41,7 @@ export function ChallengeListItem({
   const isIndividual = maxUserCount <= 1;
 
   const hasEnded = isInfiniteChallenge ? isEarlyEnded : isEnded;
-  const statusLabel = hasEnded ? '종료됨' : isOngoing ? '진행중' : '모집중';
+  const statusLabel = hasEnded ? '종료됨' : isOngoing ? '진행 중' : '모집 중';
   const statusClassName = hasEnded
     ? 'bg-gray-500'
     : isOngoing
@@ -99,11 +99,7 @@ export function ChallengeListItem({
 
         {/* Goal type + participant */}
         <div className="flex items-center gap-1.5">
-          {isIndividual ? (
-            <UserRound className="h-3.5 w-3.5 text-gray-400" />
-          ) : (
-            <Users className="h-3.5 w-3.5 text-gray-400" />
-          )}
+          <Target className="h-3.5 w-3.5 text-gray-400" />
           <Text size="caption3" weight="medium" className="text-gray-500">
             {`${challengeType}`}
             {isIndividual ? '' : ` · ${currentUserCount} / ${maxUserCount}`}

--- a/src/app.feature/challenge/shared/utils/challenge-display.ts
+++ b/src/app.feature/challenge/shared/utils/challenge-display.ts
@@ -24,7 +24,7 @@ export function formatChallengeCardTypeLabel(
   maxParticipantCount: number
 ): string {
   if (isIndividualChallenge(maxParticipantCount)) {
-    return '개인 목표';
+    return '개인 챌린지';
   }
 
   return formatChallengeTypeLabel(goalType);

--- a/src/app.feature/challenge/write/components/challenge-create-dialog.tsx
+++ b/src/app.feature/challenge/write/components/challenge-create-dialog.tsx
@@ -33,7 +33,7 @@ export function ChallengeCreateDialog({
         </Button>
       </DialogTrigger>
       <DialogContent className="flex max-h-[90vh] flex-col gap-0 p-0 sm:max-w-[520px]">
-        <DialogTitle className="sr-only">챌린지 생성 미리보기</DialogTitle>
+        <DialogTitle className="sr-only">챌린지 만들기 미리보기</DialogTitle>
         <div className="min-h-0 flex-1 overflow-y-auto p-6 pt-10">
           <ChallengeCreateDialogContent />
         </div>
@@ -48,7 +48,7 @@ export function ChallengeCreateDialog({
             className="block text-center text-black"
             id="challenge-create-dialog"
           >
-            위와 같이 챌린지를 생성하시겠습니까?
+            위와 같이 챌린지를 만드시겠습니까?
           </Text>
         </DialogDescription>
 
@@ -64,7 +64,7 @@ export function ChallengeCreateDialog({
               type="submit"
               onClick={onConfirm}
             >
-              챌린지 생성
+              챌린지 만들기
             </Button>
           </DialogClose>
         </DialogFooter>

--- a/src/app.feature/challenge/write/components/challenge-create-success-dialog.tsx
+++ b/src/app.feature/challenge/write/components/challenge-create-success-dialog.tsx
@@ -41,7 +41,7 @@ export function ChallengeCreateSuccessDialog({
           <DialogTitle>
             <DialogDescription>
               <Text size="heading1" weight="bold" className="text-center text-black">
-                챌린지 생성이 완료되었습니다!
+                챌린지 만들기가 완료되었습니다!
               </Text>
             </DialogDescription>
           </DialogTitle>

--- a/src/app.feature/challenge/write/screen/challenge-create-form-screen.tsx
+++ b/src/app.feature/challenge/write/screen/challenge-create-form-screen.tsx
@@ -160,7 +160,7 @@ export function ChallengeCreateFormScreen({
               <ChallengeCreateDialog
                 onConfirm={() => form.handleSubmit(onSubmit)()}
                 disabled={!isStepValid}
-                triggerText="챌린지 생성"
+                triggerText="챌린지 만들기"
               />
             )}
           </div>
@@ -177,7 +177,7 @@ export function ChallengeCreateFormScreen({
             문제가 발생했습니다
           </DialogTitle>
           <DialogDescription className="text-center text-gray-500">
-            챌린지 생성 중 오류가 발생했습니다.
+            챌린지 만들기 중 오류가 발생했습니다.
             <br />
             잠시 후 다시 시도해주세요.
           </DialogDescription>

--- a/src/app.feature/challenge/write/screen/challenge-create-screen.tsx
+++ b/src/app.feature/challenge/write/screen/challenge-create-screen.tsx
@@ -27,7 +27,7 @@ export default function ChallengeCreateScreen(): React.ReactElement {
         <div className="flex items-start justify-between border-b border-gray-200 pb-5">
           <div className="flex flex-col gap-2">
             <Text size="display1" weight="bold" className="text-gray-900">
-              챌린지 생성
+              챌린지 만들기
             </Text>
             <Text size="body1" weight="regular" className="text-gray-600">
               새 챌린지를 단계별로 설정해보세요.

--- a/src/app.feature/home/components/home-section-header.tsx
+++ b/src/app.feature/home/components/home-section-header.tsx
@@ -19,7 +19,7 @@ export default function HomeSectionHeader({
           {title}
         </Text>
         <Button variant="ghost" size="small" onClick={onMoreClick}>
-          더보기 +
+          전체 보기
         </Button>
       </div>
       <Text size="caption3" weight="medium" className="text-gray-600">

--- a/src/app.feature/home/screen/home-screen.tsx
+++ b/src/app.feature/home/screen/home-screen.tsx
@@ -4,8 +4,8 @@ import { BannerCarousel, PageWatermark } from '@1d1s/design-system';
 import { LoginRequiredDialog } from '@component/login-required-dialog';
 import { HOME_MAIN_BANNERS } from '@constants/consts/home-data';
 import { authStorage } from '@module/utils/auth';
-import { useRouter } from 'next/navigation';
-import React from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import React, { useEffect } from 'react';
 
 import HomeQuickActions from '../components/home-quick-actions';
 import HomeRandomChallengesSection from '../components/home-random-challenges-section';
@@ -15,8 +15,28 @@ import { useHomeRandomDiaryLike } from '../hooks/use-home-random-diary-like';
 
 export default function HomeScreen(): React.ReactElement {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isLoginRequired = searchParams.get('loginRequired') === 'true';
   const { isLikePending, showLoginDialog, setShowLoginDialog, onLikeToggle } =
     useHomeRandomDiaryLike();
+  const loginDialogDescription = isLoginRequired
+    ? '로그인 후 이용할 수 있습니다.'
+    : undefined;
+
+  useEffect(() => {
+    console.log('[home-screen] isLoginRequired =', isLoginRequired);
+    if (!isLoginRequired) {
+      return;
+    }
+    setShowLoginDialog(true);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('loginRequired');
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
   const {
     randomChallenges,
     isChallengesLoading,
@@ -33,6 +53,7 @@ export default function HomeScreen(): React.ReactElement {
       <LoginRequiredDialog
         open={showLoginDialog}
         onOpenChange={setShowLoginDialog}
+        description={loginDialogDescription}
       />
       {/* 메인 콘텐츠 */}
       <div className="flex w-full flex-col pt-6">

--- a/src/app.feature/home/screen/home-screen.tsx
+++ b/src/app.feature/home/screen/home-screen.tsx
@@ -25,7 +25,6 @@ export default function HomeScreen(): React.ReactElement {
     : undefined;
 
   useEffect(() => {
-    console.log('[home-screen] isLoginRequired =', isLoginRequired);
     if (!isLoginRequired) {
       return;
     }
@@ -37,6 +36,7 @@ export default function HomeScreen(): React.ReactElement {
       scroll: false,
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const {
     randomChallenges,
     isChallengesLoading,

--- a/src/app.module/middleware/auth.ts
+++ b/src/app.module/middleware/auth.ts
@@ -32,13 +32,9 @@ export function authMiddleware(req: NextRequest): NextResponse | null {
     return null;
   }
 
-  const token =
-    ACCESS_TOKEN_COOKIE_CANDIDATES
-      .map((cookieName) => req.cookies.get(cookieName)?.value)
-      .find((value): value is string => Boolean(value?.trim())) ??
-    req.cookies.get('JSESSIONID')?.value ??
-    req.cookies.get('SESSION')?.value ??
-    req.cookies.get('session')?.value;
+  const token = ACCESS_TOKEN_COOKIE_CANDIDATES.map(
+    (cookieName) => req.cookies.get(cookieName)?.value
+  ).find((value): value is string => Boolean(value?.trim()));
 
   if (!token) {
     const redirectUrl = new URL(fallback, req.url);

--- a/src/app.module/utils/server-auth.ts
+++ b/src/app.module/utils/server-auth.ts
@@ -35,38 +35,27 @@ export async function resolveLoginRequiredRedirect(
   const headerStore = await headers();
   const host = headerStore.get('host');
   const referer = headerStore.get('referer');
-  console.log('[resolveLoginRequiredRedirect] host =', host, 'referer =', referer, 'currentPathname =', currentPathname);
 
   if (!referer || !host) {
-    const target = appendLoginRequired(fallbackPath);
-    console.log('[resolveLoginRequiredRedirect] no referer/host -> fallback:', target);
-    return target;
+    return appendLoginRequired(fallbackPath);
   }
 
   let refererUrl: URL;
   try {
     refererUrl = new URL(referer);
   } catch {
-    const target = appendLoginRequired(fallbackPath);
-    console.log('[resolveLoginRequiredRedirect] referer parse failed -> fallback:', target);
-    return target;
+    return appendLoginRequired(fallbackPath);
   }
 
   if (refererUrl.host !== host) {
-    const target = appendLoginRequired(fallbackPath);
-    console.log('[resolveLoginRequiredRedirect] different host -> fallback:', target);
-    return target;
+    return appendLoginRequired(fallbackPath);
   }
 
   // Referer가 현재 보호 경로와 같으면 루프 방지
   if (refererUrl.pathname === currentPathname) {
-    const target = appendLoginRequired(fallbackPath);
-    console.log('[resolveLoginRequiredRedirect] self referer -> fallback:', target);
-    return target;
+    return appendLoginRequired(fallbackPath);
   }
 
   refererUrl.searchParams.set('loginRequired', 'true');
-  const target = `${refererUrl.pathname}${refererUrl.search}${refererUrl.hash}`;
-  console.log('[resolveLoginRequiredRedirect] same-origin referer -> target:', target);
-  return target;
+  return `${refererUrl.pathname}${refererUrl.search}${refererUrl.hash}`;
 }

--- a/src/app.module/utils/server-auth.ts
+++ b/src/app.module/utils/server-auth.ts
@@ -1,0 +1,72 @@
+import { cookies, headers } from 'next/headers';
+
+import { ACCESS_TOKEN_COOKIE_CANDIDATES } from './token-cookie';
+
+/**
+ * 서버 컴포넌트에서 접근 토큰 쿠키 존재 여부를 확인한다.
+ * - 미들웨어의 prefetch 스킵 등 엣지 케이스를 우회하여,
+ *   RSC 렌더링 시점에 직접 쿠키를 검사한다.
+ */
+export async function hasServerAccessToken(): Promise<boolean> {
+  const cookieStore = await cookies();
+  return ACCESS_TOKEN_COOKIE_CANDIDATES.some((name) => {
+    const value = cookieStore.get(name)?.value;
+    return Boolean(value?.trim());
+  });
+}
+
+function appendLoginRequired(pathWithMaybeQuery: string): string {
+  const [path, query = ''] = pathWithMaybeQuery.split('?');
+  const params = new URLSearchParams(query);
+  params.set('loginRequired', 'true');
+  return `${path}?${params.toString()}`;
+}
+
+/**
+ * 로그인 필요 시 돌려보낼 URL을 결정한다.
+ * - 같은 오리진의 Referer가 있으면 거기로 되돌아간다 (사용자가 온 페이지에서 모달을 띄우기 위함)
+ * - 외부 Referer거나 Referer가 없으면 fallback 경로 사용
+ * - 되돌릴 URL이 보호 상세 경로 자기 자신이면 무한 루프 방지 위해 fallback 사용
+ */
+export async function resolveLoginRequiredRedirect(
+  fallbackPath: string,
+  currentPathname: string
+): Promise<string> {
+  const headerStore = await headers();
+  const host = headerStore.get('host');
+  const referer = headerStore.get('referer');
+  console.log('[resolveLoginRequiredRedirect] host =', host, 'referer =', referer, 'currentPathname =', currentPathname);
+
+  if (!referer || !host) {
+    const target = appendLoginRequired(fallbackPath);
+    console.log('[resolveLoginRequiredRedirect] no referer/host -> fallback:', target);
+    return target;
+  }
+
+  let refererUrl: URL;
+  try {
+    refererUrl = new URL(referer);
+  } catch {
+    const target = appendLoginRequired(fallbackPath);
+    console.log('[resolveLoginRequiredRedirect] referer parse failed -> fallback:', target);
+    return target;
+  }
+
+  if (refererUrl.host !== host) {
+    const target = appendLoginRequired(fallbackPath);
+    console.log('[resolveLoginRequiredRedirect] different host -> fallback:', target);
+    return target;
+  }
+
+  // Referer가 현재 보호 경로와 같으면 루프 방지
+  if (refererUrl.pathname === currentPathname) {
+    const target = appendLoginRequired(fallbackPath);
+    console.log('[resolveLoginRequiredRedirect] self referer -> fallback:', target);
+    return target;
+  }
+
+  refererUrl.searchParams.set('loginRequired', 'true');
+  const target = `${refererUrl.pathname}${refererUrl.search}${refererUrl.hash}`;
+  console.log('[resolveLoginRequiredRedirect] same-origin referer -> target:', target);
+  return target;
+}

--- a/src/app/challenge/[id]/page.tsx
+++ b/src/app/challenge/[id]/page.tsx
@@ -1,4 +1,9 @@
 import { ChallengeDetailScreen } from '@feature/challenge/detail/screen/challenge-detail-screen';
+import {
+  hasServerAccessToken,
+  resolveLoginRequiredRedirect,
+} from '@module/utils/server-auth';
+import { redirect } from 'next/navigation';
 import React from 'react';
 
 interface ChallengeDetailProps {
@@ -9,6 +14,15 @@ export default async function ChallengeDetail({
   params,
 }: ChallengeDetailProps): Promise<React.ReactElement> {
   const { id } = await params;
+
+  const isAuthenticated = await hasServerAccessToken();
+  if (!isAuthenticated) {
+    const target = await resolveLoginRequiredRedirect(
+      '/challenge',
+      `/challenge/${id}`
+    );
+    redirect(target);
+  }
 
   return <ChallengeDetailScreen id={id} />;
 }

--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -1,4 +1,9 @@
 import { DiaryDetailScreen } from '@feature/diary/detail/screen/diary-detail-screen';
+import {
+  hasServerAccessToken,
+  resolveLoginRequiredRedirect,
+} from '@module/utils/server-auth';
+import { redirect } from 'next/navigation';
 import React from 'react';
 
 interface DiaryDetailProps {
@@ -10,6 +15,15 @@ export default async function DiaryDetailPage({
 }: DiaryDetailProps): Promise<React.ReactElement> {
   const { id } = await params;
   const diaryId = Number(id);
+
+  const isAuthenticated = await hasServerAccessToken();
+  if (!isAuthenticated) {
+    const target = await resolveLoginRequiredRedirect(
+      '/diary',
+      `/diary/${id}`
+    );
+    redirect(target);
+  }
 
   return <DiaryDetailScreen id={diaryId} />;
 }

--- a/src/app/mypage/settings/page.tsx
+++ b/src/app/mypage/settings/page.tsx
@@ -288,7 +288,7 @@ export default function AccountSettingsPage(): React.ReactElement {
             >
               <UserMinus className="h-5 w-5" />
               <Text size="body1" weight="medium" className="text-gray-600">
-                회원탈퇴
+                회원 탈퇴
               </Text>
             </button>
           </section>
@@ -333,7 +333,7 @@ export default function AccountSettingsPage(): React.ReactElement {
       >
         <DialogContent className="gap-6 px-8 py-6 sm:max-w-[380px] sm:px-6">
           <DialogHeader className="items-center text-center sm:text-center">
-            <DialogTitle>회원탈퇴 하시겠어요?</DialogTitle>
+            <DialogTitle>회원 탈퇴 하시겠어요?</DialogTitle>
           </DialogHeader>
 
           <DialogDescription className="block w-full text-center">
@@ -356,7 +356,7 @@ export default function AccountSettingsPage(): React.ReactElement {
               onClick={confirmWithdraw}
               disabled={deleteMember.isPending || logout.isPending}
             >
-              {deleteMember.isPending ? '처리 중...' : '회원탈퇴'}
+              {deleteMember.isPending ? '처리 중...' : '회원 탈퇴'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,10 @@
-'use client';
-
 import HomeScreen from '@feature/home/screen/home-screen';
+import React, { Suspense } from 'react';
 
 export default function MainPage(): React.ReactElement {
-  return <HomeScreen />;
+  return (
+    <Suspense fallback={null}>
+      <HomeScreen />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## 📌 Summary

비로그인 사용자의 챌린지/일지 상세 페이지 접근을 서버 단에서 차단하고, 프로젝트 전반에서 혼용되던 UI 용어/아이콘을 통일합니다.

## ✅ 작업 내용

### 라우트 가드 추가

- `/challenge/[id]`, `/diary/[id]` 서버 컴포넌트에 인증 검사 추가 — 비로그인 시 `redirect()`로 즉시 차단
- `hasServerAccessToken()` 유틸 추가 (`src/app.module/utils/server-auth.ts`) — `next/headers`의 `cookies()`로 실제 토큰 쿠키 존재 여부만 엄격히 검사
- `resolveLoginRequiredRedirect()` 추가 — `Referer` 헤더를 기준으로 사용자가 온 페이지로 되돌려보내서 해당 페이지에서 모달이 뜨도록 처리 (홈에서 카드 클릭 → 홈에서 모달, 목록에서 클릭 → 목록에서 모달)
- 미들웨어(`auth.ts`)에서 `JSESSIONID` / `SESSION` / `session` 같은 일반 세션 쿠키 fallback 제거 — 앱 전용 토큰 쿠키만 검증하도록 정리
- 홈 화면에서 `loginRequired=true` 쿼리 파라미터 처리 로직 추가 (기존 challenge board / diary list와 동일 패턴)

### 용어 통일

- 상태 레이블 띄어쓰기: `진행중` → `진행 중`, `모집중` → `모집 중`
- 챌린지 타입: 개인 사용자 챌린지 라벨을 `개인 목표` → `개인 챌린지`로 통일
- 액션 용어: 챌린지 생성 UI를 `생성` → `만들기`로 통일 (버튼, 다이얼로그, 토스트)
- 챌린지 나가기 토스트: `탈퇴` → `나가기`로 통일 (회원 탈퇴와 구분)
- 회원 탈퇴 띄어쓰기: `회원탈퇴` → `회원 탈퇴`
- 기타: `신청하기` → `참여 신청`, `나의 목표` → `내 목표`, 홈 섹션의 `더보기 +` → `전체 보기`
- 챌린지 카드/리스트에서 고정 목표/자유 목표/개인 챌린지 라벨 옆 아이콘을 사람(`UserRound`/`Users`) → 목표(`Target`)로 교체

## 📎 기타
- 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side authentication gating for protected pages with improved login-required redirect flow.

* **Style**
  * Updated Korean text formatting for consistency (spacing, terminology adjustments).
  * Refined challenge display labels and button text throughout the app.
  * Updated icons in challenge card and list components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->