### PR TITLE
[ODS-60] feat: feat: 라우터 캐시 staleTime + 스크롤 방향 브릿지 (sliver AppBar 대응)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,16 @@ const nextConfig = {
     removeConsole: isDev ? false : { exclude: ['error', 'warn'] },
   },
   experimental: {
+    // Next.js 15+ 기본값은 dynamic: 0 이라 라우트 캐시(=RSC payload 클라이언트
+    // 캐시) 가 즉시 stale 로 만료된다. router.prefetch 가 채워 둔 payload 도
+    // 곧바로 휘발되어, 네이티브 탭 전환마다 RSC 가 다시 fetch 되고 페이지
+    // 컴포넌트가 매번 새로 마운트되어 사용자 체감상 "매번 로딩". 두 값
+    // 모두 명시적으로 늘려, 짧은 시간 안의 탭 왕복은 캐시 hit 으로 즉시
+    // 전환되도록 한다. TanStack Query staleTime 과 별개 레이어.
+    staleTimes: {
+      dynamic: 120,
+      static: 600,
+    },
     webpackMemoryOptimizations: true,
     // 큰 라이브러리의 트리쉐이킹을 활성화해 초기 번들 크기를 줄인다.
     optimizePackageImports: [

--- a/src/app.component/layout/NativeBridge.tsx
+++ b/src/app.component/layout/NativeBridge.tsx
@@ -100,5 +100,45 @@ export default function NativeBridge({
     });
   }, [isLoggedIn, hasUnread, streakDays, profileUrl]);
 
+  // 스크롤 방향 브릿지. 네이티브 쉘의 sliver-style AppBar collapse/expand
+  // 트리거. 매 프레임 보내는 대신 방향이 바뀐 순간에만 1회 송신해 JS 채널
+  // 트래픽을 최소화한다. rAF 스로틀 + 미세 떨림(<4px) 무시.
+  // 라우트 분기는 Flutter 측에서 처리(/challenge 만 collapse) — 웹은 항상
+  // 송신해 라우트별 정책을 네이티브 단일 소스로 둔다.
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    let lastY = window.scrollY;
+    let lastDir: 'up' | 'down' | null = null;
+    let ticking = false;
+    const onScroll = (): void => {
+      if (ticking) {
+        return;
+      }
+      ticking = true;
+      window.requestAnimationFrame(() => {
+        const y = window.scrollY;
+        const delta = y - lastY;
+        if (Math.abs(delta) > 4) {
+          const dir: 'up' | 'down' = delta > 0 ? 'down' : 'up';
+          if (dir !== lastDir) {
+            lastDir = dir;
+            postNativeMessage({
+              type: 'scroll_dir',
+              payload: { dir, y },
+            });
+          }
+        }
+        lastY = y;
+        ticking = false;
+      });
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+    };
+  }, []);
+
   return null;
 }

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -19,13 +19,22 @@ export interface NativeNavPayload {
   pathname: string;
 }
 
+export interface NativeScrollDirPayload {
+  dir: 'up' | 'down';
+  y: number;
+}
+
 export type NativeMessage =
   | { type: 'auth_state'; payload: NativeAuthPayload }
   | { type: 'nav_state'; payload: NativeNavPayload }
   // 앱 부팅 1회. 웹이 첫 페인트 + 4탭 prefetch 워밍업까지 끝낸 시점.
   // 네이티브 쉘은 이 신호를 받기 전까진 스플래시를 유지해, 사용자에게
   // 빈 컨테이너나 절반만 로드된 UI 가 노출되지 않게 한다.
-  | { type: 'app_ready' };
+  | { type: 'app_ready' }
+  // 스크롤 방향이 바뀔 때만 1회. 네이티브 쉘이 sliver-style AppBar 를
+  // collapse/expand 하는 용도. 매 프레임 보내는 대신 방향 전환에만 발화해
+  // JS 채널 트래픽을 최소화한다.
+  | { type: 'scroll_dir'; payload: NativeScrollDirPayload };
 
 interface NativeChannel {
   postMessage(payload: string): void;


### PR DESCRIPTION
## 📌 Summary

탭 전환마다 RSC payload 가 다시 fetch 되어 \"매번 로딩\" 으로 체감되던 문제를 라우터 캐시 staleTime 설정으로 잡고, /challenge 의 sliver-style AppBar 를 위한 스크롤 방향 브릿지를 추가합니다.

## ✅ 작업 내용

**`next.config.ts` — `experimental.staleTimes` 명시**
- Next.js 15+ 기본값이 `dynamic: 0` 이라 Router Cache 가 dynamic 라우트의 RSC payload 를 즉시 stale 로 만든다. `router.prefetch` 가 채워둔 payload 도 곧바로 휘발되어 탭 전환마다 다시 fetch.
- `dynamic: 120` (2분), `static: 600` (10분) 으로 설정 → 짧은 시간 안의 탭 왕복은 캐시 hit 으로 즉시 전환.
- TanStack Query staleTime(5분) 과 독립된 레이어. 둘 다 의도된 값으로 명시.

**스크롤 방향 브릿지 (`nativeBridge.ts` + `NativeBridge.tsx`)**
- `NativeMessage` 유니온에 `{ type: 'scroll_dir'; payload: { dir: 'up'|'down'; y: number } }` 추가.
- `NativeBridge` 가 `window scroll` 을 rAF 스로틀 + 미세 떨림(<4px) 무시로 감시.
- 방향이 바뀌는 순간에만 1회 송신 → JS 채널 트래픽 최소화 (매 프레임 X).
- 라우트 게이팅은 Flutter 측에서 (`/challenge` 만 sliver). 웹은 항상 송신해 정책 단일 소스.

## 📎 기타

- 페어가 되는 Flutter `_1d1s_app` 측 변경 (별도 repo):
  - `web_bridge.dart`: `ScrollDirection` enum + `onScrollDirection` 콜백, `_handleMessage` 의 `scroll_dir` 분기.
  - `hybrid_shell.dart`: `TickerProviderStateMixin` + `_appBarAnim` (220ms). `/challenge` 에서 `down → reverse` (hide), `up → forward` (show). 다른 라우트로 이동 시 강제 `forward` 로 노출 복원.
  - `_SliverTopNavHost`: AppTopNav 를 감싸 `preferredSize.height` 를 0~56dp 사이로 동적 변동시킨다. ClipRect + Align(bottomCenter, heightFactor) 로 \"위로 미끄러지듯\" 사라지는 시각 효과.
- 검증
  - `pnpm lint` / `pnpm knip` / `pnpm tsc --noEmit` clean
  - `flutter analyze` clean (pre-existing 패키지명 info 1건만)
  - 프로젝트 정책상 브라우저/디바이스 동작 확인은 직접 필요
- 동작 체크 포인트 (배포 후)
  - **캐싱**: React Query DevTools 가 아니라 Network 탭에서 RSC payload 가 탭 전환마다 다시 받아지지 않는지 확인. 5분 이내 재방문은 0 request.
  - **sliver**: `/challenge` 에서 콘텐츠 스크롤 다운 시 네이티브 AppTopNav 가 위로 미끄러져 사라지고, 위로 스크롤 시 다시 내려온다. 다른 탭(`/`, `/diary`, `/mypage`) 은 AppBar 고정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scroll direction detection that tracks upward and downward scroll movements and captures scroll position for native app integration.

* **Chores**
  * Updated cache configuration with optimized staleness intervals for dynamic and static content delivery to improve application performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1D1S/1D1S-client/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->