### PR TITLE
fix: 무효 세션 토큰 정리 누락으로 재로그인 불가 문제 수정

### DIFF
--- a/src/app.feature/auth/screen/LoginScreen.tsx
+++ b/src/app.feature/auth/screen/LoginScreen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Text } from '@1d1s/design-system';
-import { authStorage } from '@module/utils/auth';
+import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { cn } from '@module/utils/cn';
 import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import Link from 'next/link';
@@ -17,6 +17,7 @@ import { getLaunchStreakDay } from '../utils/streakDay';
 
 export function LoginScreen(): React.ReactElement {
   const router = useRouter();
+  const isLoggedIn = useIsLoggedIn();
   const [recommended, setRecommended] = React.useState<OAuthProvider | null>(
     null
   );
@@ -31,14 +32,20 @@ export function LoginScreen(): React.ReactElement {
 
   // 이미 로그인된 상태로 /login?returnTo=... 에 오면 바로 복귀시킨다.
   // (returnTo 가 없으면 기존처럼 로그인 화면을 그대로 보여준다)
+  //
+  // 판정은 토큰 존재(hasTokens)가 아니라 권위 있는 세션 상태(useIsLoggedIn)로
+  // 한다. 무효/만료 세션에서도 90일 힌트 쿠키가 남아 hasTokens() 는 true 일 수
+  // 있는데, 이걸로 리다이렉트하면 보호 라우트→/login→보호 라우트 무한 루프에
+  // 갇혀 재로그인이 불가능해진다. useIsLoggedIn 은 사이드바 응답으로 세션을
+  // 확인하며, 세션이 죽으면 forceLogout 이 힌트를 정리해 루프가 풀린다.
   React.useEffect(() => {
     const returnTo = sanitizeReturnTo(
       new URLSearchParams(window.location.search).get(RETURN_TO_PARAM)
     );
-    if (returnTo && authStorage.hasTokens()) {
+    if (returnTo && isLoggedIn) {
       router.replace(returnTo);
     }
-  }, [router]);
+  }, [router, isLoggedIn]);
 
   const providers = getOrderedProviders(recommended);
 

--- a/src/app.feature/auth/screen/LoginScreen.tsx
+++ b/src/app.feature/auth/screen/LoginScreen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Text } from '@1d1s/design-system';
-import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { cn } from '@module/utils/cn';
 import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import Link from 'next/link';
