### PR TITLE
feat: 챌린지 참여자 등수/스트릭 조회 대응

### DIFF
--- a/src/app.feature/challenge/board/consts/queryKeys.ts
+++ b/src/app.feature/challenge/board/consts/queryKeys.ts
@@ -1,6 +1,7 @@
 import {
   ChallengeListParams,
   MemberChallengesParams,
+  ParticipantListParams,
   RandomChallengesParams,
 } from '../type/challenge';
 
@@ -29,4 +30,7 @@ export const CHALLENGE_QUERY_KEYS = {
       'infinite',
       params,
     ] as const,
+  participants: () => [...CHALLENGE_QUERY_KEYS.all, 'participants'] as const,
+  participantList: (challengeId: number, params?: ParticipantListParams) =>
+    [...CHALLENGE_QUERY_KEYS.participants(), challengeId, params] as const,
 };

--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -88,12 +88,41 @@ export interface Participant {
   status: ParticipantStatus;
   // 참여자별 목표 — FIXED 는 공통 목표, FLEXIBLE 는 본인이 설정한 목표.
   goals?: ChallengeGoal[];
+  // 등수 — 시작 전이거나 순위 산정 대상이 아니면 null.
+  rank: number | null;
+  // 연속 달성일수 / 완료한 목표 개수
+  streak: number;
+  completedGoalCount: number;
+}
+
+// 참여자 목록 정렬 — 참여순(기본) / 등수순
+export type ParticipantSort = 'PARTICIPATION' | 'RANK';
+
+export interface ParticipantListParams {
+  sort?: ParticipantSort;
+  page?: number;
+  size?: number;
+}
+
+// 오프셋 페이지네이션 공통 페이지 정보 (챌린지 일지 목록과 동일 형태)
+export interface OffsetPageInfo {
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNextPage: boolean;
+}
+
+export interface ParticipantListResponse {
+  items: Participant[];
+  pageInfo: OffsetPageInfo;
 }
 
 export interface ChallengeDetailResponse {
   challengeSummary: ChallengeSummary;
   challengeDetail: ChallengeDetail;
   challengeGoals: ChallengeGoal[];
+  // 챌린지 상세는 등수순 상위 5명만 내려준다(각 항목에 rank 포함).
   participants: Participant[];
 }
 

--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -102,6 +102,8 @@ export interface ParticipantListParams {
   sort?: ParticipantSort;
   page?: number;
   size?: number;
+  // 상태 필터 (다중). 미지정 시 서버 기본(호스트: 전체 / 그 외: 승인자만).
+  status?: ParticipantStatus[];
 }
 
 // 오프셋 페이지네이션 공통 페이지 정보 (챌린지 일지 목록과 동일 형태)

--- a/src/app.feature/challenge/detail/api/challengeDetailApi.ts
+++ b/src/app.feature/challenge/detail/api/challengeDetailApi.ts
@@ -1,5 +1,9 @@
 import { apiClient } from '@module/api/client';
-import { requestBody, requestData } from '@module/api/request';
+import {
+  buildQueryString,
+  requestBody,
+  requestData,
+} from '@module/api/request';
 
 import {
   ChallengeDetailResponse,
@@ -24,26 +28,25 @@ export const challengeDetailApi = {
       method: 'GET',
     }),
 
-  // 챌린지 참여자 목록 조회 (오프셋 페이지네이션 + 정렬)
+  // 챌린지 참여자 목록 조회 (오프셋 페이지네이션 + 정렬 + 상태 필터)
   getParticipants: async (
     challengeId: number,
     params: ParticipantListParams = {}
   ): Promise<ParticipantListResponse> => {
-    const requestParams: Record<string, string | number> = {};
-    if (params.sort !== undefined) {
-      requestParams.sort = params.sort;
-    }
-    if (params.page !== undefined) {
-      requestParams.page = params.page;
-    }
-    if (params.size !== undefined) {
-      requestParams.size = params.size;
-    }
+    // buildQueryString 이 undefined 를 생략하고 배열(status)을 같은 키
+    // 반복(status=HOST&status=PARTICIPANT)으로 직렬화한다.
+    const query = buildQueryString({
+      sort: params.sort,
+      page: params.page,
+      size: params.size,
+      status: params.status,
+    });
 
     return requestData<ParticipantListResponse>(apiClient, {
-      url: `/challenges/${challengeId}/participants`,
+      url: query
+        ? `/challenges/${challengeId}/participants?${query}`
+        : `/challenges/${challengeId}/participants`,
       method: 'GET',
-      params: Object.keys(requestParams).length > 0 ? requestParams : undefined,
     });
   },
 

