### PR TITLE
release: 무효 세션 재로그인 수정 상용 반영 (#125)

### DIFF
--- a/src/app.feature/auth/screen/LoginScreen.tsx
+++ b/src/app.feature/auth/screen/LoginScreen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Text } from '@1d1s/design-system';
-import { authStorage } from '@module/utils/auth';
+import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { cn } from '@module/utils/cn';
 import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import Link from 'next/link';
@@ -17,6 +17,11 @@ import { getLaunchStreakDay } from '../utils/streakDay';
 
 export function LoginScreen(): React.ReactElement {
   const router = useRouter();
+  // 사이드바 실데이터(= 서버가 확인해 준 살아있는 세션)만 리다이렉트 근거로
+  // 삼는다. isLoading 동안 낙관적으로 true 를 주는 useIsLoggedIn 을 쓰면, 무효
+  // 세션(힌트만 남음)에서 조회가 끝나기 전에 returnTo 로 튕겼다가 미들웨어에
+  // 다시 /login 으로 돌아오는 깜빡임이 생긴다. data 가 확정될 때만 이동한다.
+  const { data: sidebarData } = useSidebar();
   const [recommended, setRecommended] = React.useState<OAuthProvider | null>(
     null
   );
@@ -31,14 +36,20 @@ export function LoginScreen(): React.ReactElement {
 
   // 이미 로그인된 상태로 /login?returnTo=... 에 오면 바로 복귀시킨다.
   // (returnTo 가 없으면 기존처럼 로그인 화면을 그대로 보여준다)
+  //
+  // 판정은 토큰 존재(hasTokens)가 아니라 서버가 확인한 세션(sidebarData)으로
+  // 한다. 무효/만료 세션에서도 90일 힌트 쿠키가 남아 hasTokens() 는 true 일 수
+  // 있는데, 이걸로 리다이렉트하면 보호 라우트→/login→보호 라우트 무한 루프에
+  // 갇혀 재로그인이 불가능해진다. 세션이 죽으면 사이드바 조회가 실패하며
+  // forceLogout 이 힌트를 정리하고 data 는 계속 비어 있어 루프가 생기지 않는다.
   React.useEffect(() => {
     const returnTo = sanitizeReturnTo(
       new URLSearchParams(window.location.search).get(RETURN_TO_PARAM)
     );
-    if (returnTo && authStorage.hasTokens()) {
+    if (returnTo && sidebarData) {
       router.replace(returnTo);
     }
-  }, [router]);
+  }, [router, sidebarData]);
 
   const providers = getOrderedProviders(recommended);
 

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -98,6 +98,12 @@ export const isUnauthorizedError = (error: unknown): boolean =>
 export const isRedirectError = (error: unknown): boolean =>
   isAxiosErrorLike(error) && error.response?.status === 302;
 
+// 403. 리프레시/인증 요청이 서버에서 명시적으로 거부된(세션 복구 불가) 경우.
+// 회전형 refresh 재사용 감지로 family 가 무효화되면 401 대신 403 으로 응답할 수
+// 있어 401 과 동일하게 취급한다. 5xx·429·408·네트워크 오류(일시적)와는 구분한다.
+export const isForbiddenError = (error: unknown): boolean =>
+  isAxiosErrorLike(error) && error.response?.status === 403;
+
 export const isInvalidRefreshTokenError = (error: unknown): boolean => {
   if (!isAxiosErrorLike(error)) {
     return false;

--- a/src/app.module/api/errorNotify.ts
+++ b/src/app.module/api/errorNotify.ts
@@ -6,6 +6,7 @@ import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
 
 import { API_BASE_URL } from './config';
 import {
+  isForbiddenError,
   isInvalidRefreshTokenError,
   isRedirectError,
   isUnauthorizedError,
@@ -54,11 +55,21 @@ export const handleAuthError = (error: unknown): void => {
     return;
   }
 
-  // 401(토큰 없음/만료) 또는 refresh token 무효(AUTH-006) 모두 세션을 복구할
-  // 수 없으므로 동일하게 정리한다. AUTH-006 을 빼면 hasTokens() 가 계속 true 라
-  // 새로고침/재개마다 /auth/token 재시도 → 같은 에러가 무한 반복된다.
+  // 서버가 세션을 명시적으로 거부한 경우만 정리한다:
+  //   - 401(토큰 없음/만료)
+  //   - 403(회전형 refresh 재사용 감지로 family 무효화 등)
+  //   - refresh token 무효 코드(AUTH-006)
+  // 401/AUTH-006 만 정리하면, 서버가 403 등 다른 에러로 리프레시를 거부할 때
+  // hasTokens() 가 계속 true 라 무효 토큰이 남아 재로그인이 막히고 같은 에러가
+  // 무한 반복된다. 반대로 5xx·429·408·네트워크/타임아웃(일시적)에는 세션을
+  // 유지하고 다음 요청에서 재시도하게 둔다 — 백엔드 순단으로 로그인 사용자를
+  // 일괄 로그아웃시키지 않기 위함.
   const invalidRefresh = isInvalidRefreshTokenError(error);
-  if (!isUnauthorizedError(error) && !invalidRefresh) {
+  if (
+    !isUnauthorizedError(error) &&
+    !isForbiddenError(error) &&
+    !invalidRefresh
+  ) {
     return;
   }
 


### PR DESCRIPTION
## 📌 Summary

develop → main 승격. 무효/만료 인증 토큰이 정리되지 않아 재로그인이 막히던 문제 수정(#125)을 상용에 반영합니다.

## ✅ 작업 내용

- #125 만 포함 (단일 커밋):
  - `handleAuthError`: 세션 복구 불가 판정을 401 / 403 / AUTH-006 로 한정해 무효 refresh 응답에도 토큰을 확실히 정리. 5xx·429·408·네트워크는 세션 유지(순단 시 일괄 로그아웃 방지).
  - `LoginScreen`: 자동 리다이렉트를 토큰 존재가 아니라 서버가 확인한 세션(사이드바 데이터) 기준으로 변경해 무효 세션의 로그인 무한 루프 해소.
  - `error.ts`: `isForbiddenError`(403) 헬퍼 추가.

## 📎 기타

- 변경 파일: `src/app.feature/auth/screen/LoginScreen.tsx`, `src/app.module/api/error.ts`, `src/app.module/api/errorNotify.ts`
- develop CI green 확인 후 승격.
