### PR TITLE
[ODS-177] use client, useEffect 관련 내용 처리

### DIFF
--- a/src/app.feature/auth/screen/LoginScreen.tsx
+++ b/src/app.feature/auth/screen/LoginScreen.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Icon, Text } from '@1d1s/design-system';
 import Link from 'next/link';
 

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -5,7 +5,7 @@ import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import { HOME_MAIN_BANNERS } from '@constants/consts/homeData';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import HomeQuickActions from '../components/HomeQuickActions';
 import HomeRandomChallengesSection from '../components/HomeRandomChallengesSection';
@@ -25,25 +25,26 @@ export default function HomeScreen(): React.ReactElement {
     ? '로그인 후 이용할 수 있습니다.'
     : undefined;
 
-  const [prevIsLoginRequired, setPrevIsLoginRequired] = useState(false);
-  if (isLoginRequired !== prevIsLoginRequired) {
-    setPrevIsLoginRequired(isLoginRequired);
+  useEffect(() => {
     if (isLoginRequired && !isLoggedIn) {
       setShowLoginDialog(true);
     }
-  }
+    // 마운트 시에만 로그인 변경 여부를 확인하기 위해 의존성 배열을 비웠습니다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  useEffect(() => {
-    if (!isLoginRequired) {
-      return;
+  const handleDialogOpenChange = (open: boolean): void => {
+    setShowLoginDialog(open);
+    if (!open && isLoginRequired) {
+      // dialog가 닫히는 순간에만 URL 청소
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('loginRequired');
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
     }
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('loginRequired');
-    const query = params.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname, {
-      scroll: false,
-    });
-  }, [isLoginRequired, pathname, router, searchParams]);
+  };
 
   const {
     randomChallenges,
@@ -60,7 +61,7 @@ export default function HomeScreen(): React.ReactElement {
     <div className="flex min-h-screen w-full flex-col bg-white">
       <LoginRequiredDialog
         open={showLoginDialog}
-        onOpenChange={setShowLoginDialog}
+        onOpenChange={handleDialogOpenChange}
         description={loginDialogDescription}
       />
       {/* 메인 콘텐츠 */}

--- a/src/app.module/middleware/auth.ts
+++ b/src/app.module/middleware/auth.ts
@@ -2,33 +2,36 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { ACCESS_TOKEN_COOKIE_CANDIDATES } from '../utils/tokenCookie';
 
+type ProtectedRoute =
+  | { pattern: RegExp; type: 'list-redirect'; fallback: string }
+  | { pattern: RegExp; type: 'login-redirect' };
+
 /**
  * 인증 미들웨어
  * - JWT 토큰을 사용하여 인증 및 권한 검사
- * - 비로그인 시 부모 목록 페이지로 리디렉션 + loginRequired 쿼리 파라미터 전달
+ * - list-redirect: 비로그인 시 부모 목록 + loginRequired 쿼리 파라미터로 리디렉션
+ * - login-redirect: 비로그인 시 /login으로 바로 리디렉션
  *
  * @param req NextRequest
  * @returns NextResponse | null
  */
-const PROTECTED_DETAIL_ROUTES: Array<{
-  pattern: RegExp;
-  fallback: string;
-}> = [
-  { pattern: /^\/challenge\/\d+\/?$/, fallback: '/challenge' },
-  { pattern: /^\/diary\/\d+\/?$/, fallback: '/diary' },
+const PROTECTED_ROUTES: ProtectedRoute[] = [
+  { pattern: /^\/challenge\/\d+\/?$/, type: 'list-redirect', fallback: '/challenge' },
+  { pattern: /^\/diary\/\d+\/?$/,    type: 'list-redirect', fallback: '/diary' },
+
+  { pattern: /^\/challenge\/\d+\/edit\/?$/, type: 'login-redirect' },
+  { pattern: /^\/challenge\/create\/?$/,    type: 'login-redirect' },
+  { pattern: /^\/mypage(\/.*)?$/,           type: 'login-redirect' },
 ];
 
-function getFallbackRoute(pathname: string): string | null {
-  const matched = PROTECTED_DETAIL_ROUTES.find(({ pattern }) =>
-    pattern.test(pathname)
-  );
-  return matched?.fallback ?? null;
+function matchRoute(pathname: string): ProtectedRoute | null {
+  return PROTECTED_ROUTES.find(({ pattern }) => pattern.test(pathname)) ?? null;
 }
 
 export function authMiddleware(req: NextRequest): NextResponse | null {
   const { pathname } = req.nextUrl;
-  const fallback = getFallbackRoute(pathname);
-  if (!fallback) {
+  const matched = matchRoute(pathname);
+  if (!matched) {
     return null;
   }
 
@@ -37,7 +40,10 @@ export function authMiddleware(req: NextRequest): NextResponse | null {
   ).find((value): value is string => Boolean(value?.trim()));
 
   if (!token) {
-    const redirectUrl = new URL(fallback, req.url);
+    if (matched.type === 'login-redirect') {
+      return NextResponse.redirect(new URL('/login', req.url));
+    }
+    const redirectUrl = new URL(matched.fallback, req.url);
     redirectUrl.searchParams.set('loginRequired', 'true');
     return NextResponse.redirect(redirectUrl);
   }

--- a/src/app/inquiry/page.tsx
+++ b/src/app/inquiry/page.tsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from '@1d1s/design-system';
 import { INQUIRY_FAQ_ITEMS } from '@constants/consts/inquiryData';
+import { cn } from '@module/utils/cn';
 import { Mail } from 'lucide-react';
 import React from 'react';
 
@@ -24,57 +25,61 @@ export default function InquiryPage(): React.ReactElement {
           </Text>
         </div>
 
-      <div className="flex w-full flex-1 flex-col">
-        <div className="h-6" />
+        <div className="flex w-full flex-1 flex-col">
+          <div className="h-6" />
 
-        {/* FAQ 섹션 */}
-        <Text size="heading1" weight="bold" className="mb-4 text-gray-900">
-          자주 묻는 질문 (FAQ)
-        </Text>
-        <Accordion type="single" collapsible className="w-full">
-          {INQUIRY_FAQ_ITEMS.map((item) => (
-            <AccordionItem key={item.id} value={item.id}>
-              <AccordionTrigger>
-                <Text size="body1" weight="bold" className="text-left">
-                  {item.question}
-                </Text>
-              </AccordionTrigger>
-              <AccordionContent>
-                <Text size="body2" weight="medium" className="text-gray-600">
-                  {item.answer}
-                </Text>
-              </AccordionContent>
-            </AccordionItem>
-          ))}
-        </Accordion>
+          {/* FAQ 섹션 */}
+          <Text size="heading1" weight="bold" className="mb-4 text-gray-900">
+            자주 묻는 질문 (FAQ)
+          </Text>
+          <Accordion type="single" collapsible className="w-full">
+            {INQUIRY_FAQ_ITEMS.map((item) => (
+              <AccordionItem key={item.id} value={item.id}>
+                <AccordionTrigger>
+                  <Text size="body1" weight="bold" className="text-left">
+                    {item.question}
+                  </Text>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <Text size="body2" weight="medium" className="text-gray-600">
+                    {item.answer}
+                  </Text>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
 
-        <div className="h-20" />
+          <div className="h-20" />
 
-        {/* 1:1 문의 섹션 */}
-        <div className="flex flex-col items-center text-center">
-          <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-blue-50 text-blue-500">
-            <Mail size={32} />
+          {/* 1:1 문의 섹션 */}
+          <div className="flex flex-col items-center text-center">
+            <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-blue-50 text-blue-500">
+              <Mail size={32} />
+            </div>
+
+            <Text size="heading1" weight="bold" className="mb-2 text-gray-900">
+              무엇을 도와드릴까요?
+            </Text>
+            <Text size="body1" weight="medium" className="mb-8 text-gray-500">
+              문제가 발생하거나 추가됐으면 하는 기능이 있다면
+              <br />
+              아래 버튼을 통해 문의를 남겨주세요.
+            </Text>
+
+            <a
+              href="https://forms.gle/yxgnTJdYViRmb2zR6"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                'mb-10 flex w-full max-w-lg items-center justify-center',
+                'rounded-2xl px-6 py-4 font-bold text-white transition-colors',
+                'bg-main-800 hover:bg-main-900'
+              )}
+            >
+              문의 남기기
+            </a>
           </div>
-
-          <Text size="heading1" weight="bold" className="mb-2 text-gray-900">
-            무엇을 도와드릴까요?
-          </Text>
-          <Text size="body1" weight="medium" className="mb-8 text-gray-500">
-            문제가 발생하거나 추가됐으면 하는 기능이 있다면
-            <br />
-            아래 버튼을 통해 문의를 남겨주세요.
-          </Text>
-
-          <a
-            href="https://forms.gle/yxgnTJdYViRmb2zR6"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="bg-main-800 hover:bg-main-900 mb-10 flex w-full max-w-lg items-center justify-center rounded-2xl px-6 py-4 font-bold text-white transition-colors"
-          >
-            문의 남기기
-          </a>
         </div>
-      </div>
       </section>
     </div>
   );

--- a/src/app/mypage/settings/page.tsx
+++ b/src/app/mypage/settings/page.tsx
@@ -144,21 +144,35 @@ export default function AccountSettingsPage(): React.ReactElement {
             <div className="flex flex-col gap-6 px-5 py-5">
               {/* 프로필 사진 */}
               <div className="flex flex-col items-center gap-3">
-                <AvatarImagePicker
-                  size={160}
-                  defaultImageUrl={profilePreview || undefined}
-                  changeLabel="변경"
-                  onChange={handleProfileImageChange}
-                />
-                {updateProfileImage.isPending && (
-                  <Text
-                    size="caption1"
-                    weight="regular"
-                    className="text-gray-400"
-                  >
-                    업로드 중...
-                  </Text>
-                )}
+                <div className="relative" style={{ width: 160, height: 160 }}>
+                  <AvatarImagePicker
+                    size={160}
+                    defaultImageUrl={
+                      updateProfileImage.isPending
+                        ? undefined
+                        : (profilePreview || undefined)
+                    }
+                    changeLabel="변경"
+                    onChange={handleProfileImageChange}
+                  />
+                  {updateProfileImage.isPending && (
+                    <div
+                      className={cn(
+                        'pointer-events-none absolute inset-0 z-20',
+                        'flex items-center justify-center',
+                        'overflow-hidden rounded-full',
+                      )}
+                    >
+                      <Text
+                        size="caption1"
+                        weight="regular"
+                        className="text-gray-400"
+                      >
+                        업로드 중...
+                      </Text>
+                    </div>
+                  )}
+                </div>
               </div>
 
               {/* 닉네임 */}
@@ -182,6 +196,7 @@ export default function AccountSettingsPage(): React.ReactElement {
                   />
                   <Button
                     size="small"
+                    className="shrink-0"
                     onClick={handleNicknameSave}
                     disabled={
                       updateNickname.isPending ||


### PR DESCRIPTION
## 📌 Summary

<!-- 간단한 설명 -->

use client와 useEffect를 제거해도 되는 부분을 수정했습니다.

## ✅ 작업 내용

- useEffect에서 로그인 상태 체크하는 방식을 middleware로 옮겨 불필요한 렌더를 줄였습니다.
- Home에서 dialog 마운트되는 방식을 수정했습니다.
- useEffect를 이용해서 dialog를 닫는 것이 아닌, 함수에 종속되게 변경했습니다.
- LoginScreen에 불필요한 use client를 제거했습니다.

## 📎 기타

- inquiry는 createContext를 모듈 호출하자마자 실행되어 사실상 서버 컴포넌트에서 실행되는 것과 같아, use client를 지우지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended authentication protection to additional application pages including challenge management and user profile sections.

* **Improvements**
  * Enhanced login dialog behavior with automatic URL cleanup upon dialog closure.
  * Improved profile image upload experience with visual loading indicator overlay during uploads.

* **Style**
  * Updated styling utilities for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->