### PR TITLE
[ODS-60] feat: feat: 네이티브 쉘 chrome 정밀화 + 캐시 휘발 버그 수정

### DIFF
--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -183,8 +183,12 @@ export default function ChallengeBoardScreen(): React.ReactElement {
         description={loginDialogDescription}
       />
 
-      {/* 모바일 sticky 헤더 — 타이틀 + 새 챌린지 + 검색바 */}
+      {/* 모바일 sticky 헤더 — 타이틀 + 새 챌린지 + 검색바.
+          네이티브 쉘에서는 헤더(타이틀/검색) 는 유지(data-native-keep)
+          하되, 인라인 "새 챌린지" 버튼은 숨기고(data-native-hide) 같은
+          액션을 Flutter Extended FAB 가 대신 노출한다. */}
       <div
+        data-native-keep
         className={cn(
           'sticky top-0 z-20 border-b border-gray-100',
           'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
@@ -203,6 +207,7 @@ export default function ChallengeBoardScreen(): React.ReactElement {
           <button
             type="button"
             onClick={handleCreateChallenge}
+            data-native-hide
             className={cn(
               'bg-main-800 inline-flex items-center gap-1 rounded-full',
               'px-3 py-1.5 text-[11px] font-extrabold text-white',

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -715,8 +715,11 @@ export function ChallengeDetailScreen({
     <>
       {/* 모바일 sliver-style sticky 헤더 — 스크롤 시 페이드인.
           data-fade-in 래퍼 밖에 둔다: 래퍼의 transform 이 containing block 을
-          만들어 position: fixed 가 뷰포트 대신 래퍼 기준이 되는 문제를 피한다. */}
+          만들어 position: fixed 가 뷰포트 대신 래퍼 기준이 되는 문제를 피한다.
+          네이티브 쉘에선 AppBackBar 가 같은 역할을 하므로 data-native-hide
+          로 가린다. globals.css 의 sticky 일괄 룰은 fixed 는 안 잡는다. */}
       <div
+        data-native-hide
         className={cn(
           'fixed top-0 right-0 left-0 z-30 flex h-14 items-center',
           'gap-3 border-b border-gray-100 bg-white/95 px-4',
@@ -777,10 +780,13 @@ export function ChallengeDetailScreen({
             bleed
             hideTextOnMobile
           />
+          {/* 히어로 위 모바일 floating 백버튼. 네이티브에선 AppBackBar 가
+              상단에 있으므로 data-native-hide 로 가려 중복을 막는다. */}
           <button
             type="button"
             aria-label="뒤로가기"
             onClick={() => router.back()}
+            data-native-hide
             className={cn(
               'absolute left-3.5 z-10 flex h-9 w-9',
               'top-[calc(0.875rem+env(safe-area-inset-top))]',

--- a/src/app.feature/diary/board/screen/DiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/DiaryListScreen.tsx
@@ -251,8 +251,12 @@ export default function DiaryListScreen(): React.ReactElement {
         description={loginDialogDescription}
       />
 
-      {/* 모바일 sticky 헤더 — 일지 */}
+      {/* 모바일 sticky 헤더 — 일지.
+          네이티브에서는 헤더는 유지(data-native-keep) 하되, 인라인
+          "일지 쓰기" 버튼은 숨기고(data-native-hide) Flutter Extended FAB
+          가 같은 액션을 비로그인 분기까지 포함해 제공한다. */}
       <div
+        data-native-keep
         className={cn(
           'sticky top-0 z-20 flex items-center justify-between',
           'gap-3 border-b border-gray-100',
@@ -273,6 +277,7 @@ export default function DiaryListScreen(): React.ReactElement {
             type="button"
             onClick={() => router.push('/diary/create')}
             aria-label="일지 쓰기"
+            data-native-hide
             className={cn(
               'rounded-2 bg-brand shrink-0 px-3 py-1.5',
               'text-[12px] font-bold text-white transition',

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -69,9 +69,15 @@ export function onNativeNavigateRequest(
   }
   const listener = (event: Event): void => {
     const detail = (event as CustomEvent<{ to?: string }>).detail;
-    if (detail?.to) {
-      handler(detail.to);
+    if (!detail?.to) {
+      return;
     }
+    // preventDefault 는 "내가 처리한다" 시그널. Flutter 측 __NATIVE_NAV__
+    // 가 dispatchEvent 반환값을 보고 fallback (location.assign 풀 리로드)
+    // 을 건너뛴다. 이 호출이 빠지면 React Query 캐시가 매번 휘발되어
+    // 사용자가 탭 전환마다 로딩을 다시 보게 된다.
+    event.preventDefault();
+    handler(detail.to);
   };
   win.addEventListener(NAVIGATE_EVENT, listener);
   return () => win.removeEventListener(NAVIGATE_EVENT, listener);

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -64,21 +64,28 @@
 
   /* Flutter 등 네이티브 쉘이 자체 헤더를 그리는 환경에서, 페이지가 자체적으로
      그리는 모바일 sticky 헤더(HomeMobileHeader, 챌린지/일지 보드·상세·작성,
-     알림, 회원 프로필, 친구, 약관 등 약 19곳) 가 네이티브 헤더 아래로
-     중복돼 보이지 않도록 일괄 차단한다.
+     알림, 회원 프로필, 친구, 약관, 마이페이지 settings/profile, 알림 설정,
+     공지 상세/목록, 문의 등 약 26곳) 가 네이티브 헤더 아래로 중복돼
+     보이지 않도록 일괄 차단한다.
 
-     선택자 근거: 모바일 전용 sticky 상단 chrome 은 모두
-     `sticky top-0 ... lg:hidden` 패턴이고, 글로벌 AppTopNav 는 `hidden
-     lg:flex` 로 이 셀렉터에 해당되지 않아 안전하다. `data-native-app`
-     속성은 RootLayout 의 SSR + AppLayoutShell 의 useEffect 양쪽에서
-     관리되므로 SSR UA 누락도 자연스럽게 복구된다.
+     선택자 근거: 모바일 전용 상단 chrome 은 두 가지 포지셔닝 패턴을 쓴다.
+     - sticky top-0 ... lg:hidden (보드/상세/작성 등 다수)
+     - fixed top-0 ... lg:hidden (settings, 공지, 문의 등 스크롤 추적이
+       필요한 경우)
+     `:is()` 로 둘 다 매칭한다. 글로벌 AppTopNav 는 `hidden lg:flex` 이고
+     fixed top-0 + lg:hidden 조합은 모바일 상단 바 이외 용도로 거의 쓰이지
+     않아 오탐 위험이 낮다. `data-native-app` 속성은 RootLayout 의 SSR +
+     AppLayoutShell 의 useEffect 양쪽에서 관리되므로 SSR UA 누락도
+     자연스럽게 복구된다.
 
      예외: `data-native-keep` 이 붙은 헤더는 네이티브에서도 그대로 보인다.
      /challenge, /diary 보드 헤더처럼 타이틀/검색을 그대로 노출하고 싶을 때
      사용. 헤더는 유지하면서 안쪽 일부 요소(예: 인라인 추가 버튼) 만
-     숨기려면 그 요소에 `data-native-hide` 를 별도로 부착한다. */
+     숨기려면 그 요소에 `data-native-hide` 를 별도로 부착한다.
+     `absolute` 로 떠 있는 모바일 chrome(예: 챌린지 상세 floating 백버튼)
+     은 이 selector 가 잡지 못하므로 그쪽은 data-native-hide 를 직접 부착. */
   html[data-native-app='true']
-    .sticky.top-0.lg\:hidden:not([data-native-keep]) {
+    :is(.sticky.top-0, .fixed.top-0).lg\:hidden:not([data-native-keep]) {
     display: none !important;
   }
 

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -71,8 +71,20 @@
      `sticky top-0 ... lg:hidden` 패턴이고, 글로벌 AppTopNav 는 `hidden
      lg:flex` 로 이 셀렉터에 해당되지 않아 안전하다. `data-native-app`
      속성은 RootLayout 의 SSR + AppLayoutShell 의 useEffect 양쪽에서
-     관리되므로 SSR UA 누락도 자연스럽게 복구된다. */
-  html[data-native-app='true'] .sticky.top-0.lg\:hidden {
+     관리되므로 SSR UA 누락도 자연스럽게 복구된다.
+
+     예외: `data-native-keep` 이 붙은 헤더는 네이티브에서도 그대로 보인다.
+     /challenge, /diary 보드 헤더처럼 타이틀/검색을 그대로 노출하고 싶을 때
+     사용. 헤더는 유지하면서 안쪽 일부 요소(예: 인라인 추가 버튼) 만
+     숨기려면 그 요소에 `data-native-hide` 를 별도로 부착한다. */
+  html[data-native-app='true']
+    .sticky.top-0.lg\:hidden:not([data-native-keep]) {
+    display: none !important;
+  }
+
+  /* 네이티브에서 강제 숨김 마커. 헤더 외 임의 요소(인라인 버튼, 푸터,
+     PWA 프롬프트 등) 에 부착해 isNativeApp 분기를 JS 없이도 처리한다. */
+  html[data-native-app='true'] [data-native-hide] {
     display: none !important;
   }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */


### PR DESCRIPTION
## 📌 Summary

네이티브 쉘과 웹 chrome 간 중복/누락 케이스 4건을 정리하고, 탭 전환마다 풀 리로드 → 캐시 휘발이 일어나던 fallback 버그를 잡습니다.

## ✅ 작업 내용

**`feat: 네이티브에서 챌린지/일지 헤더 유지 + 인라인 추가 버튼 숨김` (75c0243)**
- `globals.css` 의 sticky 일괄 차단 룰에 두 가지 마커 도입.
  - `data-native-keep` : sticky 차단 예외 (헤더 자체는 유지).
  - `data-native-hide` : 임의 요소에 부착해 네이티브에서 강제 숨김.
- `/challenge`, `/diary` 모바일 sticky 헤더에 `data-native-keep` 부착 → 타이틀·검색은 유지.
- 인라인 \"+ 새 챌린지\" / \"+ 일지 쓰기\" 버튼에 `data-native-hide` → Flutter Extended FAB 와 중복 방지.

**`feat: 챌린지 상세의 fixed/floating 모바일 chrome 을 네이티브에서 차단` (9a7b099)**
- `ChallengeDetailScreen` 의 두 요소가 `.sticky.top-0` 룰을 빠져나가 중복되던 문제.
  - `fixed top-0 ... lg:hidden` 스크롤 sliver 헤더 → `data-native-hide`
  - `absolute ... lg:hidden` 히어로 위 floating 백버튼 → `data-native-hide`
- 네이티브 `AppBackBar` 가 같은 자리에 단독 노출되도록.

**`fix: 네이티브 탭 전환마다 풀 리로드되어 캐시 휘발되던 문제` (6244823)** ← 중요
- Flutter `__NATIVE_NAV__` 가 `setTimeout(500ms)` 후 `location.pathname` 변화 여부로 SPA 처리 성공을 추측하던 fallback 이, `router.push` 의 RSC fetch 가 500ms 를 초과하는 정상 케이스에서도 `window.location.assign` 을 발화 → 풀 리로드 → `browserQueryClient` 인스턴스 재생성 → TanStack Query 캐시(staleTime 5분) 통째로 휘발.
- 해결: `native:navigate` 리스너가 `event.preventDefault()` 호출, Flutter 는 `dispatchEvent` 반환값으로 즉시 판정. 리스너 부착 → SPA only / 미부착 → 즉시 fallback. 타이머 의존 제거.
- 효과: 5분 안에 같은 탭 재진입 시 캐시 즉시 노출, 로딩 fallback 안 보임.

**`feat: 네이티브 차단 룰을 fixed top-0 헤더까지 확장` (1515f58)**
- 마이페이지 settings/profile, 알림 설정, 공지 목록·상세, 문의 등 7개 화면이 `fixed top-0 right-0 left-0 ... lg:hidden` 패턴이라 sticky 룰을 빠져나가 네이티브 백 바와 중복.
- 룰을 `:is(.sticky.top-0, .fixed.top-0).lg\:hidden:not([data-native-keep])` 로 확장 — 한 줄로 7곳 일괄 해결. `data-native-keep` / `data-native-hide` 예외 메커니즘은 동일하게 적용.

## 📎 기타

- 페어가 되는 Flutter `_1d1s_app` 측 변경 (별도 repo):
  - `web_bridge.dart`: `__NATIVE_NAV__` 의 setTimeout fallback 제거 → `dispatchEvent` 반환값 기반 분기.
  - `app_back_bar.dart` 신규: < 버튼 + 옵셔널 타이틀의 sub-route 용 앱 바.
  - `route_utils.dart`: `NativeChrome { topNav, backBar, none }` enum + `resolveBackBarTitle`.
  - `hybrid_shell.dart`: chrome enum 분기, Extended FAB(`/challenge`, `/diary`) + 비로그인 시 \"로그인이 필요한 서비스입니다\" 다이얼로그.
- 검증
  - `pnpm lint` / `pnpm knip` / `pnpm tsc --noEmit` 모두 clean
  - 프로젝트 정책상 브라우저/디바이스 동작 확인은 직접 필요
- 동작 체크 포인트 (배포 후)
  - 탭 전환 시 React Query DevTools 에서 queries 가 cached 로 유지 (재생성 안 됨).
  - `/challenge`, `/diary` 진입 시 헤더는 보이고, 우측 하단 \"챌린지 추가\" / \"일지 추가\" FAB 노출. 비로그인 상태에서 FAB 탭 → 다이얼로그.
  - `/challenge/{id}`, `/diary/{id}`, `/mypage/settings`, `/notice`, `/inquiry` 등 sub-route 에서 페이지 자체 헤더 사라지고 네이티브 `AppBackBar` 단독 노출.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized mobile app header display for native environments to prevent UI overlap and ensure consistent layout.
  * Enhanced navigation event handling for improved native app integration.
  * Refined CSS styling rules to properly manage header and button visibility across different platform states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1D1S/1D1S-client/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->