### PR TITLE
feat: 챌린지 UI 개선 — 리더보드/대기 목표/인증샷 배지/생성 검증

### DIFF
--- a/src/app.component/cards/ChallengeCard.tsx
+++ b/src/app.component/cards/ChallengeCard.tsx
@@ -4,7 +4,7 @@ import { Card, CircleAvatar, Icon, Stripe } from '@1d1s/design-system';
 import FadeInImage from '@component/FadeInImage';
 import { cn } from '@module/utils/cn';
 import { createActivationKeydownHandler } from '@module/utils/event';
-import { CalendarDays, Target, Users } from 'lucide-react';
+import { CalendarDays, Camera, Target, Users } from 'lucide-react';
 import Link from 'next/link';
 import React, { useMemo } from 'react';
 
@@ -31,6 +31,8 @@ export interface ChallengeCardProps {
   goalType?: ChallengeCardGoalType;
   isGroup?: boolean;
   isEnded?: boolean;
+  // 인증샷 필수 챌린지 — 카메라 배지로 표시한다.
+  isPhotoRequired?: boolean;
   // 공식 챌린지 — 브랜드 링/글로우 + "공식" 배지로 강조한다.
   isOfficial?: boolean;
   participants?: ChallengeCardParticipant[];
@@ -127,6 +129,7 @@ function ChallengeCard({
   goalType,
   isGroup = true,
   isEnded = false,
+  isPhotoRequired = false,
   isOfficial = false,
   participants,
   href,
@@ -262,6 +265,19 @@ function ChallengeCard({
               'items-center gap-1'
             )}
           >
+            {isPhotoRequired ? (
+              <span
+                aria-label="인증샷 필수"
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-full',
+                  'bg-main-800 px-2 py-1 text-[10px] font-bold text-white',
+                  'shadow-sm'
+                )}
+              >
+                <Camera className="h-3 w-3" />
+                인증샷
+              </span>
+            ) : null}
             {goalLabel ? (
               <span
                 className={cn(

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -80,6 +80,7 @@ const ChallengeBoardCardItem = React.memo(
         goalType={challenge.goalType}
         isGroup={challenge.participationType === 'GROUP'}
         isEnded={ended}
+        isPhotoRequired={challenge.photoRequired}
         isOfficial={challenge.challengeType === 'OFFICIAL'}
         participants={challenge.randomParticipants}
         href={href}

--- a/src/app.feature/challenge/board/screen/MemberChallengeListScreen.tsx
+++ b/src/app.feature/challenge/board/screen/MemberChallengeListScreen.tsx
@@ -61,6 +61,7 @@ const MemberChallengeCardItem = React.memo(
         goalType={challenge.goalType}
         isGroup={challenge.participationType === 'GROUP'}
         isEnded={ended}
+        isPhotoRequired={challenge.photoRequired}
         isOfficial={challenge.challengeType === 'OFFICIAL'}
         participants={challenge.randomParticipants}
         href={`/challenge/${challenge.challengeId}`}

--- a/src/app.feature/challenge/board/screen/MyChallengeListScreen.tsx
+++ b/src/app.feature/challenge/board/screen/MyChallengeListScreen.tsx
@@ -62,6 +62,7 @@ const MyChallengeCardItem = React.memo(
         goalType={challenge.goalType as ChallengeCardGoalType}
         isGroup={challenge.participationType === 'GROUP'}
         isEnded={ended}
+        isPhotoRequired={challenge.photoRequired}
         participants={challenge.randomParticipants}
         href={`/challenge/${challenge.challengeId}`}
       />

--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -59,6 +59,8 @@ export interface ChallengeListItem {
   goalType: GoalType;
   participationType: ParticipationType;
   participantCnt: number;
+  // 인증샷(사진) 필수 여부(서버 JSON 키: photoRequired).
+  photoRequired?: boolean;
   liked: boolean;
   likeCnt: number;
   // 공개 범위 — OFFICIAL 일 때 카드를 공식 챌린지로 강조한다.

--- a/src/app.feature/challenge/detail/components/ChallengeLeaderboardCard.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeLeaderboardCard.tsx
@@ -59,6 +59,49 @@ interface MemberRowProps {
   onGoals(): void;
 }
 
+// 1/2/3등 메달 색상 (금 / 은 / 동).
+interface MedalTone {
+  disc: string;
+  ribbon: string;
+  edge: string;
+}
+
+const MEDAL_TONES: Record<number, MedalTone> = {
+  1: { disc: '#FCD34D', ribbon: '#F59E0B', edge: '#D9930A' },
+  2: { disc: '#D5DAE1', ribbon: '#9AA4B2', edge: '#828C9B' },
+  3: { disc: '#E2A56E', ribbon: '#C07A3E', edge: '#A5682F' },
+};
+
+// 리본 + 원반 + 등수 숫자로 구성한 메달 아이콘.
+function MedalIcon({ rank }: { rank: number }): React.ReactElement {
+  const tone = MEDAL_TONES[rank];
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden className="h-full w-full">
+      <path d="M8.5 2 L11.5 2 L10.5 10 L7 9 Z" fill={tone.ribbon} />
+      <path d="M15.5 2 L12.5 2 L13.5 10 L17 9 Z" fill={tone.ribbon} />
+      <circle
+        cx="12"
+        cy="15"
+        r="6.5"
+        fill={tone.disc}
+        stroke={tone.edge}
+        strokeWidth="1"
+      />
+      <text
+        x="12"
+        y="15.5"
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize="8"
+        fontWeight="800"
+        fill="#ffffff"
+      >
+        {rank}
+      </text>
+    </svg>
+  );
+}
+
 // 인라인 리스트와 "전체 보기" 모달이 공유하는 참여자 행.
 // 아바타 + 닉네임 + HOST/참여중 배지 + 목표 버튼.
 function MemberRow({
@@ -69,6 +112,9 @@ function MemberRow({
   const hasGoals = (entry.goals?.length ?? 0) > 0;
 
   const hasRank = typeof entry.rank === 'number' && entry.rank > 0;
+
+  // 상위 3등은 메달 아이콘, 그 외에는 등수 숫자로 표시한다.
+  const isMedal = hasRank && (entry.rank as number) <= 3;
 
   return (
     <div className="flex items-center gap-1">
@@ -82,33 +128,55 @@ function MemberRow({
         )}
       >
         {hasRank ? (
-          <span
-            className={cn(
-              'flex h-5 w-5 shrink-0 items-center justify-center',
-              'text-[12px] font-extrabold tabular-nums',
-              entry.rank === 1
-                ? 'text-main-800'
-                : entry.rank && entry.rank <= 3
-                  ? 'text-gray-700'
-                  : 'text-gray-400'
-            )}
-          >
-            {entry.rank}
-          </span>
+          isMedal ? (
+            <span className="h-5 w-5 shrink-0">
+              <MedalIcon rank={entry.rank as number} />
+            </span>
+          ) : (
+            <span
+              className={cn(
+                'flex h-5 w-5 shrink-0 items-center justify-center',
+                'text-[12px] font-extrabold text-gray-400 tabular-nums'
+              )}
+            >
+              {entry.rank}
+            </span>
+          )
         ) : null}
         <CircleAvatar
           size="sm"
           imageUrl={entry.profileImg ?? undefined}
           tone="cream"
         />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <Text
-            size="caption1"
-            weight="bold"
-            className="truncate text-gray-800"
-          >
-            {entry.nickname}
-          </Text>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Text
+              size="caption1"
+              weight="bold"
+              className="truncate text-gray-800"
+            >
+              {entry.nickname}
+            </Text>
+            {entry.isHost ? (
+              <span
+                className={cn(
+                  'bg-main-200 text-main-800 shrink-0 rounded-full',
+                  'px-2 py-0.5 text-[10px] font-extrabold'
+                )}
+              >
+                HOST
+              </span>
+            ) : (
+              <span
+                className={cn(
+                  'shrink-0 rounded-full bg-gray-100 px-2 py-0.5',
+                  'text-[10px] font-extrabold text-gray-600'
+                )}
+              >
+                참여 중
+              </span>
+            )}
+          </div>
           {hasRank ? (
             <Text
               size="caption2"
@@ -119,25 +187,6 @@ function MemberRow({
             </Text>
           ) : null}
         </div>
-        {entry.isHost ? (
-          <span
-            className={cn(
-              'bg-main-200 text-main-800 rounded-full',
-              'px-2 py-0.5 text-[10px] font-extrabold'
-            )}
-          >
-            HOST
-          </span>
-        ) : (
-          <span
-            className={cn(
-              'rounded-full bg-gray-100 px-2 py-0.5',
-              'text-[10px] font-extrabold text-gray-600'
-            )}
-          >
-            참여 중
-          </span>
-        )}
       </button>
       {hasGoals ? (
         <button

--- a/src/app.feature/challenge/detail/components/PendingMemberItem.tsx
+++ b/src/app.feature/challenge/detail/components/PendingMemberItem.tsx
@@ -1,14 +1,31 @@
 'use client';
 
-import { Button, CircleAvatar, Tag, Text } from '@1d1s/design-system';
+import {
+  Button,
+  CircleAvatar,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Tag,
+  Text,
+} from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
-import { Check, X } from 'lucide-react';
-import React from 'react';
+import { Check, ListChecks, X } from 'lucide-react';
+import React, { useState } from 'react';
+
+interface PendingMemberGoal {
+  challengeGoalId: number;
+  content: string;
+}
 
 interface PendingMemberItemProps {
   name: string;
   joinedAt: string;
   profileImg?: string | null;
+  // 신청자가 설정한 목표 — 자유 목표 챌린지일 때만 전달된다(있으면 버튼 노출).
+  goals?: PendingMemberGoal[];
   onProfileClick?(): void;
   onAccept(): void;
   onReject(): void;
@@ -19,11 +36,15 @@ export function PendingMemberItem({
   name,
   joinedAt,
   profileImg,
+  goals,
   onProfileClick,
   onAccept,
   onReject,
   isLoading,
 }: PendingMemberItemProps): React.ReactElement {
+  const [goalsOpen, setGoalsOpen] = useState(false);
+  const hasGoals = (goals?.length ?? 0) > 0;
+
   return (
     <div
       className={cn(
@@ -58,6 +79,21 @@ export function PendingMemberItem({
       </button>
 
       <div className="flex shrink-0 items-center gap-1.5">
+        {hasGoals ? (
+          <button
+            type="button"
+            onClick={() => setGoalsOpen(true)}
+            aria-label={`${name}님이 설정한 목표 보기`}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full',
+              'px-2.5 py-1.5 text-[11px] font-bold transition-colors',
+              'bg-gray-100 text-gray-600 hover:bg-gray-200/70'
+            )}
+          >
+            <ListChecks className="h-3.5 w-3.5" />
+            목표
+          </button>
+        ) : null}
         <Button
           variant="primary"
           size="icon"
@@ -77,6 +113,45 @@ export function PendingMemberItem({
           <X className="h-4 w-4" />
         </Button>
       </div>
+
+      <Dialog open={goalsOpen} onOpenChange={setGoalsOpen}>
+        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[420px]">
+          <DialogHeader className="flex-col items-start gap-1.5 pb-2">
+            <DialogTitle className="text-[17px] font-extrabold tracking-[-0.3px] text-gray-900">
+              {`${name}님이 설정한 목표`}
+            </DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <ul className="flex flex-col gap-1.5">
+              {(goals ?? []).map((goal, index) => (
+                <li
+                  key={goal.challengeGoalId}
+                  className={cn(
+                    'flex items-start gap-2.5 rounded-[10px]',
+                    'border border-gray-100 bg-white px-3.5 py-2.5',
+                    'lg:bg-gray-50'
+                  )}
+                >
+                  <Text
+                    size="body2"
+                    weight="extrabold"
+                    className="text-main-800"
+                  >
+                    {index + 1}.
+                  </Text>
+                  <Text
+                    size="body2"
+                    weight="medium"
+                    className="flex-1 break-keep text-gray-700"
+                  >
+                    {goal.content}
+                  </Text>
+                </li>
+              ))}
+            </ul>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -1052,6 +1052,7 @@ export function ChallengeDetailScreen({
                     name={participant.nickname}
                     joinedAt={formatRelativeJoinedText(participant.status)}
                     profileImg={participant.profileImg}
+                    goals={isFreeChallenge ? participant.goals : undefined}
                     onProfileClick={() =>
                       router.push(`/member/${participant.memberId}`)
                     }

--- a/src/app.feature/challenge/write/components/ChallengeCreatePeriodSection.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeCreatePeriodSection.tsx
@@ -9,7 +9,7 @@ import {
 } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import { formatDateKR } from '@module/utils/date';
-import { add } from 'date-fns';
+import { add, startOfToday } from 'date-fns';
 import { type ChangeEvent } from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -103,6 +103,7 @@ export function ChallengeCreatePeriodSection(): React.ReactElement {
                     value={field.value}
                     onChange={field.onChange}
                     placeholder="YYYY/MM/DD"
+                    calendarProps={{ disabled: { before: startOfToday() } }}
                   />
                 </FormControl>
                 <FormMessage />
@@ -162,7 +163,7 @@ export function ChallengeCreatePeriodSection(): React.ReactElement {
                           inputMode="numeric"
                           pattern="[0-9]*"
                           maxLength={3}
-                          placeholder="1 ~ 730"
+                          placeholder="7 ~ 730"
                           className="w-full"
                           value={field.value ?? ''}
                           onChange={(event: ChangeEvent<HTMLInputElement>) => {

--- a/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
+++ b/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
@@ -1,5 +1,6 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { startOfToday } from 'date-fns';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -55,6 +56,12 @@ export const challengeCreateFormSchema = z
         code: z.ZodIssueCode.custom,
         message: '시작일이 선택되지 않았습니다.',
       });
+    } else if (data.startDate < startOfToday()) {
+      ctx.addIssue({
+        path: ['startDate'],
+        code: z.ZodIssueCode.custom,
+        message: '시작일은 오늘 이후로 선택해주세요.',
+      });
     }
     if (data.periodType === 'LIMITED') {
       if (!data.period) {
@@ -71,13 +78,13 @@ export const challengeCreateFormSchema = z
           !isWholeNumberString(data.periodNumber) ||
           isNaN(numberValue) ||
           !Number.isInteger(numberValue) ||
-          numberValue < 1 ||
+          numberValue < 7 ||
           numberValue > 730
         ) {
           ctx.addIssue({
             path: ['periodNumber'],
             code: z.ZodIssueCode.custom,
-            message: '1일부터 730일 사이의 숫자를 입력해주세요.',
+            message: '7일부터 730일 사이의 숫자를 입력해주세요.',
           });
         }
       }

--- a/src/app.feature/home/components/HomeRandomChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeRandomChallengesSection.tsx
@@ -117,6 +117,7 @@ export default function HomeRandomChallengesSection({
                   goalType={challenge.goalType}
                   isGroup={challenge.participationType === 'GROUP'}
                   isEnded={ended}
+                  isPhotoRequired={challenge.photoRequired}
                   participants={challenge.randomParticipants}
                   href={
                     isLoggedIn

--- a/src/app.feature/member/mypage/components/MyPageActiveChallenges.tsx
+++ b/src/app.feature/member/mypage/components/MyPageActiveChallenges.tsx
@@ -91,6 +91,7 @@ export function MyPageActiveChallenges({
                   goalType={challenge.goalType as ChallengeCardGoalType}
                   isGroup={challenge.participationType === 'GROUP'}
                   isEnded={ended}
+                  isPhotoRequired={challenge.photoRequired}
                   participants={challenge.randomParticipants}
                   href={`/challenge/${challenge.challengeId}`}
                 />

--- a/src/app.feature/member/type/member.ts
+++ b/src/app.feature/member/type/member.ts
@@ -57,6 +57,8 @@ export interface MyPageChallenge {
   goalType: string;
   participationType: string;
   participantCnt: number;
+  // 인증샷(사진) 필수 여부(서버 JSON 키: photoRequired).
+  photoRequired?: boolean;
   likeInfo: {
     likedByMe: boolean;
     likeCnt: number;


### PR DESCRIPTION
## 변경 사항

### 챌린지 상세 — 리더보드
- 참여자 행에서 HOST/참여중 배지를 닉네임 옆으로 이동 → 메타 줄(`N일 연속 · 목표 N개`) 잘림 해소
- 1~3등 커스텀 SVG 메달 아이콘(금/은/동), 4등부터는 숫자 유지
- 닉네임·메타 줄 간격 추가

### 챌린지 상세 — 참여 인원 대기
- 신청자가 설정한 목표를 볼 수 있는 버튼/다이얼로그 추가 (자유 목표 챌린지 한정)

### 챌린지 카드
- 인증샷 필수 배지 추가
- `photoRequired`를 목록 타입(`ChallengeListItem`, `MyPageChallenge`) 및 5개 호출부에 연결
  - ⚠️ 목록 API 응답에 `photoRequired`가 포함되는지 백엔드 확인 필요 (현재 상세 응답에만 존재). 없으면 배지 미표시, 에러는 없음

### 챌린지 생성 — 기간
- 시작일: 오늘 이전 날짜 캘린더 비활성 + Zod 스키마 검증
- 진행 기간 직접 입력 최소 7일 (검증 + placeholder)

## 검증
- `pnpm lint` ✅
- `pnpm knip` ✅ (설정 힌트만, 신규 미사용 코드 없음)
- `pnpm build` ✅

브라우저 동작 확인은 미실시 (프로젝트 정책상 사용자 확인).