### PR TITLE
[ODS-60] feat: refactor: multi-WebView 모델에 맞춰 NativeBridge 단순화

### DIFF
--- a/src/app.component/layout/NativeBridge.tsx
+++ b/src/app.component/layout/NativeBridge.tsx
@@ -14,33 +14,33 @@ interface NativeBridgeProps {
   authState: AuthLayoutState;
 }
 
-// 네이티브 하단 탭이 향하는 4개 라우트. 웹 AppBottomNav 가 네이티브에서
-// 숨겨지면서 거기서 돌던 prefetch 도 같이 사라졌기에, NativeBridge 에서
-// 같은 워밍업을 재현한다.
-const NATIVE_TAB_ROUTES = ['/', '/challenge', '/diary', '/mypage'] as const;
-
-// prefetch 가 RSC payload 를 백그라운드로 받기 시작한 뒤, 첫 페인트가
-// 안정될 때까지 두는 grace. 너무 짧으면 네이티브 스플래시가 빨리 사라지며
-// 빈 화면이 잠시 노출되고, 너무 길면 사용자가 불필요하게 기다린다.
+// 첫 페인트가 시각적으로 안정될 때까지 두는 grace. Flutter 쉘은 home 탭의
+// 첫 onPageFinished 또는 app_ready 중 빠른 쪽으로 스플래시를 dismiss
+// 한다. grace 가 0 이면 React hydration 직전 빈 컨테이너가 잠시 노출될
+// 수 있어 작게 둔다.
 const APP_READY_GRACE_MS = 400;
 
 /**
  * Flutter 네이티브 쉘이 띄운 WebView 내부에서만 마운트되는 동기화 컴포넌트.
  *
- * - 네이티브 쉘에서 탭을 탭하면 `window.__NATIVE_NAV__('/...')` 호출 →
- *   `native:navigate` 이벤트 → 여기서 `router.push` 로 흡수해 SPA 전환.
- *   Flutter 측 500ms 후 `location.assign` fallback 이 있어 listener 가
- *   미처 attach 되기 전 풀 페이지 리로드가 발생할 수 있으므로 mount 시
- *   가장 먼저 이 useEffect 가 돌도록 위쪽에 배치한다.
- * - 마운트 시 4개 탭 라우트(+ 비로그인 시 /login) 를 prefetch — 네이티브
- *   에서 web AppBottomNav 가 가려지면서 그쪽 prefetch 가 같이 죽었기에,
- *   첫 탭 탭핑부터 SPA 전환이 즉시 일어나도록 워밍업한다.
- * - pathname 이 바뀔 때마다 네이티브에 `nav_state` 메시지 push → 네이티브
- *   하단 탭의 active 표시가 동기화된다.
- * - 인증/사이드바/알림 상태가 바뀔 때마다 `auth_state` 를 push → 네이티브
- *   헤더의 streak chip, 알림 dot, 프로필 아바타가 동기화된다.
+ * Flutter 쉘은 탭마다 별도 WebViewController 를 alive 로 유지하고 IndexedStack
+ * 으로 활성 탭만 화면에 보여준다. 즉 각 WebView 는 자기 탭의 라우트(`/`,
+ * `/challenge`, `/diary`, `/mypage`) 만 책임지며, NativeBridge 도 그 WebView
+ * 내부에서 한 인스턴스만 동작한다.
  *
- * 렌더링 산출물이 없으므로 `null` 을 반환한다.
+ * - `native:navigate` (Flutter → 웹) 를 받아 `router.push` 로 흡수.
+ *   같은 탭 안의 sub-route 이동(예: `/challenge/123`) 에 쓰인다. 다른 탭으로
+ *   가는 cross-tab 이동은 Flutter 의 BottomNav 가 IndexedStack 인덱스를
+ *   바꾸는 식으로 처리해서 SPA 라우팅을 사용하지 않는다.
+ * - 페이지 hydrate 후 `app_ready` 1회 송신 → 스플래시 dismiss 트리거.
+ * - pathname 변경 시 `nav_state` → 활성 탭/back bar 가시성 결정용.
+ * - 인증/사이드바/알림 변경 시 `auth_state` → 네이티브 헤더 동기화.
+ * - 스크롤 방향 전환 시 `scroll_dir` → /challenge sliver AppBar 트리거.
+ *
+ * cross-tab `router.prefetch` 와 풀-투-리프레시 는 multi-WebView 모델에서
+ * 의미가 없어 Flutter 쪽으로 위임했다 — 각 탭이 본인 페이지를 자기 WebView
+ * 에서 직접 로드하고, 풀-투-리프레시 는 Flutter 가 inject 한 JS 가 잡아서
+ * `pull_refresh` 메시지로 네이티브에게 reload 를 요청한다.
  */
 export default function NativeBridge({
   authState,
@@ -56,23 +56,10 @@ export default function NativeBridge({
     [router]
   );
 
-  useEffect(() => {
-    // kind:'full' 은 레이아웃뿐 아니라 dynamic 라우트의 데이터까지 prefetch
-    // 한다. 기본값 'auto' 는 페이지의 nearest loading.tsx 경계에서 멈춰서
-    // 첫 탭 진입마다 사용자에게 skeleton 이 노출되는 원인. 네이티브 쉘은
-    // 항상 모바일 단일 사용자라 prefetch 비용보다 즉시성 이득이 크다.
-    NATIVE_TAB_ROUTES.forEach((href) => {
-      router.prefetch(href, { kind: 'full' as never });
-    });
-    if (!isLoggedIn) {
-      router.prefetch('/login', { kind: 'full' as never });
-    }
-  }, [router, isLoggedIn]);
-
-  // 앱 부팅 1회 신호. 네이티브 쉘이 스플래시를 dismiss 할 트리거다.
-  // prefetch 가 큐잉된 직후 짧은 grace 를 둬서, 첫 페인트가 안정된 상태
-  // 에서 사용자가 앱을 보게 한다. useRef 가드로 SPA 전환마다 재발화하지
-  // 않게 한다 — 백그라운드 복귀 등에서도 1회만.
+  // useRef 가드로 SPA 전환 / 백그라운드 복귀에서도 1회만 발화. 각 WebView
+  // 마다 자기 인스턴스의 1회를 보장한다 (이 컴포넌트 인스턴스가 unmount 되지
+  // 않는 한). Flutter 측은 어느 탭의 app_ready 든 받으면 home 탭이면
+  // 스플래시 dismiss 트리거로, 나머지 탭이면 무시한다.
   const hasSignaledReady = useRef(false);
   useEffect(() => {
     if (hasSignaledReady.current) {


### PR DESCRIPTION
## 📌 Summary

Flutter 쉘이 탭마다 별도 `WebViewController` + `IndexedStack` 으로 재설계되면서, NativeBridge 가 더 이상 책임지지 않아도 되는 두 가지를 걷어냅니다.

## ✅ 작업 내용

**cross-tab `router.prefetch` 제거**
- multi-WebView 모델에서는 각 탭이 본인 WebView 에서 자기 라우트(`/`, `/challenge`, `/diary`, `/mypage`) 를 직접 로드한다.
- cross-tab 이동은 BottomNav 탭이 IndexedStack 인덱스를 바꾸는 식이라 SPA 라우팅을 안 탄다.
- 따라서 한 탭의 WebView 안에서 다른 탭 URL 을 `router.prefetch` 하는 건 무의미해서 제거.

**풀-투-리프레시 listener 제거**
- Flutter 가 `injectHandshake` 단계에서 직접 JS 를 주입해 pull 제스처를 잡고, `pull_refresh` 메시지로 네이티브에 reload 를 요청한다.
- 웹 쪽에서 같은 제스처를 또 잡으면 두 번 발화 또는 충돌. 단일 소스를 Flutter 로 통일.

**`app_ready` 단순화**
- 4페이지 fetch 대기 (Promise.allSettled) 를 빼고 짧은 grace 타이머로 되돌림.
- multi-WebView 모델은 4탭이 이미 병렬로 로드되고 있어서, home 의 `app_ready` 가 곧장 발화해도 다른 탭은 백그라운드에서 계속 prefetch 된다. 스플래시를 4페이지 완료까지 잡아 둘 필요가 없어졌다.

**유지된 책임**
- `native:navigate` → `router.push` (탭 내부 sub-route 이동)
- pathname → `nav_state` post (활성 탭/back bar 가시성)
- 인증/사이드바 변경 → `auth_state` post (네이티브 헤더 동기화)
- 스크롤 방향 → `scroll_dir` post (/challenge sliver AppBar)

## 📎 기타

- 페어가 되는 Flutter `_1d1s_app` 측 변경 (별도 repo, 동시 진행):
  - `hybrid_shell.dart`: 4개 `WebViewController` 를 키-맵으로 관리, `IndexedStack` 으로 활성 탭만 렌더, alive 한 비활성 탭들이 백그라운드에서 prefetch.
  - `web_bridge.dart`: `injectHandshake` 안에 풀-투-리프레시 JS 주입(touchstart/end 추적), `pull_refresh` 메시지 + `PullRefreshCallback`.
- 검증
  - `pnpm lint` / `pnpm knip` / `pnpm tsc --noEmit` clean