### PR TITLE
[ODS-202] feat: 애니메이션 끊김 및 이미지 페이드 개선

### DIFF
--- a/src/app.component/FadeInImage.tsx
+++ b/src/app.component/FadeInImage.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { cn } from '@module/utils/cn';
+import Image, { type ImageProps } from 'next/image';
+import React, { useCallback, useState } from 'react';
+
+/**
+ * next/image 래퍼. 이미지가 디코드되면 opacity 0 → 1 로 부드럽게 페이드인해
+ * 스켈레톤/placeholder 배경(bg-*) 위에서 이미지가 "툭" 튀어나오는 현상을
+ * 막는다. opacity 트랜지션만 사용하므로 GPU 합성으로 처리돼 끊김이 없다.
+ *
+ * Safari·캐시 대응: 캐시된 이미지는 React 가 onLoad 핸들러를 붙이기 전에
+ * 이미 디코드가 끝나 onLoad 이벤트가 오지 않을 수 있다. ref 콜백에서
+ * img.complete 를 확인해 opacity 0 에 영구히 갇히는 것을 방지한다.
+ */
+type FadeInImageProps = ImageProps;
+
+function FadeInImage({
+  alt,
+  className,
+  onLoad,
+  ...rest
+}: FadeInImageProps): React.ReactElement {
+  const [loaded, setLoaded] = useState(false);
+
+  const setRef = useCallback((node: HTMLImageElement | null) => {
+    if (node?.complete) {
+      setLoaded(true);
+    }
+  }, []);
+
+  return (
+    <Image
+      ref={setRef}
+      alt={alt}
+      className={cn(
+        'transition-opacity duration-700 ease-out',
+        'motion-reduce:transition-none',
+        loaded ? 'opacity-100' : 'opacity-0',
+        className
+      )}
+      onLoad={(event) => {
+        setLoaded(true);
+        onLoad?.(event);
+      }}
+      {...rest}
+    />
+  );
+}
+
+export default FadeInImage;

--- a/src/app.component/cards/ChallengeCard.tsx
+++ b/src/app.component/cards/ChallengeCard.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Card, CircleAvatar, Stripe } from '@1d1s/design-system';
+import FadeInImage from '@component/FadeInImage';
 import { cn } from '@module/utils/cn';
 import { createActivationKeydownHandler } from '@module/utils/event';
 import { CalendarDays, Target, Users } from 'lucide-react';
-import Image from 'next/image';
 import React, { useMemo } from 'react';
 
 export type ChallengeCardGoalType = 'FIXED' | 'FLEXIBLE';
