### PR TITLE
[ODS-60] feat: feat: 로그인 흐름 정정 + 챌린지/일지 헤더 정리 + 네이티브 모달 브릿지 foundation

### DIFF
--- a/src/app.component/LoginRequiredDialog.tsx
+++ b/src/app.component/LoginRequiredDialog.tsx
@@ -10,9 +10,11 @@ import {
   Icon,
   Text,
 } from '@1d1s/design-system';
+import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
 import { cn } from '@module/utils/cn';
+import { openNativeModal } from '@module/utils/nativeBridge';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 interface LoginRequiredDialogProps {
   open: boolean;
@@ -35,8 +37,56 @@ export function LoginRequiredDialog({
   description = '로그인 후 이용할 수 있습니다.',
   required = false,
   onClose,
-}: LoginRequiredDialogProps): React.ReactElement {
+}: LoginRequiredDialogProps): React.ReactElement | null {
   const router = useRouter();
+  const isNativeApp = useIsNativeApp(false);
+
+  // 네이티브 쉘에서는 웹 다이얼로그 대신 OS 다이얼로그(showDialog 의
+  // AlertDialog) 가 뜨도록 모달 브릿지로 위임한다. required 모드도
+  // 같은 동작 — 사용자가 dismiss(밖 클릭/시스템 백) 하면 onClose 호출.
+  useEffect(() => {
+    if (!isNativeApp || !open) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const result = await openNativeModal({
+        title,
+        message: description,
+        buttons: [
+          { label: '닫기', value: 'cancel', style: 'cancel' },
+          { label: '로그인', value: 'login' },
+        ],
+      });
+      if (cancelled) {
+        return;
+      }
+      onOpenChange(false);
+      if (result === 'login') {
+        router.push('/login');
+      } else if (required) {
+        onClose?.();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    open,
+    isNativeApp,
+    title,
+    description,
+    required,
+    onOpenChange,
+    onClose,
+    router,
+  ]);
+
+  // 네이티브에서는 본 컴포넌트가 그릴 게 없다 — Flutter 가 다이얼로그를
+  // 직접 렌더하기 때문. 웹 모드만 기존 Dialog 트리를 반환.
+  if (isNativeApp) {
+    return null;
+  }
 
   if (!required) {
     return (

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -184,11 +184,10 @@ export default function ChallengeBoardScreen(): React.ReactElement {
       />
 
       {/* 모바일 sticky 헤더 — 타이틀 + 새 챌린지 + 검색바.
-          네이티브 쉘에서는 헤더(타이틀/검색) 는 유지(data-native-keep)
-          하되, 인라인 "새 챌린지" 버튼은 숨기고(data-native-hide) 같은
-          액션을 Flutter Extended FAB 가 대신 노출한다. */}
+          네이티브 쉘에서는 AppTopNav + sliver AppBar 가 동일 영역을
+          책임지고, FAB 가 "챌린지 추가" 액션을 제공하므로 이 헤더는
+          글로벌 sticky 차단 룰로 함께 가린다 (data-native-keep 제거). */}
       <div
-        data-native-keep
         className={cn(
           'sticky top-0 z-20 border-b border-gray-100',
           'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',

--- a/src/app.feature/diary/board/screen/DiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/DiaryListScreen.tsx
@@ -252,11 +252,10 @@ export default function DiaryListScreen(): React.ReactElement {
       />
 
       {/* 모바일 sticky 헤더 — 일지.
-          네이티브에서는 헤더는 유지(data-native-keep) 하되, 인라인
-          "일지 쓰기" 버튼은 숨기고(data-native-hide) Flutter Extended FAB
-          가 같은 액션을 비로그인 분기까지 포함해 제공한다. */}
+          네이티브 쉘은 AppTopNav 가 같은 영역을 차지하고 FAB 가
+          "일지 추가" 를 제공하므로, 이 헤더는 글로벌 sticky 차단 룰로
+          함께 가린다 (data-native-keep 제거). */}
       <div
-        data-native-keep
         className={cn(
           'sticky top-0 z-20 flex items-center justify-between',
           'gap-3 border-b border-gray-100',

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -7,6 +7,7 @@
 
 const CHANNEL_NAME = 'OneDayOneStreakNative';
 const NAVIGATE_EVENT = 'native:navigate';
+const MODAL_RESULT_EVENT = 'native:modal_result';
 
 export interface NativeAuthPayload {
   isLoggedIn: boolean;
@@ -24,6 +25,25 @@ export interface NativeScrollDirPayload {
   y: number;
 }
 
+export interface NativeModalButton {
+  // 사용자에게 보여줄 라벨.
+  label: string;
+  // 사용자가 이 버튼을 선택하면 Promise 가 resolve 하는 값. 임의 식별자.
+  value: string;
+  // iOS/Material 다이얼로그의 강조 스타일. 'cancel' 은 회색조, 'destructive'
+  // 는 빨강, 'default' 는 브랜드 강조. Flutter 측 매핑은 별도 합의.
+  style?: 'default' | 'cancel' | 'destructive';
+}
+
+export interface NativeModalOpenPayload {
+  // 같은 모달 요청을 식별. 응답이 돌아오는 modal_result 의 id 와 매칭.
+  id: string;
+  title: string;
+  message?: string;
+  // 1~3개 권장. 빈 배열이면 네이티브가 기본 "확인" 1개로 채운다.
+  buttons: NativeModalButton[];
+}
+
 export type NativeMessage =
   | { type: 'auth_state'; payload: NativeAuthPayload }
   | { type: 'nav_state'; payload: NativeNavPayload }
@@ -34,7 +54,10 @@ export type NativeMessage =
   // 스크롤 방향이 바뀔 때만 1회. 네이티브 쉘이 sliver-style AppBar 를
   // collapse/expand 하는 용도. 매 프레임 보내는 대신 방향 전환에만 발화해
   // JS 채널 트래픽을 최소화한다.
-  | { type: 'scroll_dir'; payload: NativeScrollDirPayload };
+  | { type: 'scroll_dir'; payload: NativeScrollDirPayload }
+  // 네이티브 다이얼로그 노출 요청. 응답은 native:modal_result CustomEvent
+  // 로 비동기 도착. openNativeModal() 헬퍼가 id 매칭으로 Promise 화 한다.
+  | { type: 'modal_open'; payload: NativeModalOpenPayload };
 
 interface NativeChannel {
   postMessage(payload: string): void;
@@ -90,4 +113,67 @@ export function onNativeNavigateRequest(
   };
   win.addEventListener(NAVIGATE_EVENT, listener);
   return () => win.removeEventListener(NAVIGATE_EVENT, listener);
+}
+
+// 모달 응답 대기 큐. id → resolver. Flutter 가 사용자 선택 후 dispatchEvent
+// 로 결과를 보내면 그 id 에 대응되는 resolver 를 깨우고 큐에서 삭제한다.
+// Flutter 가 dialog 자체를 dismiss(밖 클릭, 백 버튼) 했을 때를 위해 value
+// 는 nullable — 그 경우 호출자는 cancel 로 해석한다.
+const pendingNativeModals = new Map<string, (value: string | null) => void>();
+let modalResultListenerAttached = false;
+
+function ensureModalResultListener(): void {
+  if (modalResultListenerAttached) {
+    return;
+  }
+  const win = getNativeWindow();
+  if (!win) {
+    return;
+  }
+  const listener = (event: Event): void => {
+    const detail = (
+      event as CustomEvent<{ id?: string; value?: string | null }>
+    ).detail;
+    if (!detail?.id) {
+      return;
+    }
+    const resolver = pendingNativeModals.get(detail.id);
+    if (resolver) {
+      pendingNativeModals.delete(detail.id);
+      resolver(detail.value ?? null);
+    }
+  };
+  win.addEventListener(MODAL_RESULT_EVENT, listener);
+  modalResultListenerAttached = true;
+}
+
+function generateModalId(): string {
+  return `m_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * 네이티브 쉘에 다이얼로그 노출을 요청한다. 사용자가 버튼을 선택하면 그
+ * `value` 가, 다이얼로그를 dismiss(밖 클릭, 시스템 백) 하면 `null` 이
+ * resolve 된다. 네이티브 쉘이 아닌 일반 브라우저에서는 즉시 `null` 을
+ * resolve 해, 호출자는 자체 fallback 다이얼로그를 띄우면 된다.
+ */
+export function openNativeModal(
+  options: Omit<NativeModalOpenPayload, 'id'>
+): Promise<string | null> {
+  const win = getNativeWindow();
+  if (!win) {
+    return Promise.resolve(null);
+  }
+  if (!win[CHANNEL_NAME]) {
+    return Promise.resolve(null);
+  }
+  ensureModalResultListener();
+  const id = generateModalId();
+  return new Promise<string | null>((resolve) => {
+    pendingNativeModals.set(id, resolve);
+    postNativeMessage({
+      type: 'modal_open',
+      payload: { id, ...options },
+    });
+  });
 }


### PR DESCRIPTION
## 📌 Summary

multi-WebView 모델로 옮긴 뒤 발견된 로그인 후 화면 불일치를 잡고, 챌린지/일지 보드 헤더 중복을 정리하고, 웹 다이얼로그를 OS 네이티브 다이얼로그로 띄울 수 있는 모달 브릿지 foundation 을 추가합니다.

## ✅ 작업 내용

**`feat: /challenge, /diary 의 data-native-keep 제거`**
- 두 보드 화면의 모바일 sticky 헤더에서 `data-native-keep` 마커 제거.
- multi-WebView + sliver AppBar 도입 후 네이티브 `AppTopNav` 가 같은 영역을 차지하고, FAB 가 \"챌린지/일지 추가\" 액션을 노출하므로 페이지 자체 sticky 헤더는 시각적 중복.
- 글로벌 sticky 차단 룰이 자동으로 가린다.

**`feat: 네이티브 모달 브릿지 foundation`**
- `nativeBridge.ts`:
  - `NativeMessage` 에 `{ type: 'modal_open'; payload: { id, title, message?, buttons } }` 추가.
  - `openNativeModal(opts): Promise<string | null>` 헬퍼 — id 생성, post message, `native:modal_result` 이벤트로 결과 받아 Promise resolve. 네이티브 채널이 없으면 즉시 `null` resolve 해서 호출자가 자체 fallback 가능.
- `LoginRequiredDialog`:
  - `isNativeApp` 일 때 useEffect 가 `openNativeModal` 을 호출하고 컴포넌트는 `return null`.
  - dismiss/취소 → `onClose` (required 모드만), 로그인 선택 → `router.push('/login')`.
  - 다른 모든 호출처(HomeScreen, MemberDiary*, ChallengeBoard, ChallengeDetail, ChallengeDiaryList, DiaryDetail, MyDiary*) 가 자동으로 native 다이얼로그를 띄우게 된다.

## 📎 기타

- 페어가 되는 Flutter `_1d1s_app` 측 변경 (별도 repo):
  - `hybrid_shell.dart`: 로그인 전이 시 현재 탭까지 포함해 모든 탭을 자기 initial path 로 `loadRequest`. OAuth callback 의 `router.replace('/')` 가 mypage WebView 를 `/` 에 두던 문제를 해결.
  - `web_bridge.dart`: `NativeModalRequest` + `NativeModalButtonSpec` + `ModalOpenCallback` 추가. `_handleMessage` 에 `modal_open` 분기. 사용자 선택 후 `_dispatchModalResult` 로 `native:modal_result` CustomEvent 디스패치.
  - `hybrid_shell.dart`: `_showNativeModal` 콜백 — `AlertDialog` 로 버튼별 강조 스타일(brand/cancel/destructive) 매핑.
- 검증
  - `pnpm lint` / `pnpm knip` / `pnpm tsc --noEmit` clean
  - `flutter analyze` clean
  - 동작 확인은 정책상 직접 (배포 후 로그인 시도 → mypage WebView 가 `/mypage` 로 복귀, 로그인 다이얼로그 노출 시 OS 네이티브 다이얼로그가 보이는지)