### PR TITLE
[ODS-214] 일지 관련 안정성 개선 리팩토링

### DIFF
--- a/src/app.feature/diary/board/consts/queryKeys.ts
+++ b/src/app.feature/diary/board/consts/queryKeys.ts
@@ -18,13 +18,27 @@ export const DIARY_QUERY_KEYS = {
     [...DIARY_QUERY_KEYS.my(), 'infinite', params] as const,
   comments: () => [...DIARY_QUERY_KEYS.all, 'comments'] as const,
   diaryComments: (diaryId: number, params?: { page?: number; size?: number }) =>
-    [...DIARY_QUERY_KEYS.comments(), 'diary', diaryId, params] as const,
+    [
+      ...DIARY_QUERY_KEYS.comments(),
+      'diary',
+      diaryId,
+      ...(params ? [params] : []),
+    ] as const,
   commentReplies: () => [...DIARY_QUERY_KEYS.comments(), 'replies'] as const,
   replies: (commentId: number, params?: { page?: number; size?: number }) =>
-    [...DIARY_QUERY_KEYS.commentReplies(), commentId, params] as const,
+    [
+      ...DIARY_QUERY_KEYS.commentReplies(),
+      commentId,
+      ...(params ? [params] : []),
+    ] as const,
   repliesMap: (
     commentIds: number[],
     params?: { page?: number; size?: number }
   ) =>
-    [...DIARY_QUERY_KEYS.commentReplies(), 'map', commentIds, params] as const,
+    [
+      ...DIARY_QUERY_KEYS.commentReplies(),
+      'map',
+      commentIds,
+      ...(params ? [params] : []),
+    ] as const,
 };