@@ -156,7 +156,7 @@ function ChallengeCard({
       onClick={onClick}
       onKeyDown={handleKeyDown}
       className={cn(
-        'transition-all duration-300 ease-out',
+        'transition-all duration-500 ease-out',
         'hover:shadow-warm',
         isEnded && 'opacity-60',
         className
@@ -165,7 +165,7 @@ function ChallengeCard({
       <Card.Thumb className="px-3 pt-3">
         <div className="bg-main-100 relative aspect-[21/9] overflow-hidden rounded-lg">
           {imageUrl ? (
-            <Image
+            <FadeInImage
               src={imageUrl}
               alt={title}
               fill

--- a/src/app.component/cards/DiaryCard.tsx
+++ b/src/app.component/cards/DiaryCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Card, Icon, Stripe, Text } from '@1d1s/design-system';
+import FadeInImage from '@component/FadeInImage';
 import { ChallengeChip } from '@feature/challenge/shared/components/ChallengeChip';
 import { cn } from '@module/utils/cn';
 import { createActivationKeydownHandler } from '@module/utils/event';
@@ -85,14 +86,14 @@ function DiaryCard({
       onClick={onClick}
       onKeyDown={handleKeyDown}
       className={cn(
-        'transition-all duration-300 ease-out',
+        'transition-all duration-500 ease-out',
         'hover:shadow-warm',
         className
       )}
     >
       <Card.Thumb className="bg-main-100 aspect-[4/5]">
         {hasImage ? (
-          <Image
+          <FadeInImage
             src={imageUrl as string}
             alt={title}
             fill
@@ -152,7 +153,7 @@ function DiaryCard({
               aria-hidden
             >
               {hasProfileImage ? (
-                <Image
+                <FadeInImage
                   src={profileImageUrl as string}
                   alt=""
                   fill

--- a/src/app.feature/challenge/detail/components/ChallengeDetailHero.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDetailHero.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Stripe, Text } from '@1d1s/design-system';
+import FadeInImage from '@component/FadeInImage';
 import { cn } from '@module/utils/cn';
-import Image from 'next/image';
 import React from 'react';
 
 const PILL_CLASS = cn(
@@ -44,7 +44,7 @@ export function ChallengeDetailHero({
       style={{ background: gradient }}
     >
       {imageUrl ? (
-        <Image
+        <FadeInImage
           src={imageUrl}
           alt={title}
           fill

--- a/src/app.feature/challenge/shared/components/ChallengeListItem.tsx
+++ b/src/app.feature/challenge/shared/components/ChallengeListItem.tsx
@@ -7,9 +7,9 @@ import {
   type TagProps,
   Text,
 } from '@1d1s/design-system';
+import FadeInImage from '@component/FadeInImage';
 import { resolveDiaryImageUrl } from '@feature/diary/shared/utils/diaryImageUrl';
 import { createActivationKeydownHandler } from '@module/utils/event';
-import Image from 'next/image';
 
 export interface ChallengeListItemProps {
   challengeTitle: string;
@@ -97,7 +97,7 @@ export function ChallengeListItem({
         )}
       >
         {hasImage ? (
-          <Image
+          <FadeInImage
             src={resolvedImageUrl as string}
             alt={challengeTitle}
             fill

--- a/src/app.feature/diary/detail/components/DiaryHeroImage.tsx
+++ b/src/app.feature/diary/detail/components/DiaryHeroImage.tsx
@@ -1,5 +1,5 @@
+import FadeInImage from '@component/FadeInImage';
 import { cn } from '@module/utils/cn';
-import Image from 'next/image';
 import React from 'react';
 
 interface DiaryHeroImageProps {
@@ -22,7 +22,7 @@ export function DiaryHeroImage({
         'overflow-hidden rounded-2xl border border-gray-200 bg-gray-100'
       )}
     >
-      <Image
+      <FadeInImage
         src={imageUrl}
         alt={title}
         fill
@@ -63,7 +63,7 @@ export function DiaryImageLightbox({
         >
           ✕
         </button>
-        <Image
+        <FadeInImage
           src={imageUrl}
           alt="일지 이미지 원본"
           width={0}

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -738,7 +738,7 @@ function DiaryDetailView({
   return (
     <div
       className={cn(
-        'data-fade-in min-h-screen w-full bg-white',
+        'detail-fade-in min-h-screen w-full bg-white',
         'pb-mobile-action-bar-tall lg:pb-0'
       )}
     >

--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { Card, Icon, Stripe, Text } from '@1d1s/design-system';
+import FadeInImage from '@component/FadeInImage';
 import { resolveDiaryImageUrl } from '@feature/diary/shared/utils/diaryImageUrl';
 import { cn } from '@module/utils/cn';
-import Image from 'next/image';
 import React from 'react';
 
 import { StoryGroup } from '../type/story';
@@ -60,7 +60,7 @@ export default function StoryRing({
           onClick={onAddStory}
           aria-label="내 일지 추가"
           className={cn(
-            'flex-shrink-0 transition-all duration-300 ease-out',
+            'flex-shrink-0 transition-all duration-500 ease-out',
             'hover:shadow-warm',
             cardWidthClass
           )}
@@ -99,7 +99,7 @@ export default function StoryRing({
                   aria-hidden
                 >
                   {hasMyImage ? (
-                    <Image
+                    <FadeInImage
                       src={myImageUrl as string}
                       alt=""
                       fill
@@ -144,14 +144,14 @@ export default function StoryRing({
             onClick={() => onSelect(index)}
             aria-label={`${name} 스토리 열기`}
             className={cn(
-              'flex-shrink-0 transition-all duration-300 ease-out',
+              'flex-shrink-0 transition-all duration-500 ease-out',
               'hover:shadow-warm',
               cardWidthClass
             )}
           >
             <Card.Thumb className="bg-main-100 aspect-[4/5]">
               {hasThumbnail ? (
-                <Image
+                <FadeInImage
                   src={thumbnailUrl as string}
                   alt={title}
                   fill
@@ -196,7 +196,7 @@ export default function StoryRing({
                     aria-hidden
                   >
                     {hasProfile ? (
-                      <Image
+                      <FadeInImage
                         src={profileUrl as string}
                         alt=""
                         fill

--- a/src/app.feature/stories/components/StoryViewer.tsx
+++ b/src/app.feature/stories/components/StoryViewer.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { CircleAvatar, Icon, Stripe, Text } from '@1d1s/design-system';
+import FadeInImage from '@component/FadeInImage';
 import { resolveDiaryImageUrl } from '@feature/diary/shared/utils/diaryImageUrl';
 import { cn } from '@module/utils/cn';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -134,8 +134,8 @@ export default function StoryViewer({
       aria-modal="true"
       onClick={handleBackdropClick}
       className={cn(
-        'fixed inset-0 z-1000 flex items-center justify-center',
-        'bg-black/60 px-4 py-6 backdrop-blur-sm'
+        'animate-story-overlay-in fixed inset-0 z-1000 flex',
+        'items-center justify-center bg-black/60 px-4 py-6 backdrop-blur-sm'
       )}
     >
       <button
@@ -165,13 +165,14 @@ export default function StoryViewer({
 
       <div
         className={cn(
-          'rounded-4 relative w-full max-w-[420px] overflow-hidden bg-white',
-          'shadow-2xl'
+          'animate-story-card-in rounded-4 relative w-full max-w-[420px]',
+          'overflow-hidden bg-white shadow-2xl'
         )}
       >
         <div className="relative aspect-4/5 w-full overflow-hidden bg-gray-100">
           {thumbnailUrl ? (
-            <Image
+            <FadeInImage
+              key={`${groupIndex}-${diaryIndex}`}
               src={thumbnailUrl}
               alt={story.diaryTitle}
               fill
@@ -189,7 +190,7 @@ export default function StoryViewer({
                 <div
                   key={index}
                   className={cn(
-                    'h-1 flex-1 rounded-full',
+                    'h-1 flex-1 rounded-full transition-colors duration-300',
                     index === diaryIndex ? 'bg-white' : 'bg-white/40'
                   )}
                 />

--- a/src/app.styles/animation.css
+++ b/src/app.styles/animation.css
@@ -50,7 +50,7 @@
 }
 
 .data-fade-in {
-  animation: contentFadeIn 360ms cubic-bezier(0.2, 0, 0, 1) both;
+  animation: contentFadeIn 500ms cubic-bezier(0.2, 0, 0, 1) both;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -59,16 +59,45 @@
   }
 }
 
-/* CTA 버튼 attention pulse — 부드러운 스케일 + 링이 퍼지는 듯한 그림자.
-   "오늘 기록 +" 같은 핵심 CTA에 적용해 사용자의 시선을 끈다. */
+/* 일지 상세 전용 등장 — 일반 data-fade-in 보다 더 길고 부드럽게,
+   투명도 0 에서 시작해 초기 "팝" 없이 완전히 페이드된다.
+   slide-up(translateY) 은 쓰지 않는다: 상세 래퍼 안에 모바일 sticky
+   헤더가 있어 ancestor 에 transform 이 걸리면 sticky 가 깨진다.
+   그래서 opacity 만으로 부드러움을 낸다. */
+@keyframes detailFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.detail-fade-in {
+  animation: detailFadeIn 650ms cubic-bezier(0.2, 0, 0, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .detail-fade-in {
+    animation: none;
+  }
+}
+
+/* CTA 버튼 attention pulse — 부드러운 스케일 + 사방으로 균일하게 퍼지는 링.
+   "오늘 기록 +" 같은 핵심 CTA에 적용해 사용자의 시선을 끈다.
+
+   링은 box-shadow spread 로 그린다. transform: scale 로 링을 만들면 버튼이
+   가로로 긴 pill 모양이라 긴 축으로 더 늘어나 모양이 어긋나 보인다.
+   box-shadow spread 는 사방에 같은 두께로 퍼져 자연스럽다. 단일 CTA 한
+   곳에만 쓰여 리페인트 비용은 무시할 수준이다. */
 @keyframes ctaPulse {
   0% {
     transform: scale(1);
-    box-shadow: 0 0 0 0 rgba(255, 107, 74, 0.55);
+    box-shadow: 0 0 0 0 rgba(255, 107, 74, 0.5);
   }
-  60% {
+  70% {
     transform: scale(1.04);
-    box-shadow: 0 0 0 10px rgba(255, 107, 74, 0);
+    box-shadow: 0 0 0 12px rgba(255, 107, 74, 0);
   }
   100% {
     transform: scale(1);
@@ -77,7 +106,7 @@
 }
 
 .animate-cta-pulse {
-  animation: ctaPulse 1.8s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  animation: ctaPulse 2.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
 
 .animate-cta-pulse:hover,
@@ -87,6 +116,80 @@
 
 @media (prefers-reduced-motion: reduce) {
   .animate-cta-pulse {
+    animation: none;
+  }
+}
+
+/* 불꽃 아이콘 깜빡임 — DS 의 flame-flicker 키프레임은 매 프레임
+   filter: hue-rotate() 를 적용해 합성이 깨지고 리페인트가 발생한다.
+   홈/마이페이지/우측 레일에 여러 개가 동시에 돌기 때문에 비용이
+   누적돼 전반적인 렉의 주요 원인이었다. transform 만 쓰도록 키프레임을
+   재정의하고(색 변화 효과 제거) 레이어로 승격해 GPU 합성으로 처리한다.
+   (로컬 animation.css 는 DS globals 이후에 import 되므로 동일 이름의
+   @keyframes 가 DS 정의를 덮어쓴다.) */
+@keyframes flame-flicker {
+  0%,
+  100% {
+    transform: scale(1) rotate(-2deg);
+  }
+  25% {
+    transform: scale(1.05) rotate(2deg);
+  }
+  50% {
+    transform: scale(0.98) rotate(-1deg);
+  }
+  75% {
+    transform: scale(1.03) rotate(1deg);
+  }
+}
+
+.animate-flame-flicker {
+  will-change: transform;
+  /* DS 기본 1.8s 보다 느리게 돌려 더 부드럽게(animation 단축속성 뒤에
+     선언된 longhand 가 duration 만 덮어쓴다). */
+  animation-duration: 2.4s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-flame-flicker {
+    animation: none;
+  }
+}
+
+/* 스토리 뷰어 등장 — 배경은 페이드, 카드는 살짝 확대되며 부드럽게 올라온다.
+   모달이 "툭" 나타나는 대신 자연스럽게 등장한다. opacity/transform 만
+   쓰므로 GPU 합성으로 처리된다. */
+@keyframes storyOverlayIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes storyCardIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.animate-story-overlay-in {
+  animation: storyOverlayIn 320ms ease-out both;
+}
+
+.animate-story-card-in {
+  animation: storyCardIn 420ms cubic-bezier(0.2, 0, 0, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-story-overlay-in,
+  .animate-story-card-in {
     animation: none;
   }
 }

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -120,7 +120,7 @@
 
 /* fallback: grid 유틸리티가 기본 2열을 보장 */
 .diary-card-grid {
-  transition: grid-template-columns 300ms ease-in-out;
+  transition: grid-template-columns 400ms ease-in-out;
 }
 
 @supports (container-type: inline-size) {
@@ -153,7 +153,7 @@
 }
 
 .challenge-card-grid {
-  transition: grid-template-columns 280ms ease-in-out;
+  transition: grid-template-columns 380ms ease-in-out;
 }
 
 @supports (container-type: inline-size) {


### PR DESCRIPTION
## 📌 Summary

Safari/크롬에서 끊기던 애니메이션과 "툭" 등장하던 이미지를 부드럽게 개선합니다.

## ✅ 작업 내용

- **이미지 pop-in 제거**: `FadeInImage` 신설(opacity 페이드인 + Safari 캐시 `img.complete` 대응). 일지/챌린지 카드·스토리·상세 히어로·리스트 썸네일 등 콘텐츠 이미지에 적용
- **렉 주원인 제거**: `flame-flicker`가 매 프레임 적용하던 `filter: hue-rotate()` 제거(transform만 사용, GPU 합성). 홈/마이페이지/우측 레일에 동시 다발로 돌며 비용이 누적되던 부분
- **전환 부드럽게**: 카드 hover(300→500ms), 이미지 페이드(700ms), 콘텐츠 등장(`data-fade-in` 360→500ms), 그리드 컬럼 전환 등 지속시간 상향. 불꽃/CTA 펄스 루프 속도 완화(1.8→2.2~2.4s)
- **스토리 뷰어**: 모달 등장 애니메이션(배경 페이드 + 카드 scale-in), 스토리 넘김 시 이미지 페이드, 진행 바 transition 추가
- **일지 상세**: 전용 `detail-fade-in`(650ms, opacity 0→1)으로 분리해 더 길고 부드럽게

## 📎 기타

- 모든 신규 애니메이션 `prefers-reduced-motion` 대응
- 정적 검증(`pnpm lint`, `pnpm tsc --noEmit`)만 수행 — 실제 브라우저 동작은 미확인(프로젝트 정책)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smooth fade-in animations for images loading across the app for enhanced visual polish.
  * New entrance animations for story viewing and diary detail pages for improved user experience.

* **Style**
  * Updated transition timing across interactive elements for smoother, more consistent animations.
  * Enhanced animation accessibility by respecting user's reduced-motion preferences system-wide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->