### PR TITLE
fix: 이미지 Cache-Control 추가 (캐싱 정상화)

### DIFF
--- a/src/app.feature/auth/screen/SignUpScreen.tsx
+++ b/src/app.feature/auth/screen/SignUpScreen.tsx
@@ -4,6 +4,7 @@ import { ConfirmDialog, Icon, StepIndicator, Text } from '@1d1s/design-system';
 import { Form } from '@component/ui/Form';
 import { MEMBER_QUERY_KEYS } from '@feature/member/consts/queryKeys';
 import { notifyApiError } from '@module/api/errorNotify';
+import { putToStorage } from '@module/api/presignedUpload';
 import { toast } from '@module/providers/toast';
 import { authStorage } from '@module/utils/auth';
 import { cn } from '@module/utils/cn';
@@ -73,12 +74,7 @@ export function SignUpScreen(): React.ReactElement {
           fileName: values.img.name,
           fileType: values.img.type,
         });
-        // iOS에서 HEIC 등 일부 포맷은 file.type이 빈 문자열일 수 있음
-        await fetch(presigned.presignedUrl, {
-          method: 'PUT',
-          body: values.img,
-          headers: { 'Content-Type': values.img.type || 'image/jpeg' },
-        });
+        await putToStorage(presigned.presignedUrl, values.img);
         profileImageKey = presigned.objectKey;
       }
 

--- a/src/app.feature/challenge/write/components/ChallengeCreateBannerSection.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeCreateBannerSection.tsx
@@ -9,6 +9,7 @@ import {
 import { ImageCropDialog } from '@component/ImageCropDialog';
 import { CATEGORY_OPTIONS } from '@constants/categories';
 import { apiClient } from '@module/api/client';
+import { putToStorage } from '@module/api/presignedUpload';
 import { requestData } from '@module/api/request';
 import { useState } from 'react';
 import { Control, useFormContext, useWatch } from 'react-hook-form';
@@ -82,12 +83,7 @@ export function ChallengeCreateBannerSection(): React.ReactElement {
         data: { fileName: file.name, fileType: file.type },
       });
 
-      // iOS HEIC 등 일부 포맷은 file.type 이 빈 문자열일 수 있어 fallback 적용.
-      await fetch(presignedUrl, {
-        method: 'PUT',
-        body: file,
-        headers: { 'Content-Type': file.type || 'image/jpeg' },
-      });
+      await putToStorage(presignedUrl, file);
 
       setValue('thumbnailImageKey', objectKey);
       setValue('thumbnailPreviewUrl', blobUrl);

--- a/src/app.feature/challenge/write/components/ChallengeEditBannerSection.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeEditBannerSection.tsx
@@ -9,6 +9,7 @@ import {
 import { ImageCropDialog } from '@component/ImageCropDialog';
 import { CATEGORY_OPTIONS } from '@constants/categories';
 import { apiClient } from '@module/api/client';
+import { putToStorage } from '@module/api/presignedUpload';
 import { requestData } from '@module/api/request';
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -58,11 +59,7 @@ export function ChallengeEditBannerSection(): React.ReactElement {
         data: { fileName: file.name, fileType: file.type },
       });
 
-      await fetch(presignedUrl, {
-        method: 'PUT',
-        body: file,
-        headers: { 'Content-Type': file.type || 'image/jpeg' },
-      });
+      await putToStorage(presignedUrl, file);
 
       setValue('thumbnailImageKey', objectKey, { shouldDirty: true });
       setValue('thumbnailPreviewUrl', blobUrl, { shouldDirty: true });

--- a/src/app.feature/member/api/memberApi.ts
+++ b/src/app.feature/member/api/memberApi.ts
@@ -3,6 +3,7 @@ import {
   normalizeDiaryItems,
 } from '@feature/diary/shared/utils/normalizeDiary';
 import { apiClient, publicApiClient } from '@module/api/client';
+import { putToStorage } from '@module/api/presignedUpload';
 import {
   buildQueryString,
   requestBody,
@@ -89,13 +90,7 @@ export const memberApi = {
       data: { fileName: file.name, fileType: file.type },
     });
 
-    // iOS에서 HEIC 등 일부 포맷은 file.type이 빈 문자열일 수 있음
-    // Content-Type이 없으면 S3 서명 불일치(403)가 발생하므로 fallback 적용
-    await fetch(presignedUrl, {
-      method: 'PUT',
-      body: file,
-      headers: { 'Content-Type': file.type || 'image/jpeg' },
-    });
+    await putToStorage(presignedUrl, file);
 
     await requestData<void>(apiClient, {
       url: '/member/profile-image',

--- a/src/app.module/api/presignedUpload.ts
+++ b/src/app.module/api/presignedUpload.ts
@@ -29,14 +29,27 @@ async function requestPresignedUrls(
   );
 }
 
-// ② 스토리지 직접 PUT 업로드. Content-Type 이 ①에서 보낸 fileType 과
-// 정확히 일치해야 S3 가 403 을 내지 않는다. 여기선 ①의 fileType 에
-// file.type 을 넣었으므로 동일 file.type 으로 PUT 하면 항상 일치한다.
-async function putToStorage(uploadUrl: string, file: File): Promise<void> {
+// presigned PUT 시 S3 오브젝트에 저장되는 캐시 정책. 백엔드가 presigned
+// 서명에 이 값을 포함하므로, PUT 헤더도 한 글자까지 정확히 일치해야 S3 가
+// 403 SignatureDoesNotMatch 를 내지 않는다. 업로드 URL 은 UUID 키라 내용이
+// 바뀌지 않으므로 immutable + 1년 max-age 가 안전하다.
+const IMAGE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+// presigned URL 로 스토리지에 직접 PUT 업로드하는 공용 헬퍼. 모든 이미지
+// 업로드(단건/배치)가 이 함수를 지나가 Content-Type·Cache-Control 헤더를
+// 한 곳에서만 관리한다. Content-Type 은 ①에서 서명한 fileType 과 일치해야
+// 하며, HEIC 등 file.type 이 빈 문자열이면 image/jpeg 로 fallback 한다.
+export async function putToStorage(
+  uploadUrl: string,
+  file: File
+): Promise<void> {
   const response = await fetch(uploadUrl, {
     method: 'PUT',
     body: file,
-    headers: { 'Content-Type': file.type },
+    headers: {
+      'Content-Type': file.type || 'image/jpeg',
+      'Cache-Control': IMAGE_CACHE_CONTROL,
+    },
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## 요약
S3 이미지 오브젝트에 `Cache-Control` 헤더가 없어 브라우저가 이미지를 매번 재검증(304 왕복)하던 문제 수정.

## 변경
- presigned PUT 헤더에 `Cache-Control: public, max-age=31536000, immutable` 추가 (백엔드 서명 값과 일치)
- 단건/배치 5개 업로드 경로를 `putToStorage` 공용 헬퍼로 통일 — 캐시 문자열 단일 출처

## 배포 주의
- 백엔드가 presigned 서명에 `Cache-Control` 포함 후 **동시 배포** 필요. 백엔드만 먼저 나가면 옛 프론트 PUT이 403.
- 검증: `curl -sI <object-url> | grep -i cache-control`