@@ -17,7 +17,11 @@ import { getLaunchStreakDay } from '../utils/streakDay';
 
 export function LoginScreen(): React.ReactElement {
   const router = useRouter();
-  const isLoggedIn = useIsLoggedIn();
+  // 사이드바 실데이터(= 서버가 확인해 준 살아있는 세션)만 리다이렉트 근거로
+  // 삼는다. isLoading 동안 낙관적으로 true 를 주는 useIsLoggedIn 을 쓰면, 무효
+  // 세션(힌트만 남음)에서 조회가 끝나기 전에 returnTo 로 튕겼다가 미들웨어에
+  // 다시 /login 으로 돌아오는 깜빡임이 생긴다. data 가 확정될 때만 이동한다.
+  const { data: sidebarData } = useSidebar();
   const [recommended, setRecommended] = React.useState<OAuthProvider | null>(
     null
   );
@@ -33,19 +37,19 @@ export function LoginScreen(): React.ReactElement {
   // 이미 로그인된 상태로 /login?returnTo=... 에 오면 바로 복귀시킨다.
   // (returnTo 가 없으면 기존처럼 로그인 화면을 그대로 보여준다)
   //
-  // 판정은 토큰 존재(hasTokens)가 아니라 권위 있는 세션 상태(useIsLoggedIn)로
+  // 판정은 토큰 존재(hasTokens)가 아니라 서버가 확인한 세션(sidebarData)으로
   // 한다. 무효/만료 세션에서도 90일 힌트 쿠키가 남아 hasTokens() 는 true 일 수
   // 있는데, 이걸로 리다이렉트하면 보호 라우트→/login→보호 라우트 무한 루프에
-  // 갇혀 재로그인이 불가능해진다. useIsLoggedIn 은 사이드바 응답으로 세션을
-  // 확인하며, 세션이 죽으면 forceLogout 이 힌트를 정리해 루프가 풀린다.
+  // 갇혀 재로그인이 불가능해진다. 세션이 죽으면 사이드바 조회가 실패하며
+  // forceLogout 이 힌트를 정리하고 data 는 계속 비어 있어 루프가 생기지 않는다.
   React.useEffect(() => {
     const returnTo = sanitizeReturnTo(
       new URLSearchParams(window.location.search).get(RETURN_TO_PARAM)
     );
-    if (returnTo && isLoggedIn) {
+    if (returnTo && sidebarData) {
       router.replace(returnTo);
     }
-  }, [router, isLoggedIn]);
+  }, [router, sidebarData]);
 
   const providers = getOrderedProviders(recommended);
 

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -98,11 +98,11 @@ export const isUnauthorizedError = (error: unknown): boolean =>
 export const isRedirectError = (error: unknown): boolean =>
   isAxiosErrorLike(error) && error.response?.status === 302;
 
-// 요청이 서버에 도달해 HTTP 응답(상태 코드)을 받았는지 여부. 네트워크/타임아웃
-// (응답 없음)과 서버의 명시적 거부를 구분한다. 리프레시 실패가 일시적 오프라인
-// 인지, 세션 무효(회전형 refresh 재사용 감지 등)인지 판정하는 데 쓴다.
-export const hasHttpResponseStatus = (error: unknown): boolean =>
-  isAxiosErrorLike(error) && error.response?.status !== undefined;
+// 403. 리프레시/인증 요청이 서버에서 명시적으로 거부된(세션 복구 불가) 경우.
+// 회전형 refresh 재사용 감지로 family 가 무효화되면 401 대신 403 으로 응답할 수
+// 있어 401 과 동일하게 취급한다. 5xx·429·408·네트워크 오류(일시적)와는 구분한다.
+export const isForbiddenError = (error: unknown): boolean =>
+  isAxiosErrorLike(error) && error.response?.status === 403;
 
 export const isInvalidRefreshTokenError = (error: unknown): boolean => {
   if (!isAxiosErrorLike(error)) {

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -98,6 +98,12 @@ export const isUnauthorizedError = (error: unknown): boolean =>
 export const isRedirectError = (error: unknown): boolean =>
   isAxiosErrorLike(error) && error.response?.status === 302;
 
+// 요청이 서버에 도달해 HTTP 응답(상태 코드)을 받았는지 여부. 네트워크/타임아웃
+// (응답 없음)과 서버의 명시적 거부를 구분한다. 리프레시 실패가 일시적 오프라인
+// 인지, 세션 무효(회전형 refresh 재사용 감지 등)인지 판정하는 데 쓴다.
+export const hasHttpResponseStatus = (error: unknown): boolean =>
+  isAxiosErrorLike(error) && error.response?.status !== undefined;
+
 export const isInvalidRefreshTokenError = (error: unknown): boolean => {
   if (!isAxiosErrorLike(error)) {
     return false;

--- a/src/app.module/api/errorNotify.ts
+++ b/src/app.module/api/errorNotify.ts
@@ -6,7 +6,7 @@ import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
 
 import { API_BASE_URL } from './config';
 import {
-  hasHttpResponseStatus,
+  isForbiddenError,
   isInvalidRefreshTokenError,
   isRedirectError,
   isUnauthorizedError,
@@ -55,16 +55,21 @@ export const handleAuthError = (error: unknown): void => {
     return;
   }
 
-  // 401(토큰 없음/만료), refresh token 무효(AUTH-006), 그 외 서버가 응답으로
-  // 거부한 모든 인증/리프레시 실패(403·회전형 refresh 재사용 감지로 family
-  // 무효화 등)를 세션 복구 불가로 보고 동일하게 정리한다. 특정 상태/코드만
-  // 정리하면, 서버가 다른 에러로 리프레시를 거부할 때 hasTokens() 가 계속 true 라
-  // 무효 토큰이 남아 재로그인이 막히고 같은 에러가 무한 반복된다.
-  // 네트워크/타임아웃(응답 없음)은 일시적일 수 있어 세션을 유지하고 다음 요청에서
-  // 재시도하게 둔다.
+  // 서버가 세션을 명시적으로 거부한 경우만 정리한다:
+  //   - 401(토큰 없음/만료)
+  //   - 403(회전형 refresh 재사용 감지로 family 무효화 등)
+  //   - refresh token 무효 코드(AUTH-006)
+  // 401/AUTH-006 만 정리하면, 서버가 403 등 다른 에러로 리프레시를 거부할 때
+  // hasTokens() 가 계속 true 라 무효 토큰이 남아 재로그인이 막히고 같은 에러가
+  // 무한 반복된다. 반대로 5xx·429·408·네트워크/타임아웃(일시적)에는 세션을
+  // 유지하고 다음 요청에서 재시도하게 둔다 — 백엔드 순단으로 로그인 사용자를
+  // 일괄 로그아웃시키지 않기 위함.
   const invalidRefresh = isInvalidRefreshTokenError(error);
-  const serverRejected = hasHttpResponseStatus(error);
-  if (!isUnauthorizedError(error) && !invalidRefresh && !serverRejected) {
+  if (
+    !isUnauthorizedError(error) &&
+    !isForbiddenError(error) &&
+    !invalidRefresh
+  ) {
     return;
   }
 

--- a/src/app.module/api/errorNotify.ts
+++ b/src/app.module/api/errorNotify.ts
@@ -6,6 +6,7 @@ import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
 
 import { API_BASE_URL } from './config';
 import {
+  hasHttpResponseStatus,
   isInvalidRefreshTokenError,
   isRedirectError,
   isUnauthorizedError,
@@ -54,11 +55,16 @@ export const handleAuthError = (error: unknown): void => {
     return;
   }
 
-  // 401(토큰 없음/만료) 또는 refresh token 무효(AUTH-006) 모두 세션을 복구할
-  // 수 없으므로 동일하게 정리한다. AUTH-006 을 빼면 hasTokens() 가 계속 true 라
-  // 새로고침/재개마다 /auth/token 재시도 → 같은 에러가 무한 반복된다.
+  // 401(토큰 없음/만료), refresh token 무효(AUTH-006), 그 외 서버가 응답으로
+  // 거부한 모든 인증/리프레시 실패(403·회전형 refresh 재사용 감지로 family
+  // 무효화 등)를 세션 복구 불가로 보고 동일하게 정리한다. 특정 상태/코드만
+  // 정리하면, 서버가 다른 에러로 리프레시를 거부할 때 hasTokens() 가 계속 true 라
+  // 무효 토큰이 남아 재로그인이 막히고 같은 에러가 무한 반복된다.
+  // 네트워크/타임아웃(응답 없음)은 일시적일 수 있어 세션을 유지하고 다음 요청에서
+  // 재시도하게 둔다.
   const invalidRefresh = isInvalidRefreshTokenError(error);
-  if (!isUnauthorizedError(error) && !invalidRefresh) {
+  const serverRejected = hasHttpResponseStatus(error);
+  if (!isUnauthorizedError(error) && !invalidRefresh && !serverRejected) {
     return;
   }
 


### PR DESCRIPTION
## 📌 Summary

무효/만료된 인증 토큰이 정리되지 않고 남아 재로그인이 막히는 문제를 수정합니다.

## ✅ 작업 내용

### 근본 원인
- `handleAuthError`(errorNotify.ts)가 refresh 실패를 **401 / AUTH-006** 일 때만 정리했다. 회전형(rotation) refresh 토큰 재사용 감지로 family 가 무효화되며 서버가 그 외 응답(예: 403·다른 도메인 코드)으로 거부하면 early-return 되어 `clearTokens()` 가 호출되지 않았다. → 90일 힌트 쿠키가 남아 `hasTokens()` 가 계속 true.
- `LoginScreen` 가드가 `authStorage.hasTokens()`(토큰 존재)만으로 `returnTo` 자동 리다이렉트를 수행했다. 무효 세션인데 힌트 쿠키가 남으면 `보호 라우트 → /login?returnTo → 보호 라우트` 무한 리다이렉트 루프에 갇혀 로그인 화면 진입/재로그인이 불가능했다.

### 수정
- `handleAuthError`: 서버가 응답으로 거부한 인증/리프레시 실패(HTTP 응답 존재)를 모두 세션 복구 불가로 보고 토큰/인증 상태를 정리하도록 확장. 네트워크·타임아웃(응답 없음)은 일시적일 수 있어 세션을 유지해 다음 요청에서 재시도.
- `error.ts`: 응답 유무를 판정하는 `hasHttpResponseStatus` 헬퍼 추가.
- `LoginScreen`: 자동 리다이렉트 판정을 토큰 존재가 아니라 권위 있는 세션 상태(`useIsLoggedIn`)로 변경. 무효 세션에서는 사이드바 조회 실패 → `forceLogout` 으로 힌트가 정리되어 루프가 풀리고 로그인 화면이 노출된다.

## 📎 기타

- 검증: `tsc --noEmit`, `pnpm lint` 통과. 브라우저 동작 확인은 직접 하지 않았습니다(프로젝트 정책상 preview 미사용).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login redirect behavior so users are only sent to their requested page when they are actually signed in.
  * Reduced the chance of redirect loops on the login page.
  * Refined authentication error handling to avoid unnecessary session resets or redirects when the server did not return a clear response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->