### PR TITLE
fix: 이미지/일지 업로드 요청 타임아웃 상향

### DIFF
--- a/src/app.feature/diary/write/api/diaryWriteApi.ts
+++ b/src/app.feature/diary/write/api/diaryWriteApi.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@module/api/client';
+import { API_UPLOAD_TIMEOUT_MS } from '@module/api/config';
 import { requestData } from '@module/api/request';
 
 import {
@@ -16,6 +17,7 @@ export const diaryWriteApi = {
       url: '/diaries',
       method: 'POST',
       data,
+      timeout: API_UPLOAD_TIMEOUT_MS,
     }),
 
   // 다이어리 수정하기
@@ -27,6 +29,7 @@ export const diaryWriteApi = {
       url: `/diaries/${id}`,
       method: 'PATCH',
       data,
+      timeout: API_UPLOAD_TIMEOUT_MS,
     }),
 
   // 다이어리 리포트 생성

--- a/src/app.module/api/client.ts
+++ b/src/app.module/api/client.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosInstance } from 'axios';
 
-import { API_BASE_URL } from './config';
+import { API_BASE_URL, API_DEFAULT_TIMEOUT_MS } from './config';
 import { attachInterceptors, type ClientOptions } from './interceptors';
 import { refreshAccessTokenOnce } from './tokenRefresh';
 
@@ -8,7 +8,7 @@ const createClient = (options: ClientOptions): AxiosInstance =>
   attachInterceptors(
     axios.create({
       baseURL: API_BASE_URL,
-      timeout: 10000,
+      timeout: API_DEFAULT_TIMEOUT_MS,
       maxRedirects: 0,
       withCredentials: true,
     }),
@@ -26,7 +26,7 @@ export const publicApiClient = createClient({
 // auth/token, auth/logout 직접 호출용 (순환 임포트 방지 - auth-api.ts가 client.ts를 임포트함)
 export const tokenClient = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10000,
+  timeout: API_DEFAULT_TIMEOUT_MS,
   withCredentials: true,
 });
 
@@ -35,7 +35,7 @@ export const tokenClient = axios.create({
 export const silentAuthClient: AxiosInstance = (() => {
   const instance = axios.create({
     baseURL: API_BASE_URL,
-    timeout: 10000,
+    timeout: API_DEFAULT_TIMEOUT_MS,
     withCredentials: true,
   });
 

--- a/src/app.module/api/config.ts
+++ b/src/app.module/api/config.ts
@@ -16,3 +16,10 @@ const resolveApiBaseUrl = (): string => {
 };
 
 export const API_BASE_URL = resolveApiBaseUrl();
+
+// 일반 REST 요청(JSON) axios 기본 타임아웃.
+export const API_DEFAULT_TIMEOUT_MS = 10000;
+
+// 이미지 파일 PUT 업로드·일지 저장처럼 느려질 수 있는 요청용 타임아웃.
+// 큰 파일이 느린 네트워크에서 끊기지 않도록 넉넉히 잡는다.
+export const API_UPLOAD_TIMEOUT_MS = 120000;

--- a/src/app.module/api/presignedUpload.ts
+++ b/src/app.module/api/presignedUpload.ts
@@ -1,6 +1,7 @@
 import { compressImageFile } from '@/app.lib/compressImage';
 
 import { apiClient } from './client';
+import { API_UPLOAD_TIMEOUT_MS } from './config';
 import { requestData } from './request';
 
 export interface PresignedUrlItem {
@@ -33,14 +34,24 @@ async function requestPresignedUrls(
 // 정확히 일치해야 S3 가 403 을 내지 않는다. 여기선 ①의 fileType 에
 // file.type 을 넣었으므로 동일 file.type 으로 PUT 하면 항상 일치한다.
 async function putToStorage(uploadUrl: string, file: File): Promise<void> {
-  const response = await fetch(uploadUrl, {
-    method: 'PUT',
-    body: file,
-    headers: { 'Content-Type': file.type },
-  });
+  // raw fetch 는 기본 타임아웃이 없어 느린/멈춘 업로드가 무한정 hang 될 수
+  // 있다. AbortController 로 큰 파일도 견딜 만큼 긴 상한만 건다.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_UPLOAD_TIMEOUT_MS);
 
-  if (!response.ok) {
-    throw new Error(`이미지 업로드 실패 (${response.status})`);
+  try {
+    const response = await fetch(uploadUrl, {
+      method: 'PUT',
+      body: file,
+      headers: { 'Content-Type': file.type },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`이미지 업로드 실패 (${response.status})`);
+    }
+  } finally {
+    clearTimeout(timer);
   }
 }
 


### PR DESCRIPTION
## 요약
presigned 이미지 업로드가 느릴 때 타임아웃으로 끊기는 문제를 해결한다.

- axios 기본 타임아웃(10s)을 상수화(`API_DEFAULT_TIMEOUT_MS`)
- 업로드/일지 저장용 별도 타임아웃 `API_UPLOAD_TIMEOUT_MS = 120s` 신설
- 실제 파일 PUT 업로드(raw fetch)에 없던 타임아웃을 `AbortController`로 추가(120s) — 멈춘 업로드 무한 hang 방지
- 일지 저장 `POST/PATCH /diaries`에 per-request 120s 적용

## 변경 파일
- `src/app.module/api/config.ts`
- `src/app.module/api/client.ts`
- `src/app.module/api/presignedUpload.ts`
- `src/app.feature/diary/write/api/diaryWriteApi.ts`

## 검증
- tsc / eslint 로컬 통과

> 참고: 원래 PR #116 은 이미 머지됨. 이 커밋은 그 이후 추가된 후속 수정이라 별도 PR 로 develop 반영.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request reliability by applying consistent timeout settings across API calls.
  * Added a longer timeout for file uploads to reduce failures during slow transfers.
  * Upload requests now stop automatically if they exceed the allowed time, helping prevent hanging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->