### PR TITLE
refactor: middleware.ts를 proxy.ts로 마이그레이션 (Next.js 16)

### DIFF
--- a/src/app.module/middleware/middleware.ts
+++ b/src/app.module/middleware/middleware.ts
@@ -6,7 +6,7 @@ import { loggingMiddleware } from './logging';
 import { redirectMiddleware } from './redirect';
 import { securityMiddleware } from './security';
 
-export function middleware(req: NextRequest): NextResponse {
+export function proxy(req: NextRequest): NextResponse {
   // 1. 로깅 시작
   const start = loggingMiddleware(req);
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
-import { middleware } from '@module/middleware/middleware';
+import { proxy } from '@module/middleware/middleware';
 
-export { middleware };
+export { proxy };
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## 📌 Summary

Next.js 16에서 deprecated된 `middleware` 파일 컨벤션을 `proxy`로 마이그레이션

## ✅ 작업 내용

- `src/middleware.ts` → `src/proxy.ts`로 파일명 변경 (Next.js 16 새 컨벤션)
- 내부 구현 함수 `middleware` → `proxy`로 rename (`src/app.module/middleware/middleware.ts`)
- 빌드 시 출력되던 `The "middleware" file convention is deprecated. Please use "proxy" instead.` 경고 제거

## 📎 기타

- `src/app.module/middleware/` 디렉토리와 내부 파일(`auth.ts`, `headers.ts`, `logging.ts`, `redirect.ts`, `security.ts`)은 그대로 유지했습니다. Next.js 규약 파일이 아니라 내부 모듈이며, 하위 함수들은 여전히 일반적인 "middleware 패턴"이므로 의미가 맞습니다.
- `config.matcher` 포맷과 `NextRequest`/`NextResponse` API는 Next.js 16에서 동일하게 동작합니다.
- 로컬 `pnpm build` 검증 완료 — 해당 경고 사라짐 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)