### PR TITLE
fix: ODS-221 Vercel 이미지 최적화 한도 소진 시 빈 이미지 문제 해결

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -20,6 +20,9 @@ const config: KnipConfig = {
     'src/app.module/middleware/middleware.ts',
     'next.config.{js,ts,mjs}',
     'postcss.config.{js,cjs,mjs}',
+    // next.config images.loaderFile 로 지정되는 커스텀 이미지 로더.
+    // 문자열 경로라 정적 분석으로 추적되지 않아 entry 로 명시한다.
+    'src/app.lib/imageLoader.ts',
   ],
   project: ['src/**/*.{ts,tsx}'],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -44,33 +44,17 @@ const nextConfig = {
     ],
   },
   images: {
-    dangerouslyAllowSVG: isDev,
-    // 변환 결과를 길게 캐시해 같은 이미지의 재변환(=재과금)을 줄인다.
-    // 업로드 이미지는 보통 URL 이 새로 생기므로 stale 위험이 낮다.
-    minimumCacheTTL: 60 * 60 * 24 * 30, // 30일
-    // AVIF 까지 켜면 브라우저별로 변환이 2배가 되므로 webp 단일 유지.
-    formats: ['image/webp'],
-    // 전부 기본 품질(75)만 쓰므로 1종으로 고정해 변형 다중화를 막는다.
-    qualities: [75],
-    // 실제 사용하는 sizes 기준으로 너비 변형 가짓수를 줄인다.
-    // 기본값(최대 3840)은 거의 안 쓰는 초대형 변환을 만들어 낭비가 크다.
+    // Vercel 기본 최적화기(/_next/image)를 우회하는 커스텀 로더.
+    // 한도(Image Transformations) 소진 시 이 엔드포인트가 402 를 반환해
+    // 업로드 이미지가 통째로 빈 이미지로 내려오던 문제를 회피한다.
+    // 로더는 변환기를 거치지 않고 원본 URL 을 그대로 쓰므로 한도와
+    // 무관하다. 동작/확장은 src/app.lib/imageLoader.ts 참고.
+    loader: 'custom',
+    loaderFile: './src/app.lib/imageLoader.ts',
+    // srcset 의 width 후보. 지금은 로더가 width 를 무시하지만, 백엔드
+    // 리사이징 도입 시 그대로 변환 폭으로 재사용된다.
     deviceSizes: [640, 828, 1080, 1920, 2048],
     imageSizes: [32, 64, 128, 256, 384],
-    remotePatterns: [
-      // ⚠️ hostname '**' 는 누구나 이 최적화기로 외부 이미지를 변환하게
-      // 허용해 쿼터가 도난될 수 있다. 실제 이미지 호스트(백엔드 +
-      // OAuth 프로필 CDN)로 좁히는 것을 권장(아래 설명 참고).
-      {
-        protocol: 'https',
-        hostname: '**',
-        pathname: '/**',
-      },
-      {
-        protocol: 'http',
-        hostname: 'localhost',
-        pathname: '/**',
-      },
-    ],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/js-cookie": "^3.0.6",
     "autoprefixer": "^10.4.21",
     "axios": "^1.9.0",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       axios:
         specifier: ^1.9.0
         version: 1.9.0
+      browser-image-compression:
+        specifier: ^2.0.2
+        version: 2.0.2
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2337,6 +2340,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-image-compression@2.0.2:
+    resolution: {integrity: sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==}
+
   browserslist@4.25.0:
     resolution: {integrity: sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -4356,6 +4362,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uzip@0.20201231.0:
+    resolution: {integrity: sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -6573,6 +6582,10 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browser-image-compression@2.0.2:
+    dependencies:
+      uzip: 0.20201231.0
 
   browserslist@4.25.0:
     dependencies:
@@ -8845,6 +8858,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  uzip@0.20201231.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/src/app.component/FadeInImage.tsx
+++ b/src/app.component/FadeInImage.tsx
@@ -16,16 +16,35 @@ import React, { useCallback, useState } from 'react';
  * 떨림 방지: 페이드가 끝나며 합성 레이어가 해제될 때 이미지가 서브픽셀
  * 단위로 살짝 튀는 떨림이 있어, translateZ(0)/backface-hidden 으로 레이어를
  * 고정해 등장 직후의 미세한 떨림을 없앤다.
+ *
+ * 로드 실패 대응: URL 만료·삭제·네트워크 오류로 로드가 실패하면 onLoad
+ * 가 오지 않아 opacity 0 에 영구히 갇혀 "로딩 중"과 구분되지 않는 빈
+ * 이미지로 남는다. fallbackSrc 가 있으면 1회 그 이미지로 교체하고,
+ * 없으면 페이드인만 끝내 부모 placeholder 배경이 드러나게 한다.
  */
-type FadeInImageProps = ImageProps;
+type FadeInImageProps = ImageProps & {
+  /** 로드 실패 시 1회 교체할 대체 이미지. 미지정 시 교체하지 않는다. */
+  fallbackSrc?: ImageProps['src'];
+};
 
 function FadeInImage({
   alt,
   className,
   onLoad,
+  onError,
+  src,
+  fallbackSrc,
   ...rest
 }: FadeInImageProps): React.ReactElement {
   const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+  // src 가 바뀌면(다른 이미지로 교체) 로드/에러 상태를 초기화한다.
+  const [trackedSrc, setTrackedSrc] = useState(src);
+  if (trackedSrc !== src) {
+    setTrackedSrc(src);
+    setLoaded(false);
+    setErrored(false);
+  }
 
   const setRef = useCallback((node: HTMLImageElement | null) => {
     if (node?.complete) {
@@ -33,10 +52,13 @@ function FadeInImage({
     }
   }, []);
 
+  const resolvedSrc = errored && fallbackSrc ? fallbackSrc : src;
+
   return (
     <Image
       ref={setRef}
       alt={alt}
+      src={resolvedSrc}
       className={cn(
         'transition-opacity duration-700 ease-out',
         'motion-reduce:transition-none',
@@ -47,6 +69,15 @@ function FadeInImage({
       onLoad={(event) => {
         setLoaded(true);
         onLoad?.(event);
+      }}
+      onError={(event) => {
+        // fallbackSrc 로 1회만 교체(무한 루프 방지). fallback 까지
+        // 실패하면 더 바꾸지 않고 부모 배경이 보이도록 둔다.
+        if (fallbackSrc && !errored) {
+          setErrored(true);
+          setLoaded(false);
+        }
+        onError?.(event);
       }}
       {...rest}
     />

--- a/src/app.component/cards/DiaryCard.tsx
+++ b/src/app.component/cards/DiaryCard.tsx
@@ -99,6 +99,7 @@ function DiaryCard({
             fill
             sizes="(min-width: 1024px) 280px, 50vw"
             className="object-cover"
+            fallbackSrc="/images/default-card.png"
           />
         ) : (
           <Stripe tone={tone} />

--- a/src/app.feature/diary/detail/components/DiaryHeroImage.tsx
+++ b/src/app.feature/diary/detail/components/DiaryHeroImage.tsx
@@ -28,6 +28,7 @@ export function DiaryHeroImage({
         fill
         sizes="(max-width: 1024px) 100vw, 720px"
         className="object-cover"
+        fallbackSrc="/images/default-card.png"
       />
     </button>
   );

--- a/src/app.feature/diary/detail/hooks/useDiaryMutations.ts
+++ b/src/app.feature/diary/detail/hooks/useDiaryMutations.ts
@@ -5,6 +5,8 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
+import { compressImageFile } from '@/app.lib/compressImage';
+
 import { CHALLENGE_QUERY_KEYS } from '../../../challenge/board/consts/queryKeys';
 import { MEMBER_QUERY_KEYS } from '../../../member/consts/queryKeys';
 import { DIARY_QUERY_KEYS } from '../../board/consts/queryKeys';
@@ -142,8 +144,10 @@ export function useUploadDiaryImage(): UseMutationResult<
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, file }: { id: number; file: File }) =>
-      diaryWriteApi.uploadDiaryImage(id, file),
+    mutationFn: async ({ id, file }: { id: number; file: File }) => {
+      const compressed = await compressImageFile(file);
+      return diaryWriteApi.uploadDiaryImage(id, compressed);
+    },
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({
         queryKey: DIARY_QUERY_KEYS.detail(id),

--- a/src/app.lib/compressImage.ts
+++ b/src/app.lib/compressImage.ts
@@ -1,0 +1,37 @@
+import imageCompression from 'browser-image-compression';
+
+// 표시에 쓰는 최대 폭(next.config deviceSizes 최대=2048)에 맞춰 그 이상
+// 해상도는 불필요하므로 리사이즈한다. 목표 용량을 함께 두어 초과 시
+// 라이브러리가 품질을 자동으로 낮춰 맞춘다.
+const COMPRESSION_OPTIONS = {
+  maxWidthOrHeight: 2048,
+  maxSizeMB: 1,
+  useWebWorker: true,
+};
+
+/**
+ * 업로드 직전 이미지 압축/리사이즈.
+ *
+ * 백엔드·Vercel 모두 리사이즈를 하지 않아 업로드한 원본이 그대로
+ * 저장되고 목록/카드에서도 그대로 다운로드된다. 업로드 시점에 표시에
+ * 충분한 크기로 줄여 저장 용량과 로딩 무게를 함께 낮춘다. EXIF
+ * orientation 은 라이브러리가 보정하므로 iOS 세로 사진이 눕는 문제도
+ * 방지된다. 압축이 실패하면 원본을 그대로 반환해 업로드 자체는 막지
+ * 않는다.
+ */
+export async function compressImageFile(file: File): Promise<File> {
+  if (!file.type.startsWith('image/')) {
+    return file;
+  }
+
+  // 이미 목표 용량 이하면 재인코딩으로 품질만 떨어뜨리지 않도록 통과.
+  if (file.size <= COMPRESSION_OPTIONS.maxSizeMB * 1024 * 1024) {
+    return file;
+  }
+
+  try {
+    return await imageCompression(file, COMPRESSION_OPTIONS);
+  } catch {
+    return file;
+  }
+}

--- a/src/app.lib/imageLoader.ts
+++ b/src/app.lib/imageLoader.ts
@@ -1,0 +1,28 @@
+import type { ImageLoaderProps } from 'next/image';
+
+/**
+ * next/image 커스텀 로더 — Vercel 기본 최적화기(/_next/image) 우회용.
+ *
+ * 기본 로더는 모든 이미지를 `/_next/image` 변환 엔드포인트로 보낸다.
+ * Vercel Hobby 플랜의 월 변환(Image Transformations) 한도가 소진되면
+ * 이 엔드포인트가 402 를 반환해 이미지가 통째로 깨진다(빈 이미지).
+ * 커스텀 로더를 지정하면 next/image 가 변환기를 거치지 않고 로더가
+ * 반환한 URL 을 그대로 <img src> 로 사용하므로 한도와 무관해진다.
+ *
+ * 지금은 원본 URL 을 그대로 통과시킨다(pass-through). 백엔드/CDN 이
+ * width 기반 리사이징(예: `?w=800`)을 지원하는 것이 확인되면 아래
+ * 주석 위치에서 width/quality 를 쿼리로 덧붙여 변환을 위임하면 된다.
+ * 그 전까지 임의 파라미터를 붙이면 백엔드가 무시하거나 404 를 낼 수
+ * 있으므로 붙이지 않는다.
+ */
+export default function imageLoader({ src }: ImageLoaderProps): string {
+  // data:/blob: 인라인 소스, 앱 내부 정적 자산(/_next, /images),
+  // 외부 업로드 이미지 모두 원본 그대로 반환한다.
+  //
+  // 백엔드 리사이징 확인 시 이 자리에서 확장:
+  //   const url = new URL(src);
+  //   url.searchParams.set('w', String(width));
+  //   url.searchParams.set('q', String(quality ?? 75));
+  //   return url.toString();
+  return src;
+}


### PR DESCRIPTION
## 배경
Vercel Image Optimization(Image Transformations) 월 한도가 소진되면 `next/image`가 거치는 `/_next/image` 변환 엔드포인트가 402를 반환해, 업로드 이미지가 통째로 빈 이미지로 내려왔습니다. 백엔드·Vercel 모두 리사이즈를 하지 않는 환경입니다.

## 변경
- **커스텀 로더로 최적화기 우회** — `src/app.lib/imageLoader.ts` 신규 + `next.config.ts`에 `loader: 'custom'` 지정. `/_next/image`를 거치지 않고 원본 URL을 직접 사용하므로 한도와 무관해집니다. 한도 리셋 대기 없이 배포 즉시 복구되고, 기존 `remotePatterns: '**'` 쿼터 도난 위험도 사라집니다.
- **`FadeInImage` onError 안전망** — 로드 실패(URL 만료/네트워크 오류) 시 `default-card.png`로 1회 교체. 기존엔 `opacity:0`에 영구히 갇혀 빈 이미지로 남던 문제를 방지합니다. (일지 카드·히어로에 연결)
- **업로드 시 클라이언트 압축** — `src/app.lib/compressImage.ts` 신규. `browser-image-compression`으로 최대 2048px / 1MB로 리사이즈(EXIF orientation 보정 포함). `useUploadDiaryImage` mutation 한 곳에 적용해 작성·수정 업로드 모두 커버. 신규 업로드부터 적용됩니다.

## 검증
- `pnpm lint` 통과, `tsc --noEmit` 통과
- 브라우저 동작은 미확인 — 리뷰어 측에서 실제 업로드/표시 확인 필요

## 참고
- 이미 저장된 기존 원본 이미지는 소급 압축되지 않습니다(백엔드 일괄 처리 영역).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uploaded diary images are now automatically compressed before saving to reduce size and improve upload performance.
* **Bug Fixes**
  * Improved image load behavior: when images fail to load, a default fallback image is shown instead of broken placeholders.
  * Enhanced robustness of image fade-in transitions to avoid getting stuck during load errors.
* **Performance & Reliability**
  * Updated image delivery settings to better preserve original image URLs and improve reliability when transformations are constrained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->