### PR TITLE
feat: 챌린지 인증샷 필수 옵션 + 일지 사진 필수 처리

### DIFF
--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -70,6 +70,8 @@ export interface ChallengeListItem {
 export interface ChallengeDetail {
   description: string;
   allowMidJoin?: boolean;
+  // 인증샷(사진) 필수 여부. 백엔드 계약 확정 전 가정 필드명.
+  isPhotoRequired?: boolean;
   myStatus: ParticipantStatus;
   participationRate: number;
   goalCompletionRate: number;
@@ -108,6 +110,8 @@ export interface CreateChallengeRequest {
   participationType: ParticipationType;
   goals: string[];
   allowMidJoin: boolean;
+  // 인증샷(사진) 필수 여부. 백엔드 계약 확정 전 가정 필드명(기본 false).
+  isPhotoRequired: boolean;
   thumbnailImage?: string;
   // 공개 범위. 생성 시 PUBLIC 또는 PRIVATE 를 보낸다.
   challengeType: ChallengeType;

--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -70,8 +70,8 @@ export interface ChallengeListItem {
 export interface ChallengeDetail {
   description: string;
   allowMidJoin?: boolean;
-  // 인증샷(사진) 필수 여부. 백엔드 계약 확정 전 가정 필드명.
-  isPhotoRequired?: boolean;
+  // 인증샷(사진) 필수 여부(서버 JSON 키: photoRequired).
+  photoRequired?: boolean;
   myStatus: ParticipantStatus;
   participationRate: number;
   goalCompletionRate: number;
@@ -110,8 +110,8 @@ export interface CreateChallengeRequest {
   participationType: ParticipationType;
   goals: string[];
   allowMidJoin: boolean;
-  // 인증샷(사진) 필수 여부. 백엔드 계약 확정 전 가정 필드명(기본 false).
-  isPhotoRequired: boolean;
+  // 인증샷(사진) 필수 여부(서버 JSON 키: photoRequired, 기본 false).
+  photoRequired: boolean;
   thumbnailImage?: string;
   // 공개 범위. 생성 시 PUBLIC 또는 PRIVATE 를 보낸다.
   challengeType: ChallengeType;

--- a/src/app.feature/challenge/write/components/ChallengeCreatePhotoSection.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeCreatePhotoSection.tsx
@@ -1,0 +1,44 @@
+import { SegmentedControl, Text } from '@1d1s/design-system';
+import { useFormContext } from 'react-hook-form';
+
+import { FormControl, FormField, FormItem } from '@/app.component/ui/Form';
+
+import { ChallengeCreateFormValues } from '../hooks/useChallengeCreateForm';
+import { ChallengeCreateSectionCard } from './ChallengeCreateSectionCard';
+
+export function ChallengeCreatePhotoSection(): React.ReactElement {
+  const { control } = useFormContext<ChallengeCreateFormValues>();
+
+  return (
+    <ChallengeCreateSectionCard step={6} title="인증샷">
+      <FormField
+        control={control}
+        name="isPhotoRequired"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <SegmentedControl
+                value={field.value ? 'REQUIRED' : 'OPTIONAL'}
+                onValueChange={(value) => field.onChange(value === 'REQUIRED')}
+                aria-label="인증샷 필수 여부"
+                options={[
+                  { value: 'OPTIONAL', label: '선택' },
+                  { value: 'REQUIRED', label: '필수' },
+                ]}
+              />
+            </FormControl>
+            <Text
+              size="caption1"
+              weight="regular"
+              className="mt-1 block text-gray-500"
+            >
+              {field.value
+                ? '일지를 쓸 때 사진(인증샷)을 반드시 첨부해야 해요.'
+                : '사진 없이도 일지를 작성할 수 있어요.'}
+            </Text>
+          </FormItem>
+        )}
+      />
+    </ChallengeCreateSectionCard>
+  );
+}

--- a/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
+++ b/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
@@ -33,6 +33,7 @@ export const challengeCreateFormSchema = z
     memberCountNumber: z.string().optional(),
     goalType: z.enum(['FIXED', 'FLEXIBLE']),
     allowMidJoin: z.boolean(),
+    isPhotoRequired: z.boolean(),
     // 공개 범위 — 생성 시에는 공개/비공개만 선택할 수 있다.
     challengeType: z.enum(['PUBLIC', 'PRIVATE']),
     password: z.string().optional(),
@@ -150,6 +151,7 @@ export function useChallengeCreateForm(): ReturnType<
       // 챌린지 시작 후에도 다른 사용자들이 자유롭게 합류할 수 있도록 기본값을
       // 허용으로 둔다. 작성자는 필요 시 토글로 비허용으로 바꿀 수 있다.
       allowMidJoin: true,
+      isPhotoRequired: false,
       challengeType: 'PUBLIC',
       password: '',
       goals: [],

--- a/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
@@ -94,6 +94,7 @@ function formatFormValues(
     goals: values.goals.map((goal) => goal.value),
     allowMidJoin:
       values.participationType === 'INDIVIDUAL' ? false : values.allowMidJoin,
+    // 와이어(서버) 키는 photoRequired, 폼 내부 필드명은 isPhotoRequired.
     photoRequired: values.isPhotoRequired,
     thumbnailImage: values.thumbnailImageKey,
     challengeType: values.challengeType,

--- a/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
@@ -94,7 +94,7 @@ function formatFormValues(
     goals: values.goals.map((goal) => goal.value),
     allowMidJoin:
       values.participationType === 'INDIVIDUAL' ? false : values.allowMidJoin,
-    isPhotoRequired: values.isPhotoRequired,
+    photoRequired: values.isPhotoRequired,
     thumbnailImage: values.thumbnailImageKey,
     challengeType: values.challengeType,
     // 비공개일 때만 비밀번호를 동봉한다.

--- a/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
@@ -18,6 +18,7 @@ import { ChallengeCreateDialog } from '@feature/challenge/write/components/Chall
 import { ChallengeCreateGoalSection } from '@feature/challenge/write/components/ChallengeCreateGoalSection';
 import { ChallengeCreateParticipationSection } from '@feature/challenge/write/components/ChallengeCreateParticipationSection';
 import { ChallengeCreatePeriodSection } from '@feature/challenge/write/components/ChallengeCreatePeriodSection';
+import { ChallengeCreatePhotoSection } from '@feature/challenge/write/components/ChallengeCreatePhotoSection';
 import { ChallengeCreatePreviewCard } from '@feature/challenge/write/components/ChallengeCreatePreviewCard';
 import { ChallengeCreateSuccessDialog } from '@feature/challenge/write/components/ChallengeCreateSuccessDialog';
 import { ChallengeCreateVisibilitySection } from '@feature/challenge/write/components/ChallengeCreateVisibilitySection';
@@ -93,6 +94,7 @@ function formatFormValues(
     goals: values.goals.map((goal) => goal.value),
     allowMidJoin:
       values.participationType === 'INDIVIDUAL' ? false : values.allowMidJoin,
+    isPhotoRequired: values.isPhotoRequired,
     thumbnailImage: values.thumbnailImageKey,
     challengeType: values.challengeType,
     // 비공개일 때만 비밀번호를 동봉한다.
@@ -195,6 +197,7 @@ export default function ChallengeCreateScreen(): React.ReactElement {
               <ChallengeCreateGoalSection />
               <ChallengeCreatePeriodSection />
               <ChallengeCreateVisibilitySection />
+              <ChallengeCreatePhotoSection />
             </div>
 
             <aside className="hidden lg:block">

--- a/src/app.feature/diary/write/components/DiaryCreateThumbnailSection.tsx
+++ b/src/app.feature/diary/write/components/DiaryCreateThumbnailSection.tsx
@@ -5,6 +5,8 @@ interface DiaryCreateThumbnailSectionProps {
   previews: string[];
   /** previews 중 대표 썸네일 인덱스(없으면 -1). */
   thumbnailIndex: number;
+  /** 인증샷 필수 챌린지면 라벨/안내를 필수로 표시하고 빈 상태를 경고한다. */
+  required?: boolean;
   onSelectFiles(files: File[]): void;
   onRemove(index: number): void;
   onSelectThumbnail(index: number): void;
@@ -13,15 +15,33 @@ interface DiaryCreateThumbnailSectionProps {
 function DiaryCreateThumbnailSectionComponent({
   previews,
   thumbnailIndex,
+  required = false,
   onSelectFiles,
   onRemove,
   onSelectThumbnail,
 }: DiaryCreateThumbnailSectionProps): React.ReactElement {
+  const showRequiredWarning = required && previews.length === 0;
+
   return (
     <div>
       <Text size="caption1" weight="bold" className="mb-2 block text-gray-600">
-        사진 첨부 <span className="font-medium text-gray-400">· 선택</span>
+        사진 첨부{' '}
+        {required ? (
+          <span className="text-red-500">· 인증샷 필수</span>
+        ) : (
+          <span className="font-medium text-gray-400">· 선택</span>
+        )}
       </Text>
+
+      {showRequiredWarning ? (
+        <Text
+          size="caption2"
+          weight="regular"
+          className="mb-2 block text-red-500"
+        >
+          이 챌린지는 인증샷(사진)을 1장 이상 첨부해야 저장할 수 있어요.
+        </Text>
+      ) : null}
 
       {/* 최대 5장. 이미지를 누르면 대표 썸네일로 지정/해제(토글)된다.
           대표는 목록·카드에 노출되며, 미선택 시 표시되지 않는다. */}

--- a/src/app.feature/diary/write/consts/photoRequired.ts
+++ b/src/app.feature/diary/write/consts/photoRequired.ts
@@ -1,0 +1,19 @@
+import type { ChallengeDetailResponse } from '@feature/challenge/board/type/challenge';
+
+// 인증샷(사진) 필수 관련 상수/헬퍼를 한 곳에 모은다. 백엔드 최종 필드명이나
+// 에러 코드가 확정되면 이 파일(+ challenge.ts 타입)만 수정하면 된다.
+
+// 사진 필수 위반 시 백엔드가 내려주는 도메인 에러 코드(가정값).
+export const PHOTO_REQUIRED_ERROR_CODE = 'DIARY-010';
+
+// 프론트 선제 차단 및 백엔드 위반 응답을 받았을 때 공통으로 쓰는 안내 문구.
+export const PHOTO_REQUIRED_MESSAGE =
+  '이 챌린지는 인증샷(사진)을 1장 이상 첨부해야 해요.';
+
+// 챌린지 상세 응답에서 인증샷 필수 여부를 읽는다. 응답 내 위치/필드명이
+// 바뀌면 이 함수만 고치면 된다.
+export function isChallengePhotoRequired(
+  detail: ChallengeDetailResponse | undefined
+): boolean {
+  return detail?.challengeDetail?.isPhotoRequired === true;
+}

--- a/src/app.feature/diary/write/consts/photoRequired.ts
+++ b/src/app.feature/diary/write/consts/photoRequired.ts
@@ -15,5 +15,5 @@ export const PHOTO_REQUIRED_MESSAGE =
 export function isChallengePhotoRequired(
   detail: ChallengeDetailResponse | undefined
 ): boolean {
-  return detail?.challengeDetail?.isPhotoRequired === true;
+  return detail?.challengeDetail?.photoRequired === true;
 }

--- a/src/app.feature/diary/write/hooks/useDiaryCreateForm.ts
+++ b/src/app.feature/diary/write/hooks/useDiaryCreateForm.ts
@@ -1,5 +1,6 @@
 import { isChallengeOngoing } from '@feature/challenge/board/utils/challengePeriod';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
+import { getApiErrorCode } from '@module/api/error';
 import { uploadImagesViaPresigned } from '@module/api/presignedUpload';
 import { toast } from '@module/providers/toast';
 import { formatDateISO } from '@module/utils/date';
@@ -25,6 +26,11 @@ import {
   useUpdateDiary,
 } from '../../detail/hooks/useDiaryMutations';
 import { resolveDiaryImageUrl } from '../../shared/utils/diaryImageUrl';
+import {
+  isChallengePhotoRequired,
+  PHOTO_REQUIRED_ERROR_CODE,
+  PHOTO_REQUIRED_MESSAGE,
+} from '../consts/photoRequired';
 import type { DiaryImageItem } from '../utils/diaryFormHelpers';
 import {
   getDiaryImageUrls,
@@ -68,6 +74,8 @@ interface UseDiaryCreateFormResult {
   imagePreviewUrls: string[];
   /** imagePreviewUrls 중 대표 썸네일 인덱스(없으면 -1). */
   thumbnailIndex: number;
+  /** 선택한 챌린지가 인증샷(사진) 필수인지 여부. */
+  isPhotoRequired: boolean;
   submitButtonLabel: string;
   canSubmit: boolean;
   isSubmitting: boolean;
@@ -204,6 +212,8 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
     isLoading: isChallengeCheckWriteDatesLoading,
   } = useChallengeCheckWriteDates(selectedChallenge?.challengeId ?? 0);
   const goals = challengeDetail?.challengeGoals ?? EMPTY_GOALS;
+  // 인증샷 필수 챌린지는 최종 이미지(유지+신규)가 0장이면 제출을 막는다.
+  const isPhotoRequired = isChallengePhotoRequired(challengeDetail);
 
   const editModeDateKey = useMemo(() => {
     if (!isEditMode || !existingDiary) {
@@ -277,6 +287,7 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
       : false) &&
     !isChallengeCheckWriteDatesLoading &&
     !isSubmitting &&
+    (!isPhotoRequired || images.length > 0) &&
     (!isEditMode || !isExistingDiaryLoading);
   const isInitialChallengeLoading =
     requestedChallengeId !== null &&
@@ -569,6 +580,12 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
       return;
     }
 
+    // 인증샷 필수 챌린지 선제 차단(버튼 비활성화가 우회된 경우 방어).
+    if (isPhotoRequired && images.length === 0) {
+      toast.error(PHOTO_REQUIRED_MESSAGE);
+      return;
+    }
+
     // mutation onSuccess 의 캐시 무효화가 마지막 작성 가능일을 사라지게 만들면
     // useEffect 가 'unavailable' 다이얼로그를 띄울 수 있다. 제출 시작 시점에
     // 가드를 올려, 제출-네비게이션 사이의 어떤 refetch 도 다이얼로그를
@@ -645,9 +662,14 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
       });
 
       router.push('/diary');
-    } catch {
+    } catch (error) {
       submitSuccessRef.current = false;
-      toast.error('일지 저장 또는 이미지 업로드에 실패했습니다.');
+      // 프론트에서 이미 막지만, 백엔드 사진 필수 위반 응답도 방어적으로 처리.
+      toast.error(
+        getApiErrorCode(error) === PHOTO_REQUIRED_ERROR_CODE
+          ? PHOTO_REQUIRED_MESSAGE
+          : '일지 저장 또는 이미지 업로드에 실패했습니다.'
+      );
     }
   }, [
     achievedDate,
@@ -657,6 +679,7 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
     disabledAchievedDateKeySet,
     images,
     isEditMode,
+    isPhotoRequired,
     isSubmitting,
     router,
     requestedDiaryId,
@@ -695,6 +718,7 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
     disabledAchievedDateKeys,
     imagePreviewUrls,
     thumbnailIndex,
+    isPhotoRequired,
     submitButtonLabel,
     canSubmit,
     isSubmitting,

--- a/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
+++ b/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
@@ -59,6 +59,7 @@ export default function DiaryCreateScreen(): React.ReactElement {
     achievedGoalIds,
     imagePreviewUrls,
     thumbnailIndex,
+    isPhotoRequired,
     submitButtonLabel,
     canSubmit,
     isSubmitting,
@@ -102,6 +103,7 @@ export default function DiaryCreateScreen(): React.ReactElement {
       <DiaryCreateThumbnailSection
         previews={imagePreviewUrls}
         thumbnailIndex={thumbnailIndex}
+        required={isPhotoRequired}
         onSelectFiles={handleAddImageFiles}
         onRemove={handleRemoveImageAt}
         onSelectThumbnail={handleSelectThumbnailAt}
@@ -110,6 +112,7 @@ export default function DiaryCreateScreen(): React.ReactElement {
     [
       imagePreviewUrls,
       thumbnailIndex,
+      isPhotoRequired,
       handleAddImageFiles,
       handleRemoveImageAt,
       handleSelectThumbnailAt,


### PR DESCRIPTION
## 📌 Summary

챌린지에 "인증샷 필수" 옵션을 추가하고, 해당 챌린지의 일지 작성 시 사진 첨부를 프론트에서 선제 차단합니다.

## ✅ 작업 내용

- **챌린지 생성 폼**: "인증샷" 섹션에 필수/선택 토글 추가 → 생성 요청에 `isPhotoRequired` 전송 (기본 false)
- **타입**: `CreateChallengeRequest`, `ChallengeDetail`에 `isPhotoRequired` 필드 추가
- **일지 작성**: 선택한 챌린지가 `isPhotoRequired=true`면
  - 사진 첨부 영역에 "인증샷 필수" 라벨 + 안내 문구 노출
  - 최종 이미지(유지+신규)가 0장이면 제출 버튼 비활성화 + 제출 시 방어 차단
- **방어 처리**: 백엔드 사진 필수 위반 에러코드(`DIARY-010`) 응답 시 안내 토스트
- **집중화**: 백엔드 필드명/에러코드/문구를 `diary/write/consts/photoRequired.ts` 한 곳에 모아, 계약 확정 시 이 파일 + 타입만 수정하면 되도록 구성

## 📎 기타

- 백엔드 계약(`isPhotoRequired`, `DIARY-010`)은 동시 작업 중인 가정값입니다. 최종 필드명/코드가 달라지면 `photoRequired.ts`와 `challenge.ts` 타입만 조정하면 됩니다.
- `tsc --noEmit`, `pnpm lint` 통과. 브라우저 동작 확인은 미실시(로컬 정적 검증까지만).
