### PR TITLE
[ODS-222] fix: QA 보고 버그 6건 수정 (로그인·코드블록·알림·스토리·AUTH-006)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -68,15 +68,12 @@ self.addEventListener('notificationclick', (event) => {
     clients
       .matchAll({ type: 'window', includeUncontrolled: true })
       .then((windowClients) => {
-        // 이미 열린 탭이 있으면 해당 경로로 이동시킨 뒤 포커스한다.
+        // 이미 열린 탭이 있으면, 클라이언트가 Next 라우터로 push 하도록
+        // 메시지를 보낸 뒤 포커스한다. client.navigate() 는 현재 history
+        // 항목을 "교체"해 뒤로가기가 동작하지 않으므로 사용하지 않는다.
         for (const client of windowClients) {
           if ('focus' in client) {
-            if ('navigate' in client) {
-              return client
-                .navigate(url)
-                .then((navigated) => (navigated || client).focus())
-                .catch(() => client.focus());
-            }
+            client.postMessage({ type: 'NOTIFICATION_NAVIGATE', url });
             return client.focus();
           }
         }

--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -4,6 +4,7 @@ import { Button } from '@1d1s/design-system';
 import { AddToHomeScreenPrompt } from '@feature/install/components/AddToHomeScreenPrompt';
 import { BrowserPermissionPrompt } from '@feature/notification/components/BrowserPermissionPrompt';
 import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
+import { useServiceWorkerNavigation } from '@module/hooks/useServiceWorkerNavigation';
 import { useTokenRefreshOnResume } from '@module/hooks/useTokenRefreshOnResume';
 import { cn } from '@module/utils/cn';
 import { ArrowLeft } from 'lucide-react';
@@ -142,6 +143,8 @@ export default function AppLayoutShell({
   }, [isNativeApp]);
 
   useTokenRefreshOnResume();
+  // 알림 클릭 시 서비스워커가 보낸 딥링크를 라우터 push 로 처리(뒤로가기 보존).
+  useServiceWorkerNavigation();
 
   // 인증/사이드바 상태는 별도 hook 으로 묶었다. shell 은 라우트 가시성 판단과
   // 핸들러 안정화에만 집중한다.

--- a/src/app.component/layout/useAuthLayoutState.ts
+++ b/src/app.component/layout/useAuthLayoutState.ts
@@ -116,11 +116,8 @@ export function useAuthLayoutState(): AuthLayoutState {
   // (데이터 페칭은 그대로 TanStack Query 가 담당한다.)
   const [, revalidateAuth] = useReducer((count: number) => count + 1, 0);
   useEffect(() => {
-    if (authStorage.hasTokens()) {
-      return;
-    }
     let attempts = 0;
-    let timer: ReturnType<typeof setTimeout>;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const recheck = (): void => {
       attempts += 1;
       if (authStorage.hasTokens()) {
@@ -131,8 +128,38 @@ export function useAuthLayoutState(): AuthLayoutState {
         timer = setTimeout(recheck, 150);
       }
     };
-    timer = setTimeout(recheck, 150);
-    return () => clearTimeout(timer);
+    if (!authStorage.hasTokens()) {
+      timer = setTimeout(recheck, 150);
+    }
+
+    // 재접속(PWA 백그라운드 복귀 / BFCache 복원 / 탭 재포커스) 시 토큰 힌트를
+    // 다시 평가한다. 레이아웃은 soft navigation 으로 재마운트되지 않으므로 이
+    // 이벤트가 없으면, 최초 폴링이 끝난 뒤 게스트 오인이 새로고침 전까지
+    // 고착된다(= "다시 접속하면 로그아웃처럼 보이는" 문제). hasTokens() 가
+    // 다시 true 로 보이면 re-render 를 유발해 useSidebar 의 enabled(=hasTokens)
+    // 를 재평가시켜 비활성 상태의 쿼리를 되살린다.
+    const revalidateIfAuthed = (): void => {
+      if (authStorage.hasTokens()) {
+        revalidateAuth();
+      }
+    };
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState === 'visible') {
+        revalidateIfAuthed();
+      }
+    };
+    window.addEventListener('focus', revalidateIfAuthed);
+    window.addEventListener('pageshow', revalidateIfAuthed);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      window.removeEventListener('focus', revalidateIfAuthed);
+      window.removeEventListener('pageshow', revalidateIfAuthed);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   }, []);
 
   const hasTokenHint = hasMounted && authStorage.hasTokens();

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -28,6 +28,7 @@ import {
 } from '@feature/diary/detail/hooks/useDiaryMutations';
 import { normalizeApiError } from '@module/api/error';
 import { notifyApiError } from '@module/api/errorNotify';
+import { useSafeBack } from '@module/hooks/useSafeBack';
 import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import { ArrowLeft, CircleAlert, Heart, Trash2 } from 'lucide-react';
@@ -86,6 +87,8 @@ export function ChallengeDetailScreen({
 }: ChallengeDetailScreenProps): React.ReactElement {
   const challengeId = Number(id);
   const router = useRouter();
+  // 알림 딥링크/콜드 스타트로 진입해 history 가 없을 때 챌린지 목록으로 보낸다.
+  const handleBack = useSafeBack('/challenge');
 
   const { data, isLoading, isError, error } = useChallengeDetail(challengeId);
   const showSkeleton = useMinimumLoading(isLoading);
@@ -733,7 +736,7 @@ export function ChallengeDetailScreen({
         <button
           type="button"
           aria-label="뒤로가기"
-          onClick={() => router.back()}
+          onClick={handleBack}
           className={cn(
             'flex h-8 w-8 shrink-0 items-center justify-center',
             'rounded-lg text-gray-700 transition-colors hover:bg-gray-100'
@@ -786,7 +789,7 @@ export function ChallengeDetailScreen({
           <button
             type="button"
             aria-label="뒤로가기"
-            onClick={() => router.back()}
+            onClick={handleBack}
             data-native-hide
             className={cn(
               'absolute left-3.5 z-10 flex h-9 w-9',

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -12,6 +12,7 @@ import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import { DiaryCommentsSkeleton } from '@component/skeletons/DiaryCommentsSkeleton';
 import { DiaryDetailSkeleton } from '@component/skeletons/DiaryDetailSkeleton';
 import { normalizeApiError } from '@module/api/error';
+import { useSafeBack } from '@module/hooks/useSafeBack';
 import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import {
@@ -669,6 +670,8 @@ function DiaryDetailView({
   onRequireLogin(): void;
 }): React.ReactElement {
   const router = useRouter();
+  // 알림 딥링크/콜드 스타트로 진입해 history 가 없을 때 일지 목록으로 보낸다.
+  const handleBack = useSafeBack('/diary');
   const { data: sidebarData } = useSidebar();
   const isLoggedIn = useIsLoggedIn();
   const currentMemberId = useMemo(
@@ -766,7 +769,7 @@ function DiaryDetailView({
         <button
           type="button"
           aria-label="뒤로가기"
-          onClick={() => router.back()}
+          onClick={handleBack}
           className={cn(
             'flex h-8 w-8 items-center justify-center rounded-lg',
             'text-gray-700 transition-colors hover:bg-gray-100'

--- a/src/app.feature/diary/shared/components/DiaryContentRenderer.tsx
+++ b/src/app.feature/diary/shared/components/DiaryContentRenderer.tsx
@@ -48,7 +48,11 @@ export function DiaryContentRenderer({
         '[&_ul]:list-disc [&_ul]:pl-5',
         '[&_pre]:rounded-lg [&_pre]:border [&_pre]:border-gray-200',
         '[&_pre]:bg-gray-50 [&_pre]:p-4 [&_pre]:text-gray-800',
+        // 긴 코드 줄이 가로로 넘치지 않고 줄바꿈되도록 강제한다.
+        // (hljs github 테마의 overflow-x:auto 보다 우선해 줄바꿈으로 처리)
+        '[&_pre]:break-words [&_pre]:whitespace-pre-wrap',
         '[&_pre_code]:bg-transparent [&_pre_code]:p-0',
+        '[&_pre_code]:break-words [&_pre_code]:whitespace-pre-wrap',
         '[&_pre_code]:text-[0.875rem]',
         '[&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-gray-100',
         '[&_:not(pre)>code]:px-1 [&_:not(pre)>code]:py-0.5',

--- a/src/app.feature/diary/write/components/DiaryContentEditor.tsx
+++ b/src/app.feature/diary/write/components/DiaryContentEditor.tsx
@@ -256,7 +256,10 @@ export function DiaryContentEditor({
               '[&_ul]:list-disc [&_ul]:pl-5',
               '[&_pre]:rounded-lg [&_pre]:border [&_pre]:border-gray-200',
               '[&_pre]:bg-gray-50 [&_pre]:p-4 [&_pre]:text-gray-800',
+              // 작성 화면도 본문과 동일하게 긴 코드 줄을 줄바꿈한다.
+              '[&_pre]:break-words [&_pre]:whitespace-pre-wrap',
               '[&_pre_code]:bg-transparent [&_pre_code]:p-0',
+              '[&_pre_code]:break-words [&_pre_code]:whitespace-pre-wrap',
               '[&_pre_code]:text-[0.875rem]',
               '[&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-gray-100',
               '[&_:not(pre)>code]:px-1 [&_:not(pre)>code]:py-0.5',

--- a/src/app.feature/member/profile/screen/MemberProfileScreen.tsx
+++ b/src/app.feature/member/profile/screen/MemberProfileScreen.tsx
@@ -12,9 +12,9 @@ import { MyPageProfileCard } from '@feature/member/mypage/components/MyPageProfi
 import { MyPageStatSection } from '@feature/member/mypage/components/MyPageStatSection';
 import { MyPageStreakHeroCard } from '@feature/member/mypage/components/MyPageStreakHeroCard';
 import { normalizeApiError } from '@module/api/error';
+import { useSafeBack } from '@module/hooks/useSafeBack';
 import { cn } from '@module/utils/cn';
 import { ArrowLeft } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import React from 'react';
 
 interface MemberProfileScreenProps {
@@ -22,7 +22,8 @@ interface MemberProfileScreenProps {
 }
 
 function MobileBackHeader({ title }: { title: string }): React.ReactElement {
-  const router = useRouter();
+  // 알림 딥링크/콜드 스타트로 진입해 history 가 없을 때 홈으로 보낸다.
+  const handleBack = useSafeBack('/');
   return (
     <div
       className={cn(
@@ -35,7 +36,7 @@ function MobileBackHeader({ title }: { title: string }): React.ReactElement {
       <button
         type="button"
         aria-label="뒤로가기"
-        onClick={() => router.back()}
+        onClick={handleBack}
         className={cn(
           'flex h-8 w-8 items-center justify-center rounded-lg',
           'text-gray-700 transition-colors hover:bg-gray-100'

--- a/src/app.feature/stories/components/Stories.tsx
+++ b/src/app.feature/stories/components/Stories.tsx
@@ -6,7 +6,7 @@ import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import { Lock } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import React, { useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { useStories } from '../hooks/useStoryQueries';
 import { sortStoryGroups } from '../utils/storyHelpers';
@@ -139,6 +139,15 @@ export default function Stories({
   const { data: sidebar } = useSidebar();
   const showSkeleton = useMinimumLoading(isPending);
 
+  // 정렬 결과를 매 렌더마다 새로 만들면 배열 ID 가 바뀌어 뷰어의 자동 전환
+  // 타이머가 끊기고 인덱스가 흔들린다. data 가 바뀔 때만 재정렬한다.
+  const groups = useMemo(
+    () => (data ? sortStoryGroups(data.storyGroups) : []),
+    [data]
+  );
+  // 인라인 핸들러는 매 렌더마다 새로 생성돼 뷰어의 콜백 안정성을 깬다.
+  const handleCloseViewer = useCallback(() => setOpenIndex(-1), []);
+
   if (!isLoggedIn) {
     return <StoryLoginPrompt onRequireLogin={onRequireLogin} />;
   }
@@ -149,8 +158,6 @@ export default function Stories({
   if (showSkeleton) {
     return <StoryRingSkeleton />;
   }
-
-  const groups = data ? sortStoryGroups(data.storyGroups) : [];
 
   const handleAddStory = (): void => {
     router.push('/diary/create');
@@ -168,9 +175,10 @@ export default function Stories({
       </div>
       {openIndex >= 0 ? (
         <StoryViewer
+          key={openIndex}
           groups={groups}
           startIndex={openIndex}
-          onClose={() => setOpenIndex(-1)}
+          onClose={handleCloseViewer}
         />
       ) : null}
     </>

--- a/src/app.feature/stories/components/StoryViewer.tsx
+++ b/src/app.feature/stories/components/StoryViewer.tsx
@@ -29,10 +29,24 @@ export default function StoryViewer({
   const viewStoryMutation = useViewStory();
   const reportedRef = useRef<Set<number>>(new Set());
 
-  const [groupIndex, setGroupIndex] = useState(startIndex);
+  // 뷰어가 열려 있는 동안 부모의 재정렬(시청 처리 → 캐시 갱신)이 그룹 배열을
+  // 흔들어 인덱스가 어긋나는 것을 막기 위해, 열린 시점의 스냅샷을 고정한다.
+  const [frozenGroups] = useState(groups);
+  const lastGroupIndex = Math.max(0, frozenGroups.length - 1);
+  const [groupIndex, setGroupIndex] = useState(() =>
+    Math.min(Math.max(startIndex, 0), lastGroupIndex)
+  );
   const [diaryIndex, setDiaryIndex] = useState(0);
 
-  const group = groups[groupIndex];
+  // 자동 전환 타이머와 수동 넘김이 경합할 때, stale 클로저가 인덱스를 두 번
+  // 증가시켜 경계를 벗어나면 뷰어가 빈 화면으로 멈춘다(다시 열어도 안 열림).
+  // 최신 위치를 ref 로 동기 추적해 항상 한 칸씩, 경계 안에서만 이동한다.
+  const positionRef = useRef({ groupIndex, diaryIndex });
+  useEffect(() => {
+    positionRef.current = { groupIndex, diaryIndex };
+  }, [groupIndex, diaryIndex]);
+
+  const group = frozenGroups[groupIndex];
   const story = group?.stories[diaryIndex];
 
   const diaryId = story?.diaryId;
@@ -53,34 +67,41 @@ export default function StoryViewer({
   }, [diaryId, hasUnreadJournal, viewStoryMutate]);
 
   const advanceToNext = useCallback(() => {
-    const currentGroup = groups[groupIndex];
+    const { groupIndex: gi, diaryIndex: di } = positionRef.current;
+    const currentGroup = frozenGroups[gi];
     if (!currentGroup) {
       onClose();
       return;
     }
-    if (diaryIndex < currentGroup.stories.length - 1) {
-      setDiaryIndex((prev) => prev + 1);
+    if (di < currentGroup.stories.length - 1) {
+      positionRef.current = { groupIndex: gi, diaryIndex: di + 1 };
+      setDiaryIndex(di + 1);
       return;
     }
-    if (groupIndex < groups.length - 1) {
-      setGroupIndex((prev) => prev + 1);
+    if (gi < frozenGroups.length - 1) {
+      positionRef.current = { groupIndex: gi + 1, diaryIndex: 0 };
+      setGroupIndex(gi + 1);
       setDiaryIndex(0);
       return;
     }
     onClose();
-  }, [diaryIndex, groupIndex, groups, onClose]);
+  }, [frozenGroups, onClose]);
 
   const advanceToPrev = useCallback(() => {
-    if (diaryIndex > 0) {
-      setDiaryIndex((prev) => prev - 1);
+    const { groupIndex: gi, diaryIndex: di } = positionRef.current;
+    if (di > 0) {
+      positionRef.current = { groupIndex: gi, diaryIndex: di - 1 };
+      setDiaryIndex(di - 1);
       return;
     }
-    if (groupIndex > 0) {
-      const prevGroup = groups[groupIndex - 1];
-      setGroupIndex((prev) => prev - 1);
-      setDiaryIndex(Math.max(0, prevGroup.stories.length - 1));
+    if (gi > 0) {
+      const prevGroup = frozenGroups[gi - 1];
+      const prevDiary = Math.max(0, prevGroup.stories.length - 1);
+      positionRef.current = { groupIndex: gi - 1, diaryIndex: prevDiary };
+      setGroupIndex(gi - 1);
+      setDiaryIndex(prevDiary);
     }
-  }, [diaryIndex, groupIndex, groups]);
+  }, [frozenGroups]);
 
   // 키보드: ←/→ 이동, Esc 닫기
   useEffect(() => {
@@ -119,6 +140,14 @@ export default function StoryViewer({
       document.body.style.overflow = prevOverflow;
     };
   }, []);
+
+  // 위치가 비면 빈 화면으로 마운트된 채 남지 않도록 부모에 닫힘을 알린다.
+  // 이게 없으면 openIndex 가 리셋되지 않아 다른 스토리를 눌러도 안 열린다.
+  useEffect(() => {
+    if (!group || !story) {
+      onClose();
+    }
+  }, [group, story, onClose]);
 
   if (!group || !story) {
     return null;

--- a/src/app.feature/stories/utils/storyHelpers.ts
+++ b/src/app.feature/stories/utils/storyHelpers.ts
@@ -38,9 +38,10 @@ function sortStoriesByRecent(stories: StoryItem[]): StoryItem[] {
   );
 }
 
-// 정렬 규칙(랜덤하게 보이지 않도록 시간 기준으로 고정):
-//  1) 미시청 그룹이 위 — 읽지 않은 스토리를 먼저 보여준다.
-//  2) 최근 스토리가 있는 그룹이 위 — 시간 내림차순.
+// 정렬 규칙: 가장 최근 스토리가 있는 그룹을 항상 맨 앞에 둔다(시간 내림차순).
+// 시청 여부로 순서를 바꾸면, 방금 본 최신 스토리가 더 오래된 미시청 그룹
+// 뒤로 밀려 "최신이 먼저 보이지 않는" 문제가 생기므로 시간만으로 정렬한다.
+// (미시청 표시는 StoryRing 의 NEW 배지가 isGroupAllSeen 으로 별도 처리한다.)
 // 각 그룹 내부 스토리도 최신순으로 정렬한다.
 export function sortStoryGroups(groups: StoryGroup[]): StoryGroup[] {
   return groups
@@ -48,14 +49,7 @@ export function sortStoryGroups(groups: StoryGroup[]): StoryGroup[] {
       ...group,
       stories: sortStoriesByRecent(group.stories),
     }))
-    .sort((left, right) => {
-      const leftSeen = isGroupAllSeen(left) ? 1 : 0;
-      const rightSeen = isGroupAllSeen(right) ? 1 : 0;
-      if (leftSeen !== rightSeen) {
-        return leftSeen - rightSeen;
-      }
-      return latestStoryTime(right) - latestStoryTime(left);
-    });
+    .sort((left, right) => latestStoryTime(right) - latestStoryTime(left));
 }
 
 export function formatStoryDate(iso: string): string {

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -57,11 +57,34 @@ const getResponseMessage = (payload: unknown): string | null => {
     : null;
 };
 
+const getResponseCode = (payload: unknown): string | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const apiError = payload as ApiErrorResponse;
+  return typeof apiError.code === 'string' && apiError.code.trim()
+    ? apiError.code
+    : null;
+};
+
+// 백엔드가 내려주는 refresh token 무효/형식 오류 코드. 상태 코드와 무관하게
+// 세션을 복구할 수 없으므로 로컬 토큰을 정리해야 한다(예: AUTH-006).
+const INVALID_REFRESH_TOKEN_CODES = new Set(['AUTH-006']);
+
 export const isUnauthorizedError = (error: unknown): boolean =>
   isAxiosErrorLike(error) && error.response?.status === 401;
 
 export const isRedirectError = (error: unknown): boolean =>
   isAxiosErrorLike(error) && error.response?.status === 302;
+
+export const isInvalidRefreshTokenError = (error: unknown): boolean => {
+  if (!isAxiosErrorLike(error)) {
+    return false;
+  }
+  const code = getResponseCode(error.response?.data);
+  return code !== null && INVALID_REFRESH_TOKEN_CODES.has(code);
+};
 
 export const normalizeApiError = (error: unknown): NormalizedApiError => {
   if (isAxiosErrorLike(error)) {

--- a/src/app.module/api/errorNotify.ts
+++ b/src/app.module/api/errorNotify.ts
@@ -3,7 +3,9 @@
 import { authStorage } from '@module/utils/auth';
 import { toast } from 'sonner';
 
+import { API_BASE_URL } from './config';
 import {
+  isInvalidRefreshTokenError,
   isRedirectError,
   isUnauthorizedError,
   normalizeApiError,
@@ -18,6 +20,61 @@ import {
 
 const TOASTED_ERRORS = new WeakSet<object>();
 let isRedirecting = false;
+
+const PROTECTED_PATH_PREFIXES = [
+  '/mypage',
+  '/diary/create',
+  '/challenge/create',
+];
+const PROTECTED_PATH_PATTERNS = [/^\/challenge\/\d+/, /^\/diary\/\d+/];
+
+const isProtectedRoute = (pathname: string): boolean =>
+  PROTECTED_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
+  PROTECTED_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
+
+// 무효 세션의 서버 쿠키 정리: 백엔드 /auth/logout 을 best-effort 로 호출해
+// HttpOnly 쿠키를 Set-Cookie 로 만료시킨다. 인터셉터/재귀를 피하려 raw fetch 를
+// 쓰고, keepalive 로 리다이렉트 중에도 요청이 살아남게 한다. (로컬 토큰은
+// 호출부에서 이미 정리됨; 실제 쿠키 만료는 백엔드 Set-Cookie 가 결정)
+const clearServerSession = (): void => {
+  void fetch(`${API_BASE_URL}/auth/logout`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
+    keepalive: true,
+  }).catch(() => {
+    // best-effort: 실패해도 로컬은 이미 정리되어 재시도 루프는 끊긴다.
+  });
+};
+
+export const handleAuthError = (error: unknown): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  // 401(토큰 없음/만료) 또는 refresh token 무효(AUTH-006) 모두 세션을 복구할
+  // 수 없으므로 동일하게 정리한다. AUTH-006 을 빼면 hasTokens() 가 계속 true 라
+  // 새로고침/재개마다 /auth/token 재시도 → 같은 에러가 무한 반복된다.
+  const invalidRefresh = isInvalidRefreshTokenError(error);
+  if (!isUnauthorizedError(error) && !invalidRefresh) {
+    return;
+  }
+
+  // 조용히 로그아웃 처리 (토스트 표시하지 않음)
+  authStorage.clearTokens();
+  localStorage.removeItem('1d1s:sidebar');
+
+  // refresh token 자체가 무효면 서버 세션/HttpOnly 쿠키까지 정리한다.
+  if (invalidRefresh) {
+    clearServerSession();
+  }
+
+  if (!isRedirecting && isProtectedRoute(window.location.pathname)) {
+    isRedirecting = true;
+    window.location.assign('/');
+  }
+};
 
 const shouldSkipToast = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {
@@ -46,6 +103,14 @@ export const notifyApiError = (error: unknown): void => {
     return;
   }
 
+  // refresh token 자체가 무효(AUTH-006)면, 같은 에러를 토스트로 반복 노출하는
+  // 대신 조용히 로그아웃 정리한다. (handleUnauthorized=false 인 publicApiClient
+  // 의 /auth/token 호출이 이 경로로 들어온다.)
+  if (isInvalidRefreshTokenError(error)) {
+    handleAuthError(error);
+    return;
+  }
+
   if (shouldSkipToast(error)) {
     return;
   }
@@ -56,34 +121,4 @@ export const notifyApiError = (error: unknown): void => {
   }
 
   toast.error(normalizedError.message);
-};
-
-const PROTECTED_PATH_PREFIXES = [
-  '/mypage',
-  '/diary/create',
-  '/challenge/create',
-];
-const PROTECTED_PATH_PATTERNS = [/^\/challenge\/\d+/, /^\/diary\/\d+/];
-
-const isProtectedRoute = (pathname: string): boolean =>
-  PROTECTED_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
-  PROTECTED_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
-
-export const handleAuthError = (error: unknown): void => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  if (!isUnauthorizedError(error)) {
-    return;
-  }
-
-  // 토큰 없음/만료 시 조용히 로그아웃 처리 (토스트 표시하지 않음)
-  authStorage.clearTokens();
-  localStorage.removeItem('1d1s:sidebar');
-
-  if (!isRedirecting && isProtectedRoute(window.location.pathname)) {
-    isRedirecting = true;
-    window.location.assign('/');
-  }
 };

--- a/src/app.module/hooks/useServiceWorkerNavigation.ts
+++ b/src/app.module/hooks/useServiceWorkerNavigation.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+interface NotificationNavigateMessage {
+  type: 'NOTIFICATION_NAVIGATE';
+  url: string;
+}
+
+function isNavigateMessage(
+  data: unknown
+): data is NotificationNavigateMessage {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const message = data as Record<string, unknown>;
+  return (
+    message.type === 'NOTIFICATION_NAVIGATE' &&
+    typeof message.url === 'string' &&
+    message.url.length > 0
+  );
+}
+
+/**
+ * 서비스워커(알림 클릭)가 보낸 인앱 네비게이션 메시지를 Next 라우터로 처리한다.
+ *
+ * 푸시 알림 클릭 시 서비스워커가 `client.navigate()` 로 직접 이동하면 현재
+ * history 항목이 "교체"돼 뒤로가기가 동작하지 않는다(특히 standalone PWA 는
+ * 시작 항목 하나만 남아 완전히 갇힌다). 대신 서비스워커가 메시지를 보내고,
+ * 살아 있는 클라이언트가 `router.push()` 로 이동하면 history 가 정상적으로
+ * 쌓여 뒤로가기로 직전 화면(목록/홈)으로 돌아갈 수 있다.
+ */
+export function useServiceWorkerNavigation(): void {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+      return;
+    }
+
+    const onMessage = (event: MessageEvent): void => {
+      if (isNavigateMessage(event.data)) {
+        router.push(event.data.url);
+      }
+    };
+
+    navigator.serviceWorker.addEventListener('message', onMessage);
+    return () => {
+      navigator.serviceWorker.removeEventListener('message', onMessage);
+    };
+  }, [router]);
+}

--- a/src/app.module/hooks/useTokenRefreshOnResume.ts
+++ b/src/app.module/hooks/useTokenRefreshOnResume.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { authApi } from '@feature/auth/api/authApi';
+import { isInvalidRefreshTokenError } from '@module/api/error';
 import { authStorage } from '@module/utils/auth';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
@@ -46,9 +47,13 @@ export function useTokenRefreshOnResume(): void {
         // 마운트된 쿼리만 즉시 refetch 되고, 백그라운드 쿼리는 다음 사용 때
         // 갱신된다.
         await queryClient.invalidateQueries();
-      } catch {
-        // 재발급 실패는 다음 API 호출에서 401 → silentAuthClient/interceptor
-        // 흐름으로 자연스럽게 정리되도록 두고, 여기선 추가 처리를 하지 않는다.
+      } catch (error) {
+        // refresh token 이 무효(AUTH-006)면 로컬 토큰을 정리해 같은 요청이
+        // 새로고침/재개마다 무한 반복되는 것을 막는다. 그 외 일시적 오류는
+        // 그대로 두어 다음 API 호출의 401 → interceptor 흐름에서 정리되게 한다.
+        if (isInvalidRefreshTokenError(error)) {
+          authStorage.clearTokens();
+        }
       } finally {
         isRefreshingRef.current = false;
       }


### PR DESCRIPTION
## 📌 Summary

QA에서 보고된 6건의 버그(재접속 로그인 오인 · 일지 코드블록 줄바꿈 · 알림 뒤로가기 · 스토리 뷰어/정렬 · AUTH-006 무한 에러)를 수정합니다.

## ✅ 작업 내용

### 1. 재접속 시 로그인 사용자가 게스트로 보이는 문제
- `useSidebar` 쿼리가 비반응형 `authStorage.hasTokens()`에 묶여, PWA 콜드/재개 시 토큰 힌트 복원이 늦으면 쿼리가 비활성으로 굳어 게스트로 표시됨 (새로고침해야 정상화)
- PWA 복귀 / 포커스 / BFCache 복원(`visibilitychange`·`focus`·`pageshow`) 시 토큰 힌트를 재평가해 비활성 쿼리를 되살리도록 `useAuthLayoutState` 보강

### 2. 일지 코드 블록 줄바꿈 안 됨
- 본문 렌더러·작성 에디터의 `pre`·`code`에 `whitespace-pre-wrap` + `break-words` 적용 → 가로 오버플로우 대신 줄바꿈

### 3. 알림 딥링크 진입 후 뒤로가기 불가(갇힘)
- 서비스워커가 `client.navigate()`(현재 history 항목 교체) 대신 메시지를 보내고, 클라이언트가 `router.push()`로 이동 → 뒤로가기 history 보존
- `useServiceWorkerNavigation` 브리지 추가 후 레이아웃에 연결
- 일지/챌린지/멤버 상세의 뒤로가기를 `useSafeBack`으로 교체 (콜드 스타트 등 history가 없을 때 목록/홈으로 폴백)

### 4. 스토리 뷰어 경합으로 닫힘/재오픈 불가 + 최신순 정렬
- 자동 전환 타이머와 수동 넘김이 경합할 때 인덱스가 경계를 벗어나 빈 화면으로 멈추고 다시 안 열리던 문제 → 위치를 ref로 동기 추적해 항상 경계 내 한 칸씩 이동, 비정상 시 `onClose`로 부모 상태 리셋
- 열린 시점의 그룹 스냅샷을 고정해 시청 처리 후 재정렬로 뷰어가 흔들리는 것 방지
- 그룹 정렬을 "미시청 우선"에서 "최신 시각 내림차순"으로 변경 (NEW 배지는 그대로 유지)

### 5. AUTH-006(무효 refresh token) 에러 무한 반복
- 응답 코드로 무효 refresh token 판별(`isInvalidRefreshTokenError`)
- 토스트로 같은 에러를 반복 노출하는 대신 조용히 로그아웃(로컬 토큰 정리) → `/auth/token` 재시도 루프 차단
- 백엔드 `/auth/logout`을 best-effort(raw fetch, keepalive)로 호출해 HttpOnly 쿠키 만료를 트리거

## 📎 기타

- 검증: `pnpm lint`, `tsc --noEmit` 통과. **브라우저 동작 확인은 미실시** — 아래 항목은 직접 확인 부탁드립니다.
  - PWA 백그라운드 → 복귀 시 로그인 유지 / 자동전환 중 빠른 탭에도 안 멈춤·재오픈 / 스토리 최신순 / 긴 코드 줄바꿈 / 알림→상세→뒤로가기
- 알림 동선 변경은 **서비스워커 갱신 후** 적용됩니다(한 번 새로 로드 필요).
- AUTH-006 시 HttpOnly 쿠키의 실제 만료는 백엔드 `/auth/logout`(또는 `/auth/token` 실패 응답)의 `Set-Cookie`에 의존합니다. 백엔드가 미지원이어도 로컬 토큰이 정리돼 **에러 무한 반복은 해결**됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Service worker notifications now trigger proper in-app navigation.

* **Bug Fixes**
  * Back navigation now works reliably when entering via notifications or without browser history.
  * Story viewer index alignment improved during browsing sessions.
  * Code block formatting enhanced with consistent line wrapping in diary entries.
  * Enhanced authentication session management on app resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->