--- a/src/app.feature/diary/board/screen/DiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/DiaryListScreen.tsx
@@ -129,18 +129,17 @@ export default function DiaryListScreen(): React.ReactElement {
   const isLoginRequired = searchParams.get('loginRequired') === 'true';
   const isLoggedIn = useIsLoggedIn();
   const [sortMode] = useState<SortMode>('latest');
-  const [showLoginDialog, setShowLoginDialog] = useState(false);
-  const [loginDialogDescription, setLoginDialogDescription] =
-    useState('로그인 후 이용할 수 있습니다.');
-
-  const [prevIsLoginRequired, setPrevIsLoginRequired] = useState(false);
-  if (isLoginRequired !== prevIsLoginRequired) {
-    setPrevIsLoginRequired(isLoginRequired);
-    if (isLoginRequired && !isLoggedIn) {
-      setShowLoginDialog(true);
-      setLoginDialogDescription('일지 상세는 로그인 후 이용할 수 있습니다.');
-    }
-  }
+  // isLoginRequired는 URL 파라미터로 첫 렌더에만 true가 되고 즉시 삭제된다.
+  // initializer로 초기값만 반영하면 충분하다.
+  const [showLoginDialog, setShowLoginDialog] = useState(
+    () => isLoginRequired && !isLoggedIn
+  );
+  const [loginDialogDescription, setLoginDialogDescription] = useState(
+    () =>
+      isLoginRequired && !isLoggedIn
+        ? '일지 상세는 로그인 후 이용할 수 있습니다.'
+        : '로그인 후 이용할 수 있습니다.'
+  );
 
   useEffect(() => {
     if (!isLoginRequired) {

--- a/src/app.feature/diary/board/screen/MemberDiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/MemberDiaryListScreen.tsx
@@ -23,9 +23,64 @@ import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 const MEMBER_DIARY_PAGE_SIZE = 12;
+
+interface MemberDiaryListItemProps {
+  item: DiaryItem;
+  onCardClick(id: number): void;
+  onLikeToggle(diary: DiaryItem): void;
+}
+
+// React.memo로 감싸 부모 재렌더 시 동일 item 카드는 재렌더를 건너뛴다.
+// 부모는 onCardClick / onLikeToggle을 useCallback으로 안정화해야 한다.
+const MemberDiaryListItem = React.memo(
+  ({
+    item,
+    onCardClick,
+    onLikeToggle,
+  }: MemberDiaryListItemProps): React.ReactElement => {
+    const handleClick = useCallback(() => {
+      onCardClick(item.id);
+    }, [onCardClick, item.id]);
+
+    const handleLike = useCallback(() => {
+      onLikeToggle(item);
+    }, [onLikeToggle, item]);
+
+    const achievementRate = Math.min(
+      100,
+      Math.max(
+        0,
+        item.achievementRate ?? item.diaryInfoDto?.achievementRate ?? 0
+      )
+    );
+
+    return (
+      <DiaryCard
+        imageUrl={resolveDiaryImageList(item.imgUrl)?.[0]}
+        profileImageUrl={
+          resolveDiaryImageUrl(item.authorInfoDto?.profileImage) ?? undefined
+        }
+        percent={achievementRate}
+        isLiked={item.likeInfo.likedByMe}
+        likes={item.likeInfo.likeCnt}
+        title={item.title}
+        user={item.authorInfoDto?.nickname ?? '익명'}
+        challengeLabel={
+          item.challenge?.title ||
+          getCategoryLabel(item.challenge?.category) ||
+          '일지'
+        }
+        emotion={mapFeelingToEmotion(item.diaryInfoDto?.feeling ?? 'NONE')}
+        onLikeToggle={handleLike}
+        onClick={handleClick}
+      />
+    );
+  }
+);
+MemberDiaryListItem.displayName = 'MemberDiaryListItem';
 
 interface MemberDiaryListScreenProps {
   memberId: string;
@@ -69,20 +124,30 @@ export function MemberDiaryListScreen({
   const hasDiaries = diaryItems.length > 0;
   const isLikePending = likeDiary.isPending || unlikeDiary.isPending;
 
-  const handleLikeToggle = (diary: DiaryItem): void => {
-    if (!isLoggedIn) {
-      setShowLoginDialog(true);
-      return;
-    }
-    if (isLikePending) {
-      return;
-    }
-    if (diary.likeInfo.likedByMe) {
-      unlikeDiary.mutate(diary.id);
-    } else {
-      likeDiary.mutate(diary.id);
-    }
-  };
+  const handleCardClick = useCallback(
+    (id: number): void => {
+      router.push(`/diary/${id}`);
+    },
+    [router]
+  );
+
+  const handleLikeToggle = useCallback(
+    (diary: DiaryItem): void => {
+      if (!isLoggedIn) {
+        setShowLoginDialog(true);
+        return;
+      }
+      if (isLikePending) {
+        return;
+      }
+      if (diary.likeInfo.likedByMe) {
+        unlikeDiary.mutate(diary.id);
+      } else {
+        likeDiary.mutate(diary.id);
+      }
+    },
+    [isLoggedIn, isLikePending, likeDiary, unlikeDiary]
+  );
 
   return (
     <div className="min-h-screen w-full">
@@ -171,36 +236,11 @@ export function MemberDiaryListScreen({
             )}
           >
             {diaryItems.map((diary) => (
-              <DiaryCard
+              <MemberDiaryListItem
                 key={diary.id}
-                imageUrl={resolveDiaryImageList(diary.imgUrl)?.[0]}
-                profileImageUrl={
-                  resolveDiaryImageUrl(diary.authorInfoDto?.profileImage) ??
-                  undefined
-                }
-                percent={Math.min(
-                  100,
-                  Math.max(
-                    0,
-                    diary.achievementRate ??
-                      diary.diaryInfoDto?.achievementRate ??
-                      0
-                  )
-                )}
-                isLiked={diary.likeInfo.likedByMe}
-                likes={diary.likeInfo.likeCnt}
-                title={diary.title}
-                user={diary.authorInfoDto?.nickname ?? '익명'}
-                challengeLabel={
-                  diary.challenge?.title ||
-                  getCategoryLabel(diary.challenge?.category) ||
-                  '일지'
-                }
-                emotion={mapFeelingToEmotion(
-                  diary.diaryInfoDto?.feeling ?? 'NONE'
-                )}
-                onLikeToggle={() => handleLikeToggle(diary)}
-                onClick={() => router.push(`/diary/${diary.id}`)}
+                item={diary}
+                onCardClick={handleCardClick}
+                onLikeToggle={handleLikeToggle}
               />
             ))}
           </div>

--- a/src/app.feature/diary/board/screen/MyDiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/MyDiaryListScreen.tsx
@@ -17,12 +17,56 @@ import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
-import { buildDiaryCardViewModels } from '../../../member/mypage/utils/mypageUtils';
+import {
+  buildDiaryCardViewModels,
+  DiaryCardViewModel,
+} from '../../../member/mypage/utils/mypageUtils';
 import { useMyDiariesInfinite } from '../hooks/useDiaryQueries';
 
 const MY_DIARY_PAGE_SIZE = 12;
+
+interface MyDiaryListItemProps {
+  item: DiaryCardViewModel;
+  onCardClick(id: number): void;
+  onLikeToggle(id: number, isLiked: boolean): void;
+}
+
+// React.memo로 감싸 부모 재렌더 시 동일 item 카드는 재렌더를 건너뛴다.
+// 부모는 onCardClick / onLikeToggle을 useCallback으로 안정화해야 한다.
+const MyDiaryListItem = React.memo(
+  ({
+    item,
+    onCardClick,
+    onLikeToggle,
+  }: MyDiaryListItemProps): React.ReactElement => {
+    const handleClick = useCallback(() => {
+      onCardClick(item.id);
+    }, [onCardClick, item.id]);
+
+    const handleLike = useCallback(() => {
+      onLikeToggle(item.id, item.isLiked);
+    }, [onLikeToggle, item.id, item.isLiked]);
+
+    return (
+      <DiaryCard
+        imageUrl={item.imageUrl}
+        profileImageUrl={item.profileImageUrl}
+        percent={item.percent}
+        isLiked={item.isLiked}
+        likes={item.likes}
+        title={item.title}
+        user={item.user}
+        challengeLabel={item.challengeLabel}
+        emotion={item.emotion}
+        onClick={handleClick}
+        onLikeToggle={handleLike}
+      />
+    );
+  }
+);
+MyDiaryListItem.displayName = 'MyDiaryListItem';
 
 export function MyDiaryListScreen(): React.ReactElement {
   const router = useRouter();
@@ -65,20 +109,30 @@ export function MyDiaryListScreen(): React.ReactElement {
   const hasDiaries = diaryCards.length > 0;
   const isLikePending = likeDiary.isPending || unlikeDiary.isPending;
 
-  const handleLikeToggle = (id: number, isLiked: boolean): void => {
-    if (!isLoggedIn) {
-      setShowLoginDialog(true);
-      return;
-    }
-    if (isLikePending) {
-      return;
-    }
-    if (isLiked) {
-      unlikeDiary.mutate(id);
-    } else {
-      likeDiary.mutate(id);
-    }
-  };
+  const handleCardClick = useCallback(
+    (id: number): void => {
+      router.push(`/diary/${id}`);
+    },
+    [router]
+  );
+
+  const handleLikeToggle = useCallback(
+    (id: number, isLiked: boolean): void => {
+      if (!isLoggedIn) {
+        setShowLoginDialog(true);
+        return;
+      }
+      if (isLikePending) {
+        return;
+      }
+      if (isLiked) {
+        unlikeDiary.mutate(id);
+      } else {
+        likeDiary.mutate(id);
+      }
+    },
+    [isLoggedIn, isLikePending, likeDiary, unlikeDiary]
+  );
 
   return (
     <div className="min-h-screen w-full">
@@ -164,19 +218,11 @@ export function MyDiaryListScreen(): React.ReactElement {
             )}
           >
             {diaryCards.map((diary) => (
-              <DiaryCard
+              <MyDiaryListItem
                 key={diary.id}
-                imageUrl={diary.imageUrl}
-                profileImageUrl={diary.profileImageUrl}
-                percent={diary.percent}
-                isLiked={diary.isLiked}
-                likes={diary.likes}
-                title={diary.title}
-                user={diary.user}
-                challengeLabel={diary.challengeLabel}
-                emotion={diary.emotion}
-                onClick={() => router.push(`/diary/${diary.id}`)}
-                onLikeToggle={() => handleLikeToggle(diary.id, diary.isLiked)}
+                item={diary}
+                onCardClick={handleCardClick}
+                onLikeToggle={handleLikeToggle}
               />
             ))}
           </div>

--- a/src/app.feature/diary/detail/hooks/useDiaryMutations.ts
+++ b/src/app.feature/diary/detail/hooks/useDiaryMutations.ts
@@ -95,9 +95,7 @@ export function useLikeDiary(): UseMutationResult<number, Error, number> {
         DIARY_QUERY_KEYS.detail(id),
         DIARY_QUERY_KEYS.lists(),
         DIARY_QUERY_KEYS.randoms(),
-        DIARY_QUERY_KEYS.allDiaries(),
         CHALLENGE_QUERY_KEYS.challengeDiaries(),
-        MEMBER_QUERY_KEYS.profiles(),
         DIARY_QUERY_KEYS.my(),
       ]);
     },
@@ -115,9 +113,7 @@ export function useUnlikeDiary(): UseMutationResult<number, Error, number> {
         DIARY_QUERY_KEYS.detail(id),
         DIARY_QUERY_KEYS.lists(),
         DIARY_QUERY_KEYS.randoms(),
-        DIARY_QUERY_KEYS.allDiaries(),
         CHALLENGE_QUERY_KEYS.challengeDiaries(),
-        MEMBER_QUERY_KEYS.profiles(),
         DIARY_QUERY_KEYS.my(),
       ]);
     },

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -253,6 +253,7 @@ function DiaryCommentSection({
   const deleteComment = useDeleteComment(diaryId);
   const isCommentPending =
     createComment.isPending || createReply.isPending || deleteComment.isPending;
+  const isCommentSubmittingRef = useRef(false);
 
   const mapCommentNode = useCallback(
     (comment: DiaryComment): CommentNode => {
@@ -421,15 +422,19 @@ function DiaryCommentSection({
 
   const handleCreateComment = (): void => {
     const content = commentContent.trim();
-    if (!content || isCommentPending) {
+    if (!content || isCommentPending || isCommentSubmittingRef.current) {
       return;
     }
 
     requireAuthAction(() => {
+      isCommentSubmittingRef.current = true;
       createComment.mutate(
         { content },
         {
           onSuccess: () => setCommentContent(''),
+          onSettled: () => {
+            isCommentSubmittingRef.current = false;
+          },
         }
       );
     });
@@ -594,18 +599,25 @@ function DiaryMobileCommentBar({
   const [content, setContent] = useState('');
   const createComment = useCreateDiaryComment(diaryId);
   const disabled = createComment.isPending || !content.trim();
+  const isSubmittingRef = useRef(false);
 
   const handleSubmit = (): void => {
     if (!isLoggedIn) {
       onRequireLogin();
       return;
     }
-    if (disabled) {
+    if (disabled || isSubmittingRef.current) {
       return;
     }
+    isSubmittingRef.current = true;
     createComment.mutate(
       { content: content.trim() },
-      { onSuccess: () => setContent('') }
+      {
+        onSuccess: () => setContent(''),
+        onSettled: () => {
+          isSubmittingRef.current = false;
+        },
+      }
     );
   };
 

--- a/src/app.feature/diary/write/hooks/useDiaryCreateForm.ts
+++ b/src/app.feature/diary/write/hooks/useDiaryCreateForm.ts
@@ -297,20 +297,19 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
         ? parsedDate
         : new Date();
     const nextThumbnailPreviewUrl = getDiaryThumbnailPreviewUrl(existingDiary);
-
     const timerId = window.setTimeout(() => {
       setTitle(existingDiary.title ?? '');
       setContent(existingDiary.content ?? '');
       setSelectedMood(diaryInfo?.feeling ?? 'NORMAL');
       setAchievedDate(nextAchievedDate);
       setSelectedChallengeId(existingDiary.challenge?.challengeId ?? null);
-      const achievedGoalIds =
+      const nextAchievedGoalIds =
         diaryInfo?.diaryGoal
           ?.filter((goal) => goal.isAchieved)
           ?.map((goal) => goal.challengeGoalId) ??
         diaryInfo?.achievement ??
         [];
-      setAchievedGoalIds(achievedGoalIds);
+      setAchievedGoalIds(nextAchievedGoalIds);
       setThumbnailPreviewUrl(nextThumbnailPreviewUrl);
       setIsEditFormInitialized(true);
     }, 0);


### PR DESCRIPTION
## 📌 Summary

<!-- 간단한 설명 -->

일지 안정성을 개선할 수 있는 사항을 찾아 리팩토링했습니다.

## ✅ 작업 내용

- DiaryListScreen: loginRequired URL 파라미터 처리를 state-in-render 패턴에서 useState initializer로 교체
- MyDiaryListScreen: DiaryCard를 React.memo 래퍼(MyDiaryListItem) + useCallback 핸들러로 감싸 memo 실효화 방지
- MemberDiaryListScreen: 동일하게 React.memo 래퍼(MemberDiaryListItem) + useCallback 핸들러 적용
- useDiaryMutations: useLikeDiary / useUnlikeDiary에서 불필요한 allDiaries, profiles 쿼리 무효화 제거
- useDiaryCreateForm: edit mode 초기화 effect 내 변수 섀도잉(achievedGoalIds) 제거
- DIARY_QUERY_KEYS: diaryComments / replies / repliesMap 키에서 params undefined 트레일링 제거

## 📎 기타

- 코드 리뷰가 필요할거 같은 경우에는 별도로 남겨두겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate diary comments from being submitted during rapid successive attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->