### PR TITLE
Release: 일지 이미지 UI 수정 (뱃지·간격·깜빡임)

### DIFF
--- a/src/app.component/FadeInImage.tsx
+++ b/src/app.component/FadeInImage.tsx
@@ -22,6 +22,21 @@ import React, { useCallback, useState } from 'react';
  * 이미지로 남는다. fallbackSrc 가 있으면 1회 그 이미지로 교체하고,
  * 없으면 페이드인만 끝내 부모 placeholder 배경이 드러나게 한다.
  */
+// 이미 한 번 디코드가 끝난 이미지 src(문자열 URL) 를 기억한다. 스크롤·
+// 리스트 리렌더 등으로 카드가 재마운트될 때 캐시에 있으면 페이드 없이
+// 즉시 opacity-100 으로 그려, 매 재마운트마다 깜빡이던 문제를 없앤다.
+// 최초 로드에서만 페이드인이 보인다.
+const loadedSrcCache = new Set<string>();
+
+function stringSrc(src: ImageProps['src']): string | null {
+  return typeof src === 'string' ? src : null;
+}
+
+function isSrcCached(src: ImageProps['src']): boolean {
+  const key = stringSrc(src);
+  return key !== null && loadedSrcCache.has(key);
+}
+
 type FadeInImageProps = ImageProps & {
   /** 로드 실패 시 1회 교체할 대체 이미지. 미지정 시 교체하지 않는다. */
   fallbackSrc?: ImageProps['src'];
@@ -36,21 +51,34 @@ function FadeInImage({
   fallbackSrc,
   ...rest
 }: FadeInImageProps): React.ReactElement {
-  const [loaded, setLoaded] = useState(false);
+  // 이미 로드된 적 있는 src 면 처음부터 opacity-100 (페이드·깜빡임 없음).
+  const [loaded, setLoaded] = useState(() => isSrcCached(src));
   const [errored, setErrored] = useState(false);
-  // src 가 바뀌면(다른 이미지로 교체) 로드/에러 상태를 초기화한다.
+  // src 가 바뀌면(다른 이미지로 교체) 로드/에러 상태를 초기화한다. 단
+  // 이미 캐시된 src 로 바뀌면 즉시 표시해 깜빡임을 막는다.
   const [trackedSrc, setTrackedSrc] = useState(src);
   if (trackedSrc !== src) {
     setTrackedSrc(src);
-    setLoaded(false);
+    setLoaded(isSrcCached(src));
     setErrored(false);
   }
 
-  const setRef = useCallback((node: HTMLImageElement | null) => {
-    if (node?.complete) {
-      setLoaded(true);
+  const markLoaded = useCallback((loadedSrc: ImageProps['src']) => {
+    const key = stringSrc(loadedSrc);
+    if (key !== null) {
+      loadedSrcCache.add(key);
     }
+    setLoaded(true);
   }, []);
+
+  const setRef = useCallback(
+    (node: HTMLImageElement | null) => {
+      if (node?.complete) {
+        markLoaded(src);
+      }
+    },
+    [markLoaded, src]
+  );
 
   const resolvedSrc = errored && fallbackSrc ? fallbackSrc : src;
 
@@ -67,7 +95,7 @@ function FadeInImage({
         className
       )}
       onLoad={(event) => {
-        setLoaded(true);
+        markLoaded(resolvedSrc);
         onLoad?.(event);
       }}
       onError={(event) => {

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -972,9 +972,15 @@ function DiaryDetailView({
                   </div>
                 ) : null}
 
-                {/* 첨부 이미지 — 하단 정사각형 갤러리 (다중 대응) */}
+                {/* 첨부 이미지 — 하단 정사각형 갤러리 (다중 대응).
+                    본문이 있으면 본문 아래 mt-5, 없으면 데스크톱에서
+                    '오늘의 기록' 라벨 아래 일정 간격(lg:mt-3.5)을 준다. */}
                 {diaryData.contentImageUrls.length > 0 ? (
-                  <div className={cn(diaryData.hasContentHtml && 'mt-5')}>
+                  <div
+                    className={cn(
+                      diaryData.hasContentHtml ? 'mt-5' : 'lg:mt-3.5'
+                    )}
+                  >
                     <DiaryImageGallery
                       imageUrls={diaryData.contentImageUrls}
                     />

--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -198,9 +198,9 @@ function StoryRing({
             {!seen ? (
               <span
                 className={cn(
-                  'absolute top-4 right-4 flex h-10 w-10 items-center',
-                  'border-main-700 justify-center rounded-full border-5',
-                  'text-main-800 bg-white text-xs font-extrabold shadow-sm'
+                  'absolute top-4 right-4 flex h-5 min-w-5 items-center',
+                  'bg-main-600 justify-center rounded-full px-1',
+                  'text-[11px] font-bold text-white ring-2 ring-white'
                 )}
                 aria-label={`${unreadCount || 1}개 새 스토리`}
               >


### PR DESCRIPTION
## 📌 Summary

develop → main 승격. 일지 이미지 UI 후속 수정들을 프로덕션에 반영합니다.

## ✅ 작업 내용

- 스토리 미읽음 개수 뱃지 축소·정리 (h-10 border-5 → 작은 솔리드 뱃지)
- 일지 상세 '오늘의 기록' 라벨-사진 간격 보정
- 스크롤·리렌더 시 이미지 깜빡임 제거 (FadeInImage 로드 캐시)

## 📎 기타

- 각 변경은 develop에서 CI(TypeScript/ESLint/Knip/Build) 통과 완료.
