### PR TITLE
release: 업로드 타임아웃 상향 프로덕션 배포

### DIFF
--- a/src/app.feature/diary/write/api/diaryWriteApi.ts
+++ b/src/app.feature/diary/write/api/diaryWriteApi.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@module/api/client';
+import { UPLOAD_TIMEOUT_MS } from '@module/api/config';
 import { requestData } from '@module/api/request';
 
 import {
@@ -16,6 +17,8 @@ export const diaryWriteApi = {
       url: '/diaries',
       method: 'POST',
       data,
+      // 이미지 다수 포함 시 저장이 느려 기본 10초로는 부족.
+      timeout: UPLOAD_TIMEOUT_MS,
     }),
 
   // 다이어리 수정하기
@@ -27,6 +30,7 @@ export const diaryWriteApi = {
       url: `/diaries/${id}`,
       method: 'PATCH',
       data,
+      timeout: UPLOAD_TIMEOUT_MS,
     }),
 
   // 다이어리 리포트 생성

--- a/src/app.module/api/client.ts
+++ b/src/app.module/api/client.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosInstance } from 'axios';
 
-import { API_BASE_URL } from './config';
+import { API_BASE_URL, DEFAULT_TIMEOUT_MS } from './config';
 import { attachInterceptors, type ClientOptions } from './interceptors';
 import { refreshAccessTokenOnce } from './tokenRefresh';
 
@@ -8,7 +8,7 @@ const createClient = (options: ClientOptions): AxiosInstance =>
   attachInterceptors(
     axios.create({
       baseURL: API_BASE_URL,
-      timeout: 10000,
+      timeout: DEFAULT_TIMEOUT_MS,
       maxRedirects: 0,
       withCredentials: true,
     }),
@@ -26,7 +26,7 @@ export const publicApiClient = createClient({
 // auth/token, auth/logout 직접 호출용 (순환 임포트 방지 - auth-api.ts가 client.ts를 임포트함)
 export const tokenClient = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10000,
+  timeout: DEFAULT_TIMEOUT_MS,
   withCredentials: true,
 });
 
@@ -35,7 +35,7 @@ export const tokenClient = axios.create({
 export const silentAuthClient: AxiosInstance = (() => {
   const instance = axios.create({
     baseURL: API_BASE_URL,
-    timeout: 10000,
+    timeout: DEFAULT_TIMEOUT_MS,
     withCredentials: true,
   });
 

--- a/src/app.module/api/config.ts
+++ b/src/app.module/api/config.ts
@@ -16,3 +16,10 @@ const resolveApiBaseUrl = (): string => {
 };
 
 export const API_BASE_URL = resolveApiBaseUrl();
+
+// presigned 발급 등 짧은 JSON 요청용 기본 타임아웃.
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+// 파일 PUT 업로드·일지 저장 등 느린 요청용 타임아웃. 이미지 여러 장을
+// 스토리지에 올리는 동안 기본 10초로는 부족해 넉넉히 잡는다.
+export const UPLOAD_TIMEOUT_MS = 120_000;

--- a/src/app.module/api/presignedUpload.ts
+++ b/src/app.module/api/presignedUpload.ts
@@ -1,6 +1,7 @@
 import { compressImageFile } from '@/app.lib/compressImage';
 
 import { apiClient } from './client';
+import { UPLOAD_TIMEOUT_MS } from './config';
 import { requestData } from './request';
 
 export interface PresignedUrlItem {
@@ -43,17 +44,27 @@ export async function putToStorage(
   uploadUrl: string,
   file: File
 ): Promise<void> {
-  const response = await fetch(uploadUrl, {
-    method: 'PUT',
-    body: file,
-    headers: {
-      'Content-Type': file.type || 'image/jpeg',
-      'Cache-Control': IMAGE_CACHE_CONTROL,
-    },
-  });
+  // 이미지 여러 장 업로드가 무한정 매달리지 않게 120초 타임아웃을 건다.
+  // raw fetch 는 axios 처럼 timeout 옵션이 없어 AbortController 로 끊는다.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
 
-  if (!response.ok) {
-    throw new Error(`이미지 업로드 실패 (${response.status})`);
+  try {
+    const response = await fetch(uploadUrl, {
+      method: 'PUT',
+      body: file,
+      headers: {
+        'Content-Type': file.type || 'image/jpeg',
+        'Cache-Control': IMAGE_CACHE_CONTROL,
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`이미지 업로드 실패 (${response.status})`);
+    }
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
## 📌 Summary

develop → main 승격. 이번 배포로 새로 나가는 변경은 **이미지 업로드·일지 저장 요청 타임아웃 상향**입니다.

## ✅ 작업 내용

- 업로드 타임아웃 상향 (#121)
  - `UPLOAD_TIMEOUT_MS`(120초) 도입 — presigned PUT 업로드·일지 저장(createDiary/updateDiary)에 적용
  - presigned 발급 등 짧은 JSON 요청은 기존 10초(`DEFAULT_TIMEOUT_MS`) 유지

## 📎 기타

- presigned 업로드 전환·대표 썸네일은 직전 승격(#119)에서 이미 프로덕션 반영됨 → 이번 diff에는 미포함
- `main..develop` diff: 4파일 (+36 / -14)