### PR TITLE
[ODS-60] feat: fix: 네이티브 탭 prefetch 를 kind:'full' 로 전환

### DIFF
--- a/src/app.component/layout/NativeBridge.tsx
+++ b/src/app.component/layout/NativeBridge.tsx
@@ -57,11 +57,15 @@ export default function NativeBridge({
   );
 
   useEffect(() => {
+    // kind:'full' 은 레이아웃뿐 아니라 dynamic 라우트의 데이터까지 prefetch
+    // 한다. 기본값 'auto' 는 페이지의 nearest loading.tsx 경계에서 멈춰서
+    // 첫 탭 진입마다 사용자에게 skeleton 이 노출되는 원인. 네이티브 쉘은
+    // 항상 모바일 단일 사용자라 prefetch 비용보다 즉시성 이득이 크다.
     NATIVE_TAB_ROUTES.forEach((href) => {
-      router.prefetch(href);
+      router.prefetch(href, { kind: 'full' as never });
     });
     if (!isLoggedIn) {
-      router.prefetch('/login');
+      router.prefetch('/login', { kind: 'full' as never });
     }
   }, [router, isLoggedIn]);
 


### PR DESCRIPTION
## 📌 Summary

네이티브 쉘에서 탭을 누를 때마다 loading.tsx 스켈레톤이 노출되던 문제를 잡습니다. `router.prefetch` 의 기본 모드가 dynamic 라우트 데이터까지는 받아오지 않기 때문입니다.

## ✅ 작업 내용

`router.prefetch(href)` 의 기본값은 `kind: 'auto'` 인데, 이 모드는 dynamic 라우트의 경우 nearest `loading.tsx` 경계에서 prefetch 가 멈춥니다. 페이지의 실제 데이터(Server Component fetch, RSC payload 의 dynamic 부분) 는 prefetch 되지 않아, 사용자가 탭을 탭할 때마다:

1. Router Cache miss → RSC fetch 발생
2. fetch 동안 `loading.tsx` 의 skeleton 노출
3. 데이터 도착 → 페이지 commit

이게 "바텀 네비 누를 때마다 패칭" 으로 체감되던 직접 원인이었습니다.

`kind: 'full'` 로 바꾸면 데이터까지 받아둡니다. 직전 PR(#99) 의 `experimental.staleTimes: { dynamic: 120 }` 와 함께 적용되어야 의미가 있습니다 — 둘 중 하나라도 빠지면 prefetch 한 데이터가 즉시 stale 처리되거나, 아예 데이터를 받지 않거나입니다.

| 설정 | 결과 |
|------|------|
| auto + staleTime 0 (기본) | 매번 fetch + loading.tsx |
| auto + staleTime 120 | 매번 fetch + loading.tsx (auto 가 데이터를 안 받음) |
| full + staleTime 0 | 매번 fetch + loading.tsx (full 효과 즉시 휘발) |
| **full + staleTime 120** | **첫 진입 후 2분 안에는 즉시 전환, loading.tsx 미노출** |

## 📎 기타

- 두 설정 모두 develop 에 머지 + 배포되어야 합니다. 둘 중 하나만 있으면 효과 안 납니다.
- 검증
  - `pnpm lint` / `pnpm tsc --noEmit` clean
- 동작 체크 (배포 후)
  - 앱 부팅 → 스플래시 → 홈
  - 챌린지/일지/마이 탭 순차 탭핑 → loading.tsx 스켈레톤 없이 즉시 전환
  - 2분 안에 같은 탭 재방문 → 즉시 (RSC payload + 데이터 캐시 hit)