### PR TITLE
[ODS-60] feat: feat: 하이브리드 앱 브릿지 + 네이티브 chrome 감지 fail-safe

### DIFF
--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@1d1s/design-system';
 import { AddToHomeScreenPrompt } from '@feature/install/components/AddToHomeScreenPrompt';
 import { BrowserPermissionPrompt } from '@feature/notification/components/BrowserPermissionPrompt';
+import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
 import { useTokenRefreshOnResume } from '@module/hooks/useTokenRefreshOnResume';
 import { cn } from '@module/utils/cn';
 import { ArrowLeft } from 'lucide-react';
@@ -13,6 +14,7 @@ import AppBottomNav from './AppBottomNav';
 import { AppLayoutProvider } from './AppLayoutContext';
 import AppRightRail from './AppRightRail';
 import AppTopNav from './AppTopNav';
+import NativeBridge from './NativeBridge';
 import { useAuthLayoutState } from './useAuthLayoutState';
 
 const TOP_NAV_HIDDEN_ROUTES = [
@@ -111,7 +113,7 @@ function needsBackButton(pathname: string): boolean {
 
 export default function AppLayoutShell({
   children,
-  isNativeApp = false,
+  isNativeApp: isNativeAppFromServer = false,
 }: {
   children: React.ReactNode;
   // Flutter 등 네이티브 앱 쉘이 자체 헤더/바텀바를 그리는 환경에서는
@@ -122,12 +124,17 @@ export default function AppLayoutShell({
   const pathname = usePathname();
   const router = useRouter();
 
+  // SSR UA 매칭이 실패해 false 로 내려와도, 클라이언트에서 JS 채널/마커/
+  // UA 를 다시 점검해 chrome 중복을 방지한다.
+  const isNativeApp = useIsNativeApp(isNativeAppFromServer);
+
   useTokenRefreshOnResume();
 
   // 인증/사이드바 상태는 별도 hook 으로 묶었다. shell 은 라우트 가시성 판단과
   // 핸들러 안정화에만 집중한다.
+  const authState = useAuthLayoutState();
   const { isLoggedIn, isAuthLoading, hasUnread, sidebarData, railChallenges } =
-    useAuthLayoutState();
+    authState;
 
   useEffect(() => {
     if (
@@ -249,6 +256,7 @@ export default function AppLayoutShell({
 
         {!isLoginPage && !isNativeApp ? <BrowserPermissionPrompt /> : null}
         {!isLoginPage && !isNativeApp ? <AddToHomeScreenPrompt /> : null}
+        {isNativeApp ? <NativeBridge authState={authState} /> : null}
       </div>
     </AppLayoutProvider>
   );

--- a/src/app.component/layout/NativeBridge.tsx
+++ b/src/app.component/layout/NativeBridge.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { resolveDiaryImageUrl } from '@feature/diary/shared/utils/diaryImageUrl';
+import {
+  onNativeNavigateRequest,
+  postNativeMessage,
+} from '@module/utils/nativeBridge';
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import type { AuthLayoutState } from './useAuthLayoutState';
+
+interface NativeBridgeProps {
+  authState: AuthLayoutState;
+}
+
+/**
+ * Flutter 네이티브 쉘이 띄운 WebView 내부에서만 마운트되는 동기화 컴포넌트.
+ *
+ * - 네이티브 쉘에서 탭을 탭하면 `window.__NATIVE_NAV__('/...')` 호출 →
+ *   `native:navigate` 이벤트 → 여기서 `router.push` 로 흡수해 SPA 전환.
+ * - pathname 이 바뀔 때마다 네이티브에 `nav_state` 메시지 push → 네이티브
+ *   하단 탭의 active 표시가 동기화된다.
+ * - 인증/사이드바/알림 상태가 바뀔 때마다 `auth_state` 를 push → 네이티브
+ *   헤더의 streak chip, 알림 dot, 프로필 아바타가 동기화된다.
+ *
+ * 렌더링 산출물이 없으므로 `null` 을 반환한다.
+ */
+export default function NativeBridge({
+  authState,
+}: NativeBridgeProps): null {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { isLoggedIn, hasUnread, sidebarData } = authState;
+  const profileUrl = resolveDiaryImageUrl(sidebarData?.profileUrl ?? null);
+  const streakDays = sidebarData?.streakCount ?? 0;
+
+  useEffect(
+    () => onNativeNavigateRequest((path) => router.push(path)),
+    [router]
+  );
+
+  useEffect(() => {
+    postNativeMessage({
+      type: 'nav_state',
+      payload: { pathname: pathname || '/' },
+    });
+  }, [pathname]);
+
+  useEffect(() => {
+    postNativeMessage({
+      type: 'auth_state',
+      payload: {
+        isLoggedIn,
+        hasUnread,
+        streakDays,
+        profileUrl: profileUrl ?? undefined,
+      },
+    });
+  }, [isLoggedIn, hasUnread, streakDays, profileUrl]);
+
+  return null;
+}

--- a/src/app.module/hooks/useIsNativeApp.ts
+++ b/src/app.module/hooks/useIsNativeApp.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+// SSR UA 매칭이 실패하더라도 chrome 이 겹쳐 보이지 않도록 클라이언트에서
+// 다시 한 번 네이티브 쉘 여부를 판정한다. 신호 우선순위:
+//
+// 1. window.__IS_NATIVE_APP__ — Flutter handshake 가 명시적으로 세팅.
+// 2. window.OneDayOneStreakNative — JS 채널 존재. addJavaScriptChannel
+//    이 첫 loadRequest 이전에 등록되므로 페이지 JS 가 깨는 순간 이미
+//    존재한다. 가장 빠른 신호.
+// 3. navigator.userAgent — 토큰 `1D1S-App` 매칭. 채널/마커가 모두 없는
+//    임시 환경(예: 브라우저 devtools UA 스푸핑) 에 대한 보조.
+
+const NATIVE_APP_UA_PATTERN = /1D1S-App/i;
+const NATIVE_READY_EVENT = 'native:ready';
+
+interface NativeWindow {
+  __IS_NATIVE_APP__?: boolean;
+  OneDayOneStreakNative?: unknown;
+}
+
+function detect(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const win = window as Window & NativeWindow;
+  if (win.__IS_NATIVE_APP__) {
+    return true;
+  }
+  if (typeof win.OneDayOneStreakNative !== 'undefined') {
+    return true;
+  }
+  if (
+    typeof navigator !== 'undefined' &&
+    NATIVE_APP_UA_PATTERN.test(navigator.userAgent)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+  window.addEventListener(NATIVE_READY_EVENT, callback);
+  return () => window.removeEventListener(NATIVE_READY_EVENT, callback);
+}
+
+/**
+ * SSR 단계의 user-agent 판정값을 받아 클라이언트 감지 결과와 OR 한다.
+ *
+ * - SSR 렌더 시: 항상 `serverValue` 를 반환해 hydration 미스매치 없이
+ *   서버 HTML 과 동일한 첫 페인트를 보장한다.
+ * - 하이드레이션 직후: `useSyncExternalStore` 가 클라이언트 스냅샷을 다시
+ *   읽어 채널/마커/UA 가 있으면 true 로 전환 → 다음 프레임에 chrome 이
+ *   제거된다.
+ * - 페이지 로드 후 Flutter handshake 가 늦게 들어와도 `native:ready`
+ *   이벤트를 받아 다시 평가한다.
+ */
+export function useIsNativeApp(serverValue: boolean): boolean {
+  const detected = useSyncExternalStore(
+    subscribe,
+    detect,
+    () => serverValue
+  );
+  return serverValue || detected;
+}

--- a/src/app.module/utils/nativeApp.ts
+++ b/src/app.module/utils/nativeApp.ts
@@ -4,8 +4,6 @@
 // `1D1S-App/<version>` 토큰을 붙여 자신을 식별한다.
 const NATIVE_APP_UA_PATTERN = /1D1S-App/i;
 
-export const NATIVE_APP_UA_TOKEN = '1D1S-App';
-
 export function isNativeAppUserAgent(
   userAgent: string | null | undefined
 ): boolean {

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -40,14 +40,6 @@ function getNativeWindow(): NativeWindow | null {
   return window as NativeWindow;
 }
 
-export function isNativeShellRuntime(): boolean {
-  const win = getNativeWindow();
-  if (!win) {
-    return false;
-  }
-  return Boolean(win.__IS_NATIVE_APP__ || win[CHANNEL_NAME]);
-}
-
 export function postNativeMessage(message: NativeMessage): void {
   const win = getNativeWindow();
   if (!win) {

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -1,0 +1,82 @@
+// 네이티브 쉘(Flutter WebView)과 웹 간의 단방향/양방향 통신 헬퍼.
+// - 웹 → 네이티브: `window.OneDayOneStreakNative.postMessage(json)`
+// - 네이티브 → 웹: `window.__NATIVE_NAV__(path)` 호출 → 커스텀 이벤트
+//   `native:navigate` 디스패치 → 웹은 router.push 로 흡수.
+//
+// 채널 이름은 Flutter 측 `kJsChannelName` 과 반드시 일치해야 한다.
+
+const CHANNEL_NAME = 'OneDayOneStreakNative';
+const NAVIGATE_EVENT = 'native:navigate';
+
+export interface NativeAuthPayload {
+  isLoggedIn: boolean;
+  hasUnread: boolean;
+  streakDays: number;
+  profileUrl?: string;
+}
+
+export interface NativeNavPayload {
+  pathname: string;
+}
+
+export type NativeMessage =
+  | { type: 'auth_state'; payload: NativeAuthPayload }
+  | { type: 'nav_state'; payload: NativeNavPayload };
+
+interface NativeChannel {
+  postMessage(payload: string): void;
+}
+
+interface NativeWindow extends Window {
+  [CHANNEL_NAME]?: NativeChannel;
+  __IS_NATIVE_APP__?: boolean;
+  __NATIVE_NAV__?(path: string): void;
+}
+
+function getNativeWindow(): NativeWindow | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window as NativeWindow;
+}
+
+export function isNativeShellRuntime(): boolean {
+  const win = getNativeWindow();
+  if (!win) {
+    return false;
+  }
+  return Boolean(win.__IS_NATIVE_APP__ || win[CHANNEL_NAME]);
+}
+
+export function postNativeMessage(message: NativeMessage): void {
+  const win = getNativeWindow();
+  if (!win) {
+    return;
+  }
+  const channel = win[CHANNEL_NAME];
+  if (!channel) {
+    return;
+  }
+  try {
+    channel.postMessage(JSON.stringify(message));
+  } catch {
+    // 네이티브 쉘이 응답하지 못하더라도 웹 흐름을 멈추지 않는다.
+  }
+}
+
+export function onNativeNavigateRequest(
+  handler: (path: string) => void
+): () => void {
+  const win = getNativeWindow();
+  if (!win) {
+    return () => {};
+  }
+  const listener = (event: Event): void => {
+    const detail = (event as CustomEvent<{ to?: string }>).detail;
+    if (detail?.to) {
+      handler(detail.to);
+    }
+  };
+  win.addEventListener(NAVIGATE_EVENT, listener);
+  return () => win.removeEventListener(NAVIGATE_EVENT, listener);
+}


### PR DESCRIPTION
## 📌 Summary

Flutter 네이티브 쉘 ↔ 웹뷰 간 양방향 JS 브릿지를 깔고, SSR User-Agent 감지가 누락돼도 글로벌 TopNav/BottomNav 가 네이티브 chrome 위로 중복 렌더되지 않도록 클라이언트 fail-safe 를 추가했습니다.

## ✅ 작업 내용

**JS 브릿지 (`src/app.module/utils/nativeBridge.ts`)**
- `OneDayOneStreakNative` 채널을 통해 `auth_state` / `nav_state` 메시지를 네이티브로 post.
- `native:navigate` 커스텀 이벤트 구독 헬퍼 — 네이티브 탭 탭핑을 SPA 라우팅으로 흡수.
- `isNativeShellRuntime()` — 런타임에서 채널/마커 존재로 네이티브 환경 여부 판정.

**브릿지 동기화 컴포넌트 (`src/app.component/layout/NativeBridge.tsx`)**
- `isNativeApp` 일 때만 마운트. pathname 변경 시 `nav_state`, 인증/streak/unread/프로필 변경 시 `auth_state` 를 push 해 네이티브 헤더·탭바와 상태 동기화.
- `native:navigate` 수신 → `router.push` 로 흡수.

**클라이언트 fail-safe 훅 (`src/app.module/hooks/useIsNativeApp.ts`)**
- `useSyncExternalStore` 로 SSR prop 값 + 클라이언트 감지를 OR.
- 감지 신호 우선순위: ① `window.__IS_NATIVE_APP__` 마커 ② `window.OneDayOneStreakNative` 채널 ③ `navigator.userAgent` 의 `1D1S-App` 토큰.
- `native:ready` 이벤트 구독 → 핸드셰이크가 늦게 들어와도 즉시 재평가.
- hydration 미스매치 없이 SSR 값으로 첫 페인트 후 다음 프레임에 chrome 제거.

**`AppLayoutShell` 결합**
- SSR prop 을 `isNativeAppFromServer` 로 받아 `useIsNativeApp` 으로 합쳐 사용. 기존 TopNav/BottomNav/PWA 프롬프트 가시성 분기는 그대로.

## 📎 기타

- 페어가 되는 Flutter 측 변경 (`_1d1s_app` 리포):
  - WebView UA 끝에 `1D1S-App/<버전>` 토큰 부착 (iOS·Android 분기).
  - `addJavaScriptChannel` 을 첫 `loadRequest` 이전에 등록 → 페이지 JS 가 깨자마자 채널이 보임.
  - `setUserAgent` 를 await 한 뒤 `loadRequest` → 첫 HTTP 요청부터 토큰 헤더 보장 (race 차단).
  - `injectHandshake` 가 `window.dispatchEvent(new Event('native:ready'))` 발화 → 늦은 핸드셰이크에도 클라이언트 훅이 반응.
  - 디버그 빌드에서 UA·토큰 매칭·채널 존재 여부를 콘솔에 로깅 (다음에 또 막힐 때 진단용).
- 검증
  - `pnpm lint` / `pnpm tsc --noEmit` 통과
  - `flutter analyze` 통과 (pre-existing `_1d1s_app` 패키지명 info 1건은 무관)
  - 프로젝트 정책상 브라우저/디바이스 동작 확인은 직접 필요 (Claude Preview 미사용)
- 동작 체크 포인트
  - WebView 콘솔에 `token match = true` + `channel present = true` → SSR/클라 모두 활성.
  - `token match = false` + `channel present = true` → 클라 fail-safe 가 동작 중이지만 SSR UA 매칭이 막힌 상태. CDN/캐시 `Vary: User-Agent` 점검 필요.
  - 둘 다 false → 채널 등록 순서가 깨졌거나 빌드 캐시. `flutter clean && flutter run`.