### PR TITLE
[ODS-218] fix: refetch할 때 변경 안되는 이슈 해결

### DIFF
--- a/src/app.feature/diary/detail/hooks/useDiaryMutations.ts
+++ b/src/app.feature/diary/detail/hooks/useDiaryMutations.ts
@@ -72,10 +72,11 @@ export function useDeleteDiary(): UseMutationResult<boolean, Error, number> {
   return useMutation({
     mutationFn: (id: number) => diaryDetailApi.deleteDiary(id),
     onSuccess: () => {
+      // 목록 캐시는 즉시 제거해 삭제된 일지가 잠깐 보이는 현상을 방지한다.
+      queryClient.removeQueries({ queryKey: DIARY_QUERY_KEYS.lists() });
+      queryClient.removeQueries({ queryKey: DIARY_QUERY_KEYS.allDiaries() });
       invalidateAll(queryClient, [
-        DIARY_QUERY_KEYS.lists(),
         DIARY_QUERY_KEYS.randoms(),
-        DIARY_QUERY_KEYS.allDiaries(),
         CHALLENGE_QUERY_KEYS.challengeDiaries(),
         MEMBER_QUERY_KEYS.myPage(),
         MEMBER_QUERY_KEYS.sidebar(),

--- a/src/app.feature/member/hooks/useMemberQueries.ts
+++ b/src/app.feature/member/hooks/useMemberQueries.ts
@@ -93,6 +93,7 @@ export function useSidebar(): UseQueryResult<SidebarData | null, Error> {
     enabled: !isServer && authStorage.hasTokens(),
     staleTime: MEMBER_INFO_STALE_TIME,
     gcTime: MEMBER_INFO_GC_TIME,
+    refetchOnMount: true,
   });
 }
 
@@ -133,5 +134,6 @@ export function useMyPage(): UseQueryResult<MyPageData, Error> {
     enabled: isLoggedIn,
     staleTime: MEMBER_INFO_STALE_TIME,
     gcTime: MEMBER_INFO_GC_TIME,
+    refetchOnMount: true,
   });
 }


### PR DESCRIPTION
## 📌 Summary

<!-- 간단한 설명 -->

- diary 관련 refetch 문제를 해결했습니다.

## ✅ 작업 내용

- `useMyPage`, `useSidebar`에 `refetchOnMount: true` 추가
  (`staleTime: Infinity`와 조합 시 명시적 invalidation 후 마운트 시에만 refetch)
- `useDeleteDiary.onSuccess`에서 일지 목록 캐시를 `invalidateQueries` 대신
  `removeQueries`로 즉시 제거해 삭제된 일지 노출 방지

## 📎 기타

- X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diary entry deletion to prevent deleted items from briefly reappearing in lists

* **Improvements**
  * Optimized data refresh behavior on member profile and sidebar pages for more consistent information display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->