### PR TITLE
[ODS-60] feat: 네이티브 쉘 모바일 sticky 헤더 일괄 차단

### DIFF
--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -128,6 +128,19 @@ export default function AppLayoutShell({
   // UA 를 다시 점검해 chrome 중복을 방지한다.
   const isNativeApp = useIsNativeApp(isNativeAppFromServer);
 
+  // SSR 가 false 로 내려왔어도 클라이언트 감지가 true 로 바뀌면 <html> 의
+  // data 속성을 동기화해, globals.css 의 sticky 헤더 차단 규칙이 즉시
+  // 적용되도록 한다. RootLayout 은 App Router 에서 재렌더되지 않으므로
+  // 이 effect 가 유일한 갱신 경로다.
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    document.documentElement.dataset.nativeApp = isNativeApp
+      ? 'true'
+      : 'false';
+  }, [isNativeApp]);
+
   useTokenRefreshOnResume();
 
   // 인증/사이드바 상태는 별도 hook 으로 묶었다. shell 은 라우트 가시성 판단과

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -61,6 +61,20 @@
   .pt-safe-top {
     padding-top: env(safe-area-inset-top);
   }
+
+  /* Flutter 등 네이티브 쉘이 자체 헤더를 그리는 환경에서, 페이지가 자체적으로
+     그리는 모바일 sticky 헤더(HomeMobileHeader, 챌린지/일지 보드·상세·작성,
+     알림, 회원 프로필, 친구, 약관 등 약 19곳) 가 네이티브 헤더 아래로
+     중복돼 보이지 않도록 일괄 차단한다.
+
+     선택자 근거: 모바일 전용 sticky 상단 chrome 은 모두
+     `sticky top-0 ... lg:hidden` 패턴이고, 글로벌 AppTopNav 는 `hidden
+     lg:flex` 로 이 셀렉터에 해당되지 않아 안전하다. `data-native-app`
+     속성은 RootLayout 의 SSR + AppLayoutShell 의 useEffect 양쪽에서
+     관리되므로 SSR UA 누락도 자연스럽게 복구된다. */
+  html[data-native-app='true'] .sticky.top-0.lg\:hidden {
+    display: none !important;
+  }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */
   .h-14-safe {
     height: calc(3.5rem + env(safe-area-inset-top));

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -93,7 +93,12 @@ export default async function RootLayout({
   const isNativeApp = isNativeAppUserAgent(headerList.get('user-agent'));
 
   return (
-    <html lang="ko">
+    // `data-native-app` 은 SSR UA 매칭 결과를 그대로 노출한다.
+    // globals.css 의 `[data-native-app="true"] .sticky.top-0.lg\:hidden` 규칙이
+    // 페이지별 모바일 sticky 헤더(HomeMobileHeader 등 19개) 를 일괄 숨긴다.
+    // SSR 가 false 로 내려와도 AppLayoutShell 의 useEffect 가 클라이언트
+    // 감지(useIsNativeApp) 결과로 같은 속성을 다시 세팅해 fail-safe 가 된다.
+    <html lang="ko" data-native-app={isNativeApp ? 'true' : 'false'}>
       <body
         className={cn(
           pretendard.variable,


### PR DESCRIPTION
## 📌 Summary

Flutter 등 네이티브 쉘에서 자체 헤더가 그려질 때, 페이지가 자체적으로 그리는 모바일 sticky 헤더 19곳이 그 아래로 중복 렌더되던 문제를 일괄 차단합니다.

## ✅ 작업 내용

**원인 분석**
- `HomeMobileHeader` 외 18곳의 페이지별 모바일 sticky 헤더 (`sticky top-0 ... lg:hidden` 패턴) 가 `isNativeApp` 분기를 모르고 그대로 렌더 → 네이티브 헤더 아래로 중복.
- 글로벌 `AppTopNav` 는 `hidden lg:flex` 라서 모바일에서 이미 안 보이고 있었음 — 이번 중복의 원인이 아님.

**일괄 차단 방식**
- `src/app/layout.tsx` — `<html data-native-app={isNativeApp ? 'true' : 'false'}>` SSR 설정.
- `src/app.component/layout/AppLayoutShell.tsx` — `useEffect` 로 `useIsNativeApp` 결과를 `document.documentElement.dataset.nativeApp` 에 동기화. SSR UA 매칭이 누락돼도 클라이언트 감지가 fail-safe.
- `src/app.styles/globals.css` — `html[data-native-app='true'] .sticky.top-0.lg\:hidden { display: none !important; }` 한 줄 추가.

**선택자 안전성**
- 모든 페이지 모바일 sticky 헤더가 `sticky top-0 ... lg:hidden` 을 공유.
- 글로벌 `AppTopNav` 는 `hidden lg:flex` 로 매칭 제외 → 네이티브 헤더는 그대로 유지, 페이지 헤더만 사라짐.
- 영향 범위: HomeMobileHeader, 알림/회원 프로필/친구/약관 sticky 헤더, 일지·챌린지 보드·상세·작성 헤더, 관련 Skeleton (총 19곳).

## 📎 기타

- 페어가 되는 Flutter `_1d1s_app` 측 임시 우회 (`web_bridge.dart` 의 `_webChromeSuppressSelectors`) 는 이제 웹에서 정식 처리되므로 후속 클린업으로 제거 가능.
- 검증
  - `pnpm lint` / `pnpm knip` / `pnpm tsc --noEmit` 모두 clean
  - 프로젝트 정책상 브라우저/디바이스 동작 확인은 직접 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate sticky header rendering in native app environments by properly synchronizing the app's native detection state with layout styling rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1D1S/1D1S-client/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->