--- a/src/app.feature/challenge/detail/api/challengeDetailApi.ts
+++ b/src/app.feature/challenge/detail/api/challengeDetailApi.ts
@@ -5,6 +5,8 @@ import {
   ChallengeDetailResponse,
   JoinChallengeRequest,
   JoinChallengeResponse,
+  ParticipantListParams,
+  ParticipantListResponse,
   PokeChallengeRequest,
   PokeChallengeResponse,
   VerifyChallengePasswordRequest,
@@ -21,6 +23,29 @@ export const challengeDetailApi = {
       url: `/challenges/${challengeId}`,
       method: 'GET',
     }),
+
+  // 챌린지 참여자 목록 조회 (오프셋 페이지네이션 + 정렬)
+  getParticipants: async (
+    challengeId: number,
+    params: ParticipantListParams = {}
+  ): Promise<ParticipantListResponse> => {
+    const requestParams: Record<string, string | number> = {};
+    if (params.sort !== undefined) {
+      requestParams.sort = params.sort;
+    }
+    if (params.page !== undefined) {
+      requestParams.page = params.page;
+    }
+    if (params.size !== undefined) {
+      requestParams.size = params.size;
+    }
+
+    return requestData<ParticipantListResponse>(apiClient, {
+      url: `/challenges/${challengeId}/participants`,
+      method: 'GET',
+      params: Object.keys(requestParams).length > 0 ? requestParams : undefined,
+    });
+  },
 
   // 챌린지 신청하기
   joinChallenge: async (

--- a/src/app.feature/challenge/detail/components/ChallengeLeaderboardCard.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeLeaderboardCard.tsx
@@ -26,12 +26,20 @@ interface LeaderboardEntry {
   profileImg?: string | null;
   isHost: boolean;
   goals?: LeaderboardEntryGoal[];
+  // 등수 — 시작 전/순위 미산정이면 null. 양수일 때만 배지로 노출한다.
+  rank?: number | null;
+  streak?: number;
+  completedGoalCount?: number;
 }
 
 interface ChallengeLeaderboardCardProps {
   entries: LeaderboardEntry[];
   onMemberClick?(memberId: number): void;
   maxRows?: number;
+  // 전체 참여자 수 — "전체 보기" 노출 여부 판단(상세는 상위 5명만 내려온다).
+  totalCount?: number;
+  // 전체 참여자 목록 화면으로 이동. 지정 시 "전체 보기"가 모달 대신 이동한다.
+  onShowAll?(): void;
   // 찌르기: 내가 참여 중 + 진행 중 + 오늘 일지 작성 완료일 때만 true
   canPoke?: boolean;
   // 내 행에는 찌르기 버튼을 노출하지 않기 위한 현재 로그인 사용자 식별값.
@@ -60,6 +68,8 @@ function MemberRow({
 }: MemberRowProps): React.ReactElement {
   const hasGoals = (entry.goals?.length ?? 0) > 0;
 
+  const hasRank = typeof entry.rank === 'number' && entry.rank > 0;
+
   return (
     <div className="flex items-center gap-1">
       <button
@@ -71,18 +81,44 @@ function MemberRow({
           'hover:bg-gray-50'
         )}
       >
+        {hasRank ? (
+          <span
+            className={cn(
+              'flex h-5 w-5 shrink-0 items-center justify-center',
+              'text-[12px] font-extrabold tabular-nums',
+              entry.rank === 1
+                ? 'text-main-800'
+                : entry.rank && entry.rank <= 3
+                  ? 'text-gray-700'
+                  : 'text-gray-400'
+            )}
+          >
+            {entry.rank}
+          </span>
+        ) : null}
         <CircleAvatar
           size="sm"
           imageUrl={entry.profileImg ?? undefined}
           tone="cream"
         />
-        <Text
-          size="caption1"
-          weight="bold"
-          className="flex-1 truncate text-gray-800"
-        >
-          {entry.nickname}
-        </Text>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <Text
+            size="caption1"
+            weight="bold"
+            className="truncate text-gray-800"
+          >
+            {entry.nickname}
+          </Text>
+          {hasRank ? (
+            <Text
+              size="caption2"
+              weight="regular"
+              className="truncate text-gray-400"
+            >
+              {entry.streak ?? 0}일 연속 · 목표 {entry.completedGoalCount ?? 0}개
+            </Text>
+          ) : null}
+        </div>
         {entry.isHost ? (
           <span
             className={cn(
@@ -126,6 +162,8 @@ export function ChallengeLeaderboardCard({
   entries,
   onMemberClick,
   maxRows = 5,
+  totalCount,
+  onShowAll,
   canPoke = false,
   currentMemberId = null,
   currentNickname = null,
@@ -136,9 +174,11 @@ export function ChallengeLeaderboardCard({
   const rows = entries.slice(0, maxRows);
   // 목표 보기 다이얼로그 — 선택된 참여자만 보관해 화면 상태와 분리한다.
   const [goalsOf, setGoalsOf] = useState<LeaderboardEntry | null>(null);
-  // 참여자 5명 이상이면 전체 목록을 모달로 펼친다.
+  // 참여자 5명 이상이면 전체 목록을 모달로 펼친다(레거시 폴백).
   const [showAll, setShowAll] = useState(false);
-  const canShowAll = entries.length >= 5;
+  const displayCount = totalCount ?? entries.length;
+  // onShowAll 이 있으면 전체 목록 화면으로 이동, 없으면 모달로 펼친다.
+  const canShowAll = onShowAll ? displayCount > maxRows : entries.length >= 5;
 
   return (
     <Card radius="lg" className="p-5">
@@ -147,15 +187,15 @@ export function ChallengeLeaderboardCard({
           참여자
         </Text>
         <div className="flex items-center gap-2">
-          {entries.length > 0 ? (
+          {displayCount > 0 ? (
             <Text size="caption2" weight="medium" className="text-gray-500">
-              {entries.length}명
+              {displayCount}명
             </Text>
           ) : null}
           {canShowAll ? (
             <button
               type="button"
-              onClick={() => setShowAll(true)}
+              onClick={() => (onShowAll ? onShowAll() : setShowAll(true))}
               className={cn(
                 'shrink-0 rounded-full bg-gray-100 px-2.5 py-1',
                 'text-[11px] font-bold text-gray-600',

--- a/src/app.feature/challenge/detail/components/ChallengeLeaderboardCard.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeLeaderboardCard.tsx
@@ -174,11 +174,9 @@ export function ChallengeLeaderboardCard({
   const rows = entries.slice(0, maxRows);
   // 목표 보기 다이얼로그 — 선택된 참여자만 보관해 화면 상태와 분리한다.
   const [goalsOf, setGoalsOf] = useState<LeaderboardEntry | null>(null);
-  // 참여자 5명 이상이면 전체 목록을 모달로 펼친다(레거시 폴백).
-  const [showAll, setShowAll] = useState(false);
   const displayCount = totalCount ?? entries.length;
-  // onShowAll 이 있으면 전체 목록 화면으로 이동, 없으면 모달로 펼친다.
-  const canShowAll = onShowAll ? displayCount > maxRows : entries.length >= 5;
+  // "전체 보기"는 전체 참여자 목록 화면으로 이동한다(onShowAll 제공 시에만).
+  const canShowAll = Boolean(onShowAll) && displayCount > maxRows;
 
   return (
     <Card radius="lg" className="p-5">
@@ -195,7 +193,7 @@ export function ChallengeLeaderboardCard({
           {canShowAll ? (
             <button
               type="button"
-              onClick={() => (onShowAll ? onShowAll() : setShowAll(true))}
+              onClick={onShowAll}
               className={cn(
                 'shrink-0 rounded-full bg-gray-100 px-2.5 py-1',
                 'text-[11px] font-bold text-gray-600',
@@ -277,45 +275,6 @@ export function ChallengeLeaderboardCard({
           })}
         </ul>
       )}
-
-      <Dialog
-        open={showAll}
-        onOpenChange={setShowAll}
-      >
-        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[420px]">
-          <DialogHeader className="flex-col items-start gap-1.5 pb-2">
-            <DialogTitle className="text-[17px] font-extrabold tracking-[-0.3px] text-gray-900">
-              참여자 {entries.length}명
-            </DialogTitle>
-          </DialogHeader>
-          <DialogBody>
-            <ul className="flex max-h-[60vh] flex-col overflow-y-auto">
-              {entries.map((entry, index) => {
-                const isLast = index === entries.length - 1;
-
-                return (
-                  <li
-                    key={entry.participantId}
-                    className={cn(!isLast && 'border-b border-gray-100')}
-                  >
-                    <MemberRow
-                      entry={entry}
-                      onSelect={() => {
-                        setShowAll(false);
-                        onMemberClick?.(entry.memberId);
-                      }}
-                      onGoals={() => {
-                        setShowAll(false);
-                        setGoalsOf(entry);
-                      }}
-                    />
-                  </li>
-                );
-              })}
-            </ul>
-          </DialogBody>
-        </DialogContent>
-      </Dialog>
 
       <Dialog
         open={goalsOf !== null}

--- a/src/app.feature/challenge/detail/hooks/useChallengeMutations.ts
+++ b/src/app.feature/challenge/detail/hooks/useChallengeMutations.ts
@@ -62,6 +62,7 @@ export function useJoinChallenge(): UseMutationResult<
       invalidateAll(queryClient, [
         CHALLENGE_QUERY_KEYS.detail(challengeId),
         CHALLENGE_QUERY_KEYS.lists(),
+        CHALLENGE_QUERY_KEYS.participants(),
       ]);
     },
   });
@@ -83,6 +84,7 @@ export function useVerifyChallengePassword(): UseMutationResult<
       invalidateAll(queryClient, [
         CHALLENGE_QUERY_KEYS.detail(challengeId),
         CHALLENGE_QUERY_KEYS.lists(),
+        CHALLENGE_QUERY_KEYS.participants(),
       ]);
     },
   });
@@ -110,9 +112,10 @@ export function useAcceptParticipant(): UseMutationResult<void, Error, number> {
     mutationFn: (participantId: number) =>
       challengeDetailApi.acceptParticipant(participantId),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: CHALLENGE_QUERY_KEYS.details(),
-      });
+      invalidateAll(queryClient, [
+        CHALLENGE_QUERY_KEYS.details(),
+        CHALLENGE_QUERY_KEYS.participants(),
+      ]);
     },
   });
 }
@@ -125,9 +128,10 @@ export function useRejectParticipant(): UseMutationResult<void, Error, number> {
     mutationFn: (participantId: number) =>
       challengeDetailApi.rejectParticipant(participantId),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: CHALLENGE_QUERY_KEYS.details(),
-      });
+      invalidateAll(queryClient, [
+        CHALLENGE_QUERY_KEYS.details(),
+        CHALLENGE_QUERY_KEYS.participants(),
+      ]);
     },
   });
 }
@@ -144,6 +148,7 @@ export function useLeaveChallenge(): UseMutationResult<void, Error, number> {
         CHALLENGE_QUERY_KEYS.detail(challengeId),
         CHALLENGE_QUERY_KEYS.lists(),
         CHALLENGE_QUERY_KEYS.members(),
+        CHALLENGE_QUERY_KEYS.participants(),
       ]);
     },
   });

--- a/src/app.feature/challenge/detail/hooks/useChallengeParticipantQueries.ts
+++ b/src/app.feature/challenge/detail/hooks/useChallengeParticipantQueries.ts
@@ -23,7 +23,8 @@ const PENDING_FETCH_SIZE = 100;
 export function useChallengeParticipantsInfinite(
   challengeId: number,
   sort: ParticipantSort,
-  size?: number
+  size?: number,
+  enabled = true
 ): UseInfiniteQueryResult<InfiniteData<ParticipantListResponse>, Error> {
   return useInfiniteQuery({
     queryKey: CHALLENGE_QUERY_KEYS.participantList(challengeId, { sort, size }),
@@ -36,7 +37,7 @@ export function useChallengeParticipantsInfinite(
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>
       lastPage.pageInfo.hasNextPage ? lastPage.pageInfo.page + 1 : undefined,
-    enabled: Boolean(challengeId),
+    enabled: enabled && Boolean(challengeId),
   });
 }
 

--- a/src/app.feature/challenge/detail/hooks/useChallengeParticipantQueries.ts
+++ b/src/app.feature/challenge/detail/hooks/useChallengeParticipantQueries.ts
@@ -1,0 +1,33 @@
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+
+import { CHALLENGE_QUERY_KEYS } from '../../board/consts/queryKeys';
+import {
+  ParticipantListResponse,
+  ParticipantSort,
+} from '../../board/type/challenge';
+import { challengeDetailApi } from '../api/challengeDetailApi';
+
+// 챌린지 참여자 목록 조회 (오프셋 페이지네이션 무한 스크롤 + 정렬)
+export function useChallengeParticipantsInfinite(
+  challengeId: number,
+  sort: ParticipantSort,
+  size?: number
+): UseInfiniteQueryResult<InfiniteData<ParticipantListResponse>, Error> {
+  return useInfiniteQuery({
+    queryKey: CHALLENGE_QUERY_KEYS.participantList(challengeId, { sort, size }),
+    queryFn: ({ pageParam }) =>
+      challengeDetailApi.getParticipants(challengeId, {
+        sort,
+        page: pageParam,
+        size,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.pageInfo.hasNextPage ? lastPage.pageInfo.page + 1 : undefined,
+    enabled: Boolean(challengeId),
+  });
+}

--- a/src/app.feature/challenge/detail/hooks/useChallengeParticipantQueries.ts
+++ b/src/app.feature/challenge/detail/hooks/useChallengeParticipantQueries.ts
@@ -2,14 +2,22 @@ import {
   InfiniteData,
   useInfiniteQuery,
   UseInfiniteQueryResult,
+  useQuery,
+  UseQueryResult,
 } from '@tanstack/react-query';
 
 import { CHALLENGE_QUERY_KEYS } from '../../board/consts/queryKeys';
 import {
+  Participant,
   ParticipantListResponse,
   ParticipantSort,
 } from '../../board/type/challenge';
 import { challengeDetailApi } from '../api/challengeDetailApi';
+
+// 대기 승인 카드는 페이지네이션 없이 신청자 전원을 한 번에 보여준다.
+// ponytail: 신청 대기자는 보통 소수라 단일 페이지로 충분. 100명 초과
+// 챌린지가 생기면 무한스크롤로 승격.
+const PENDING_FETCH_SIZE = 100;
 
 // 챌린지 참여자 목록 조회 (오프셋 페이지네이션 무한 스크롤 + 정렬)
 export function useChallengeParticipantsInfinite(
@@ -29,5 +37,27 @@ export function useChallengeParticipantsInfinite(
     getNextPageParam: (lastPage) =>
       lastPage.pageInfo.hasNextPage ? lastPage.pageInfo.page + 1 : undefined,
     enabled: Boolean(challengeId),
+  });
+}
+
+// 호스트 대기 승인 카드용 — 신청 대기(PENDING) 참여자 목록.
+// 호스트가 아닐 땐 서버가 빈 페이지를 주므로 enabled 로 호출 자체를 막는다.
+export function useChallengePendingParticipants(
+  challengeId: number,
+  enabled = true
+): UseQueryResult<Participant[], Error> {
+  return useQuery({
+    queryKey: CHALLENGE_QUERY_KEYS.participantList(challengeId, {
+      status: ['PENDING'],
+      size: PENDING_FETCH_SIZE,
+    }),
+    queryFn: async () => {
+      const response = await challengeDetailApi.getParticipants(challengeId, {
+        status: ['PENDING'],
+        size: PENDING_FETCH_SIZE,
+      });
+      return response.items;
+    },
+    enabled: enabled && Boolean(challengeId),
   });
 }

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -1216,7 +1216,14 @@ export function ChallengeDetailScreen({
                   isHost: participant.status === 'HOST',
                   // 고정 목표는 전원 공통이라 참여자별로 볼 의미가 없다.
                   goals: isFreeChallenge ? participant.goals : undefined,
+                  rank: participant.rank,
+                  streak: participant.streak,
+                  completedGoalCount: participant.completedGoalCount,
                 }))}
+                totalCount={summaryParticipantCnt}
+                onShowAll={() =>
+                  router.push(`/challenge/${id}/participants`)
+                }
                 onMemberClick={(memberId) => router.push(`/member/${memberId}`)}
                 canPoke={canPokeMembers}
                 currentMemberId={currentMemberId}

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -73,6 +73,7 @@ import {
   useUpdateParticipantGoal,
   useVerifyChallengePassword,
 } from '../hooks/useChallengeMutations';
+import { useChallengePendingParticipants } from '../hooks/useChallengeParticipantQueries';
 import { ChallengeDiaryItem } from '../type/challengeDiary';
 import { buildHeroGradient, getCategoryAccent } from '../utils/challengeAccent';
 import {
@@ -246,12 +247,6 @@ export function ChallengeDetailScreen({
       Math.min(100, Math.max(0, detail?.participationRate ?? 0)) * 10
     ) / 10;
 
-  const pendingParticipants = useMemo(
-    () =>
-      participants.filter((participant) => participant.status === 'PENDING'),
-    [participants]
-  );
-
   const activeParticipants = useMemo(
     () =>
       participants.filter((participant) =>
@@ -262,6 +257,10 @@ export function ChallengeDetailScreen({
 
   const myStatus = detail?.myStatus ?? 'NONE';
   const isHost = myStatus === 'HOST';
+  // 상세 응답 participants 는 등수순 상위 5명이라 PENDING 이 빠진다.
+  // 대기 승인 카드는 status=PENDING 목록을 호스트일 때만 별도 조회한다.
+  const { data: pendingParticipants = EMPTY_PARTICIPANTS } =
+    useChallengePendingParticipants(challengeId, isHost);
   const isPending = myStatus === 'PENDING';
   const isParticipating = PARTICIPATING_STATUS.includes(myStatus);
   const canJoinByStatus = myStatus === 'NONE' || myStatus === 'REJECTED';

--- a/src/app.feature/challenge/detail/screen/ChallengeParticipantListScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeParticipantListScreen.tsx
@@ -88,7 +88,8 @@ function ParticipantRow({
           ) : null}
         </div>
         <Text size="caption2" weight="regular" className="text-gray-400">
-          {participant.streak}일 연속 · 완료 목표 {participant.completedGoalCount}개
+          {participant.streak ?? 0}일 연속 · 완료 목표{' '}
+          {participant.completedGoalCount ?? 0}개
         </Text>
       </div>
     </button>
@@ -115,7 +116,8 @@ export function ChallengeParticipantListScreen({
   } = useChallengeParticipantsInfinite(
     challengeId,
     sort,
-    PARTICIPANT_PAGE_SIZE
+    PARTICIPANT_PAGE_SIZE,
+    isLoggedIn
   );
   const showSkeleton = useMinimumLoading(isLoading);
   const { ref } = useInfiniteScroll({
@@ -205,6 +207,7 @@ export function ChallengeParticipantListScreen({
                 <button
                   key={option.value}
                   type="button"
+                  aria-pressed={isActive}
                   onClick={() => setSort(option.value)}
                   className={cn(
                     'rounded-full px-3 py-1 text-[12px] font-bold',

--- a/src/app.feature/challenge/detail/screen/ChallengeParticipantListScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeParticipantListScreen.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import { Card, CircleAvatar, Text } from '@1d1s/design-system';
+import EmptyState from '@component/EmptyState';
+import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
+import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { normalizeApiError } from '@module/api/error';
+import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
+import { useSafeBack } from '@module/hooks/useSafeBack';
+import { cn } from '@module/utils/cn';
+import { useMinimumLoading } from '@module/utils/useMinimumLoading';
+import { ArrowLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import React, { useMemo, useState } from 'react';
+
+import { Participant, ParticipantSort } from '../../board/type/challenge';
+import { useChallengeParticipantsInfinite } from '../hooks/useChallengeParticipantQueries';
+
+const PARTICIPANT_PAGE_SIZE = 20;
+
+const SORT_OPTIONS: Array<{ value: ParticipantSort; label: string }> = [
+  { value: 'PARTICIPATION', label: '참여순' },
+  { value: 'RANK', label: '등수순' },
+];
+
+interface ChallengeParticipantListScreenProps {
+  id: string;
+}
+
+function ParticipantRow({
+  participant,
+  onClick,
+}: {
+  participant: Participant;
+  onClick(): void;
+}): React.ReactElement {
+  const hasRank =
+    typeof participant.rank === 'number' && participant.rank > 0;
+  const isHost = participant.status === 'HOST';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex w-full cursor-pointer items-center gap-3 px-2 py-3',
+        'text-left transition-colors hover:bg-gray-50'
+      )}
+    >
+      <span
+        className={cn(
+          'flex h-6 w-6 shrink-0 items-center justify-center',
+          'text-[13px] font-extrabold tabular-nums',
+          !hasRank
+            ? 'text-gray-300'
+            : participant.rank === 1
+              ? 'text-main-800'
+              : participant.rank && participant.rank <= 3
+                ? 'text-gray-700'
+                : 'text-gray-400'
+        )}
+      >
+        {hasRank ? participant.rank : '-'}
+      </span>
+      <CircleAvatar
+        size="sm"
+        imageUrl={participant.profileImg ?? undefined}
+        tone="cream"
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex items-center gap-1.5">
+          <Text
+            size="body2"
+            weight="bold"
+            className="truncate text-gray-800"
+          >
+            {participant.nickname}
+          </Text>
+          {isHost ? (
+            <span
+              className={cn(
+                'bg-main-200 text-main-800 rounded-full',
+                'px-2 py-0.5 text-[10px] font-extrabold'
+              )}
+            >
+              HOST
+            </span>
+          ) : null}
+        </div>
+        <Text size="caption2" weight="regular" className="text-gray-400">
+          {participant.streak}일 연속 · 완료 목표 {participant.completedGoalCount}개
+        </Text>
+      </div>
+    </button>
+  );
+}
+
+export function ChallengeParticipantListScreen({
+  id,
+}: ChallengeParticipantListScreenProps): React.ReactElement {
+  const challengeId = Number(id);
+  const router = useRouter();
+  const handleBack = useSafeBack(`/challenge/${id}`);
+  const isLoggedIn = useIsLoggedIn();
+  const [sort, setSort] = useState<ParticipantSort>('PARTICIPATION');
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useChallengeParticipantsInfinite(
+    challengeId,
+    sort,
+    PARTICIPANT_PAGE_SIZE
+  );
+  const showSkeleton = useMinimumLoading(isLoading);
+  const { ref } = useInfiniteScroll({
+    hasNextPage: hasNextPage ?? false,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
+
+  // 참여자는 participantId 로 유일. 페이지 경계 중복을 방어적으로 제거한다.
+  const participants = useMemo(() => {
+    const flattened = data?.pages?.flatMap((page) => page?.items ?? []) ?? [];
+    const map = new Map<number, Participant>();
+    flattened.forEach((participant) => {
+      map.set(participant.participantId, participant);
+    });
+    return Array.from(map.values());
+  }, [data]);
+
+  const total = data?.pages?.[0]?.pageInfo.totalElements ?? participants.length;
+  const hasParticipants = participants.length > 0;
+
+  if (!isLoggedIn) {
+    return (
+      <LoginRequiredDialog
+        open
+        onOpenChange={() => {}}
+        required
+        onClose={() => router.push(`/challenge/${id}`)}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen w-full">
+      {/* 모바일 sticky 헤더 */}
+      <div
+        className={cn(
+          'sticky top-0 z-30 flex items-center gap-3',
+          'h-14-safe pt-safe-top',
+          'border-b border-gray-100 bg-white/95 px-4 backdrop-blur',
+          'lg:hidden'
+        )}
+      >
+        <button
+          type="button"
+          aria-label="뒤로가기"
+          onClick={handleBack}
+          className={cn(
+            'flex h-8 w-8 items-center justify-center rounded-lg',
+            'text-gray-700 transition-colors hover:bg-gray-100'
+          )}
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <Text
+          size="body1"
+          weight="extrabold"
+          className="flex-1 tracking-[-0.3px] text-gray-900"
+        >
+          참여자
+        </Text>
+      </div>
+
+      <div className={cn('mx-auto w-full max-w-[640px]', 'px-5 py-5 lg:py-10')}>
+        <header className="hidden flex-col gap-1.5 lg:flex">
+          <Text
+            size="pageTitle"
+            weight="extrabold"
+            className="tracking-tight text-gray-900"
+          >
+            참여자
+          </Text>
+          <Text size="body2" weight="regular" className="text-gray-500">
+            챌린지에 참여 중인 멤버와 등수입니다.
+          </Text>
+        </header>
+
+        {/* 정렬 토글 — 참여순 / 등수순 */}
+        <div className="mt-4 flex items-center justify-between gap-2">
+          <Text size="caption1" weight="medium" className="text-gray-500">
+            총 {total}명
+          </Text>
+          <div className="flex gap-1 rounded-full bg-gray-100 p-1">
+            {SORT_OPTIONS.map((option) => {
+              const isActive = sort === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setSort(option.value)}
+                  className={cn(
+                    'rounded-full px-3 py-1 text-[12px] font-bold',
+                    'transition-colors',
+                    isActive
+                      ? 'bg-white text-gray-900 shadow-sm'
+                      : 'text-gray-500 hover:text-gray-700'
+                  )}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {isError && !hasParticipants ? (
+          <div className="mt-10 flex w-full justify-center py-10">
+            <Text size="body1" weight="medium" className="text-red-600">
+              {error
+                ? normalizeApiError(error).message
+                : '참여자를 불러오지 못했습니다.'}
+            </Text>
+          </div>
+        ) : null}
+
+        {!showSkeleton && hasParticipants ? (
+          <Card radius="lg" className="data-fade-in mt-4 p-2">
+            <ul className="flex flex-col divide-y divide-gray-100">
+              {participants.map((participant) => (
+                <li key={participant.participantId}>
+                  <ParticipantRow
+                    participant={participant}
+                    onClick={() =>
+                      router.push(`/member/${participant.memberId}`)
+                    }
+                  />
+                </li>
+              ))}
+            </ul>
+          </Card>
+        ) : null}
+
+        {!showSkeleton && !isError && !hasParticipants ? (
+          <EmptyState
+            variant="challenge"
+            title="아직 참여자가 없어요"
+            description="첫 참여자가 되어 보세요"
+            className="mt-10"
+          />
+        ) : null}
+
+        <div
+          ref={ref}
+          className="mt-6 flex h-10 w-full items-center justify-center"
+        >
+          {isFetchingNextPage ? (
+            <Text size="body2" className="text-gray-400">
+              불러오는 중...
+            </Text>
+          ) : isError && hasParticipants ? (
+            <Text size="body2" className="text-red-500">
+              추가 참여자를 불러오지 못했습니다.
+            </Text>
+          ) : !hasNextPage && hasParticipants ? (
+            <Text size="body2" className="text-gray-400">
+              마지막 참여자입니다.
+            </Text>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/challenge/[id]/participants/page.tsx
+++ b/src/app/challenge/[id]/participants/page.tsx
@@ -1,0 +1,14 @@
+import { ChallengeParticipantListScreen } from '@feature/challenge/detail/screen/ChallengeParticipantListScreen';
+import React from 'react';
+
+interface ChallengeParticipantListPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ChallengeParticipantListPage({
+  params,
+}: ChallengeParticipantListPageProps): Promise<React.ReactElement> {
+  const { id } = await params;
+
+  return <ChallengeParticipantListScreen id={id} />;
+}


### PR DESCRIPTION
## 📌 Summary

백엔드 참여자 랭킹 조회 추가(base dev)에 맞춰 참여자 목록을 OffsetPagination + 정렬(참여순/등수순)로 마이그레이션하고, 등수/스트릭/완료목표수를 표시합니다.

## ✅ 작업 내용

- **타입**: `ParticipantResponse`(=`Participant`)에 `rank: number|null`, `streak`, `completedGoalCount` 추가. 참여자 목록 응답을 `OffsetPagination` 형태(`{ items, pageInfo }`)로 정의(`ParticipantListResponse`/`OffsetPageInfo`).
- **API**: `GET /challenges/{challengeId}/participants` 함수 신설 — `sort=PARTICIPATION|RANK`, `page`, `size` 파라미터 지원.
- **훅**: `useChallengeParticipantsInfinite` — 페이지 방식 무한스크롤(챌린지 일지 목록 `useChallengeDiaryListInfinite` 패턴 재사용). Query Key Factory에 `participantList` 추가.
- **전체 목록 화면**: `/challenge/[id]/participants` 신설 — 참여순/등수순 토글 + 무한스크롤 + 등수/스트릭/완료목표수 표시.
- **리더보드 카드**: 등수 배지 + 스트릭·완료목표수 표시. 상세 응답이 등수순 상위 5명으로 축소된 것에 맞춰, "전체 보기"를 모달 대신 전체 목록 화면 이동(`onShowAll`)으로 연결.
- **캐시**: 참여/탈퇴/수락/거절/비번검증 뮤테이션에 참여자 목록 무효화 추가.

## 📎 기타

- 응답 형태 `List` → 객체 변경에 따른 파싱 마이그레이션 완료. 상세의 `participants`는 계속 상세 응답에서 읽으며(상위 5명), 전체 목록만 새 페이지네이션 엔드포인트를 사용합니다.
- ⚠️ **확인 필요(호스트 승인 플로우)**: 상세 화면은 `data.participants`에서 `status === 'PENDING'`을 걸러 호스트 대기 승인 카드를 그립니다. 상세 응답이 "등수순 상위 5명"으로 축소되면 PENDING(등수 null) 참여자가 응답에서 빠져 승인 UI가 비게 될 수 있습니다. 백엔드가 PENDING을 별도 포함하는지, 혹은 별도 대기자 엔드포인트가 필요한지 확인 부탁드립니다(현재 계약엔 status 필터가 없어 프론트에서 대체 불가).
- 정적 검증(`tsc --noEmit`, `pnpm lint`) 통과. 브라우저 동작은 직접 확인하지 않았습니다.