### PR TITLE
[ODS-199] fix: 스토리/일지 레이아웃 및 썸네일 수정

### DIFF
--- a/src/app.feature/challenge/shared/components/ChallengeListItem.tsx
+++ b/src/app.feature/challenge/shared/components/ChallengeListItem.tsx
@@ -7,6 +7,7 @@ import {
   type TagProps,
   Text,
 } from '@1d1s/design-system';
+import { resolveDiaryImageUrl } from '@feature/diary/shared/utils/diaryImageUrl';
 import { createActivationKeydownHandler } from '@module/utils/event';
 import Image from 'next/image';
 
@@ -51,7 +52,10 @@ export function ChallengeListItem({
   className,
   onClick,
 }: ChallengeListItemProps): React.ReactElement {
-  const hasImage = Boolean(imageUrl && imageUrl.trim().length > 0);
+  // 백엔드가 raw 키(예: challenge/xxx.jpg)를 주면 next/image 가 그리지 못해
+  // 배경색만 보인다. DiaryCard/StoryRing 과 동일하게 풀 URL 로 변환한다.
+  const resolvedImageUrl = resolveDiaryImageUrl(imageUrl) ?? undefined;
+  const hasImage = Boolean(resolvedImageUrl);
   const isIndividual = maxUserCount <= 1;
 
   const hasEnded = isInfiniteChallenge ? isEarlyEnded : isEnded;
@@ -94,7 +98,7 @@ export function ChallengeListItem({
       >
         {hasImage ? (
           <Image
-            src={imageUrl as string}
+            src={resolvedImageUrl as string}
             alt={challengeTitle}
             fill
             sizes={

--- a/src/app.feature/diary/board/type/diary.ts
+++ b/src/app.feature/diary/board/type/diary.ts
@@ -21,6 +21,7 @@ export interface ChallengeSummary {
   goalType: string;
   participationType: string;
   participantCnt: number;
+  thumbnailImage?: string | null;
   likeInfo: LikeInfo;
 }
 

--- a/src/app.feature/diary/write/utils/diaryFormHelpers.ts
+++ b/src/app.feature/diary/write/utils/diaryFormHelpers.ts
@@ -164,6 +164,7 @@ export function mapDiaryChallengeToChallengeListItem(
     participantCnt: challenge.participantCnt,
     liked: challenge.likeInfo.likedByMe,
     likeCnt: challenge.likeInfo.likeCnt,
+    thumbnailImage: challenge.thumbnailImage ?? undefined,
   };
 }
 
@@ -182,6 +183,7 @@ export function mapSidebarChallengeToChallengeListItem(
     participantCnt: challenge.participantCnt,
     liked: challenge.likeInfo.likedByMe,
     likeCnt: challenge.likeInfo.likeCnt,
+    thumbnailImage: challenge.thumbnailImage ?? undefined,
   };
 }
 

--- a/src/app.feature/member/type/member.ts
+++ b/src/app.feature/member/type/member.ts
@@ -13,6 +13,7 @@ export interface SidebarChallenge {
   goalType: string;
   participationType: string;
   participantCnt: number;
+  thumbnailImage?: string | null;
   likeInfo: {
     likedByMe: boolean;
     likeCnt: number;

--- a/src/app.feature/stories/components/Stories.tsx
+++ b/src/app.feature/stories/components/Stories.tsx
@@ -11,6 +11,7 @@ import React, { useState } from 'react';
 import { useStories } from '../hooks/useStoryQueries';
 import { sortStoryGroups } from '../utils/storyHelpers';
 import StoryRing from './StoryRing';
+import StoryRingSkeleton from './StoryRingSkeleton';
 import StoryViewer from './StoryViewer';
 
 interface StoriesProps {
@@ -20,59 +21,6 @@ interface StoriesProps {
   fetchEnabled?: boolean;
   /** 비로그인 상태에서 스토리 영역 클릭 시 동작 */
   onRequireLogin?(): void;
-}
-
-function StoryRingSkeleton(): React.ReactElement {
-  return (
-    <div
-      className={cn(
-        'scrollbar-hide flex w-full overflow-x-auto',
-        'gap-3 px-5 py-3.5 lg:px-8'
-      )}
-      aria-busy
-      aria-label="스토리 불러오는 중"
-    >
-      {Array.from({ length: 5 }).map((_, index) => (
-        <Card key={index} radius="md" className="w-[140px] flex-shrink-0">
-          <Card.Thumb className="aspect-[4/5] bg-gray-100">
-            <div className="skeleton-pulse h-full w-full bg-gray-200" />
-          </Card.Thumb>
-          <Card.Body className="gap-1.5 p-3">
-            {/* 실제 Text caption2 + leading-snug = 14px * 1.375 ≈ 19px */}
-            <div className="flex h-[19px] items-center">
-              <div
-                className={cn('skeleton-pulse h-3 w-3/4 rounded bg-gray-200')}
-              />
-            </div>
-            <Card.Meta>
-              <span className="inline-flex min-w-0 items-center gap-1.5">
-                <span
-                  className={cn(
-                    'relative h-5 w-5 shrink-0 overflow-hidden',
-                    'skeleton-pulse rounded-full bg-gray-100'
-                  )}
-                  aria-hidden
-                />
-                {/* 실제 text-[11px] 라인박스 ≈ 16px */}
-                <span className="inline-flex h-4 items-center">
-                  <span
-                    className={cn(
-                      'skeleton-pulse h-2.5 w-12 rounded bg-gray-200'
-                    )}
-                  />
-                </span>
-              </span>
-              <span className="inline-flex h-4 shrink-0 items-center">
-                <span
-                  className={cn('skeleton-pulse h-2.5 w-8 rounded bg-gray-200')}
-                />
-              </span>
-            </Card.Meta>
-          </Card.Body>
-        </Card>
-      ))}
-    </div>
-  );
 }
 
 function StoryLoginPrompt({

--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -7,7 +7,11 @@ import Image from 'next/image';
 import React from 'react';
 
 import { StoryGroup } from '../type/story';
-import { formatStoryDate, isGroupAllSeen } from '../utils/storyHelpers';
+import {
+  formatStoryDate,
+  isGroupAllSeen,
+  pickStoryStripeTone,
+} from '../utils/storyHelpers';
 
 interface StoryRingProps {
   groups: StoryGroup[];
@@ -16,9 +20,6 @@ interface StoryRingProps {
   myProfileImage?: string | null;
   onAddStory?(): void;
 }
-
-const STRIPE_TONES = ['peach', 'mint', 'sky'] as const;
-type StripeTone = (typeof STRIPE_TONES)[number];
 
 // next/image 는 절대 URL 또는 / 시작 상대 경로만 허용한다.
 function isValidNextImageSrc(src: string | undefined): src is string {
@@ -29,11 +30,6 @@ function isValidNextImageSrc(src: string | undefined): src is string {
     return true;
   }
   return /^(https?:|data:|blob:)/i.test(src);
-}
-
-function pickToneByUserId(userId: number): StripeTone {
-  const index = Math.abs(userId) % STRIPE_TONES.length;
-  return STRIPE_TONES[index];
 }
 
 export default function StoryRing({
@@ -136,7 +132,7 @@ export default function StoryRing({
         const name = group.userName?.trim() || `친구 ${group.userId}`;
         const title = preview?.diaryTitle ?? '';
         const time = preview ? formatStoryDate(preview.createdAt) : '';
-        const tone = pickToneByUserId(group.userId);
+        const tone = pickStoryStripeTone(group.userId);
 
         return (
           <Card

--- a/src/app.feature/stories/components/StoryRingSkeleton.tsx
+++ b/src/app.feature/stories/components/StoryRingSkeleton.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Card } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+interface StoryRingSkeletonProps {
+  /** 표시할 스켈레톤 카드 수 (default 5) */
+  count?: number;
+}
+
+// 실제 StoryRing 과 동일한 Card 테두리 래퍼 + 썸네일/제목/프로필+이름/시간
+// 레이아웃을 그대로 두고, 내용만 회색 pulse 플레이스홀더로 채운다.
+export default function StoryRingSkeleton({
+  count = 5,
+}: StoryRingSkeletonProps): React.ReactElement {
+  return (
+    <div
+      className={cn(
+        'scrollbar-hide flex w-full overflow-x-auto',
+        'gap-3 px-5 py-3.5 lg:px-8'
+      )}
+      aria-busy
+      aria-label="스토리 불러오는 중"
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <Card key={index} radius="md" className="w-[140px] flex-shrink-0">
+          <Card.Thumb className="aspect-[4/5] bg-gray-100">
+            <div className="skeleton-pulse h-full w-full bg-gray-100" />
+          </Card.Thumb>
+          <Card.Body className="gap-1.5 p-3">
+            <div className="skeleton-pulse h-3 w-3/4 rounded bg-gray-100" />
+            <Card.Meta>
+              <span className="inline-flex min-w-0 items-center gap-1.5">
+                <span
+                  className={cn(
+                    'skeleton-pulse h-5 w-5 shrink-0 rounded-full bg-gray-100'
+                  )}
+                  aria-hidden
+                />
+                <span className="skeleton-pulse h-2.5 w-12 rounded bg-gray-100" />
+              </span>
+              <span
+                className={cn(
+                  'skeleton-pulse h-2.5 w-8 shrink-0 rounded bg-gray-100'
+                )}
+              />
+            </Card.Meta>
+          </Card.Body>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app.feature/stories/components/StoryViewer.tsx
+++ b/src/app.feature/stories/components/StoryViewer.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  CircleAvatar,
-  Icon,
-  ImagePlaceholder,
-  Text,
-} from '@1d1s/design-system';
+import { CircleAvatar, Icon, Stripe, Text } from '@1d1s/design-system';
 import { resolveDiaryImageUrl } from '@feature/diary/shared/utils/diaryImageUrl';
 import { cn } from '@module/utils/cn';
 import Image from 'next/image';
@@ -14,7 +9,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useViewStory } from '../hooks/useStoryMutations';
 import { StoryGroup } from '../type/story';
-import { formatStoryDate } from '../utils/storyHelpers';
+import { formatStoryDate, pickStoryStripeTone } from '../utils/storyHelpers';
 
 interface StoryViewerProps {
   groups: StoryGroup[];
@@ -185,7 +180,7 @@ export default function StoryViewer({
               priority
             />
           ) : (
-            <ImagePlaceholder className="h-full w-full" logoSize="lg" />
+            <Stripe tone={pickStoryStripeTone(group.userId)} />
           )}
 
           {hasMultiple ? (

--- a/src/app.feature/stories/utils/storyHelpers.ts
+++ b/src/app.feature/stories/utils/storyHelpers.ts
@@ -2,6 +2,16 @@ import { getRelativeTimeLabel } from '@module/utils/date';
 
 import { StoryGroup } from '../type/story';
 
+const STRIPE_TONES = ['peach', 'mint', 'sky'] as const;
+export type StoryStripeTone = (typeof STRIPE_TONES)[number];
+
+// 썸네일이 없을 때 스토리 카드/뷰어에 표시할 Stripe 색을 userId 기준으로
+// 고정 배정한다. 같은 사용자는 항상 같은 색을 받는다.
+export function pickStoryStripeTone(userId: number): StoryStripeTone {
+  const index = Math.abs(userId) % STRIPE_TONES.length;
+  return STRIPE_TONES[index];
+}
+
 // 그룹 내 모든 스토리가 읽혔는지 여부.
 export function isGroupAllSeen(group: StoryGroup): boolean {
   return group.stories.every((story) => !story.hasUnreadJournal);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { CHALLENGE_QUERY_KEYS } from '@feature/challenge/board/consts/queryKeys'
 import { DIARY_QUERY_KEYS } from '@feature/diary/board/consts/queryKeys';
 import HomeMobileHeader from '@feature/home/components/HomeMobileHeader';
 import HomeScreen from '@feature/home/screen/HomeScreen';
+import StoryRingSkeleton from '@feature/stories/components/StoryRingSkeleton';
 import {
   getServerRandomChallenges,
   getServerRandomDiaries,
@@ -19,20 +20,7 @@ function HomeLoadingSkeleton(): React.ReactElement {
     <div className="mx-auto w-full max-w-[1200px] px-5 py-7 lg:px-8 lg:py-10">
       <div className="flex flex-col gap-4">
         <div className="-mx-5 lg:-mx-8">
-          <div className="scrollbar-hide flex w-full gap-3 overflow-x-auto px-5 py-3.5 lg:px-8">
-            {Array.from({ length: 5 }).map((_, index) => (
-              <div
-                key={index}
-                className="flex w-[140px] shrink-0 flex-col gap-2"
-              >
-                <div className="aspect-4/5 w-full rounded-xl bg-gray-100" />
-                <div className="flex flex-col gap-1 px-0.5">
-                  <div className="h-3 w-3/4 rounded bg-gray-100" />
-                  <div className="h-2.5 w-1/2 rounded bg-gray-100" />
-                </div>
-              </div>
-            ))}
-          </div>
+          <StoryRingSkeleton />
         </div>
         <div className="h-24 w-full animate-pulse rounded-2xl bg-gray-100" />
         <div className="h-32 w-full animate-pulse rounded-2xl bg-gray-100" />


### PR DESCRIPTION
## 📌 Summary

스토리 스켈레톤/기본 썸네일과 일지 작성 챌린지 썸네일 표시 문제를 수정합니다.

## ✅ 작업 내용

- 스토리 스켈레톤 통합: SSR Suspense fallback과 쿼리 로딩에서 서로 다른 스켈레톤이 뜨던 문제 정리. 실제 `StoryRing`과 동일한 `Card` 레이아웃(테두리/썸네일/프로필·이름/시간)을 따르는 회색 플레이스홀더로 통일.
- 스토리 기본 썸네일: 썸네일 없는 경우 레거시 `ImagePlaceholder`(배경+로고) → 일지 카드와 동일한 `Stripe`로 교체. tone 산정 로직을 `storyHelpers`로 추출해 `StoryRing`/`StoryViewer`가 공유.
- 일지 작성 챌린지 썸네일 미표시 수정: 사이드바 챌린지가 `thumbnailImage`를 누락하던 문제. `SidebarChallenge`/`ChallengeSummary` 타입에 필드 추가 + 매퍼에서 값 전달. `ChallengeListItem`이 raw 키를 풀 URL로 변환하도록 정리.

## 📎 기타

- `/member/side-bar` 응답의 챌린지 썸네일 필드명이 `thumbnailImage`가 맞는지 확인 필요. 다른 이름이면 매핑 키만 맞추면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Challenge list items now display thumbnail images.
  * Story viewer shows styled placeholders when images are unavailable.

* **Refactor**
  * Extracted story skeleton into a dedicated component for improved code organization.
  * Centralized story visual tone selection for consistent styling across components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1D1S/1D1S-client/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->