### PR TITLE
feat: 회원 통계 화면 추가 (기간 요약·감정 분포·작성 추이·친구 비교)

### DIFF
--- a/src/app.feature/member/mypage/screen/MyPageScreen.tsx
+++ b/src/app.feature/member/mypage/screen/MyPageScreen.tsx
@@ -6,6 +6,7 @@ import { useMyDiaries } from '@feature/diary/board/hooks/useDiaryQueries';
 import { MyPageFriendsEntry } from '@feature/friend/components/MyPageFriendsEntry';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useMyPage } from '@feature/member/hooks/useMemberQueries';
+import { MyPageStatisticsEntry } from '@feature/member/statistics/components/MyPageStatisticsEntry';
 import { NOOP_SUBSCRIBE } from '@module/hooks/useHasMounted';
 import { cn } from '@module/utils/cn';
 import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
@@ -81,8 +82,9 @@ export default function MyPageScreen(): React.ReactElement | null {
           challengeHref="/mypage/challenge"
         />
 
-        <div className="mt-6">
+        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
           <MyPageFriendsEntry />
+          <MyPageStatisticsEntry />
         </div>
 
         {/* Streak hero + Heatmap — 모바일은 활동 캘린더(잔디)만 노출.

--- a/src/app.feature/member/statistics/api/statisticsApi.ts
+++ b/src/app.feature/member/statistics/api/statisticsApi.ts
@@ -1,0 +1,86 @@
+import { apiClient } from '@module/api/client';
+import { buildQueryString, requestData } from '@module/api/request';
+
+import type {
+  DiaryTrendParams,
+  DiaryTrendStatistics,
+  FeelingStatistics,
+  FeelingStatisticsParams,
+  FriendComparison,
+  FriendComparisonPeriod,
+  StatisticsPeriods,
+  StatisticsPeriodUnit,
+  StatisticsSummary,
+  StatisticsSummaryParams,
+} from '../type/statistics';
+
+const withQuery = (base: string, query: string): string =>
+  query ? `${base}?${query}` : base;
+
+export const statisticsApi = {
+  getFeelings: async (
+    params: FeelingStatisticsParams = {}
+  ): Promise<FeelingStatistics> =>
+    requestData<FeelingStatistics>(apiClient, {
+      url: withQuery(
+        '/member/statistics/feelings',
+        buildQueryString({
+          from: params.from,
+          to: params.to,
+          challengeId: params.challengeId,
+        })
+      ),
+      method: 'GET',
+    }),
+
+  getDiaryTrend: async (
+    params: DiaryTrendParams
+  ): Promise<DiaryTrendStatistics> =>
+    requestData<DiaryTrendStatistics>(apiClient, {
+      url: withQuery(
+        '/member/statistics/diary-trend',
+        buildQueryString({
+          unit: params.unit,
+          from: params.from,
+          to: params.to,
+        })
+      ),
+      method: 'GET',
+    }),
+
+  getPeriods: async (
+    unit: StatisticsPeriodUnit
+  ): Promise<StatisticsPeriods> =>
+    requestData<StatisticsPeriods>(apiClient, {
+      url: withQuery(
+        '/member/statistics/periods',
+        buildQueryString({ unit })
+      ),
+      method: 'GET',
+    }),
+
+  getSummary: async (
+    params: StatisticsSummaryParams
+  ): Promise<StatisticsSummary> =>
+    requestData<StatisticsSummary>(apiClient, {
+      url: withQuery(
+        '/member/statistics/summary',
+        buildQueryString({
+          unit: params.unit,
+          periodKey: params.periodKey,
+        })
+      ),
+      method: 'GET',
+    }),
+
+  getFriendComparison: async (
+    period: FriendComparisonPeriod
+  ): Promise<FriendComparison> =>
+    requestData<FriendComparison>(apiClient, {
+      url: withQuery(
+        '/member/statistics/friend-comparison',
+        buildQueryString({ period })
+      ),
+      method: 'GET',
+    }),
+};

--- a/src/app.feature/member/statistics/components/DiaryTrendSection.tsx
+++ b/src/app.feature/member/statistics/components/DiaryTrendSection.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { SegmentedControl } from '@1d1s/design-system';
+import React, { useState } from 'react';
+
+import { useDiaryTrend } from '../hooks/useStatisticsQueries';
+import type { DiaryTrendUnit } from '../type/statistics';
+import { formatBucketLabel } from '../utils/statisticsView';
+import { StatisticsCard } from './StatisticsCard';
+import { TrendBars, type TrendDatum } from './TrendBars';
+
+const UNIT_OPTIONS = [
+  { value: 'DAY', label: '일' },
+  { value: 'WEEK', label: '주' },
+  { value: 'MONTH', label: '월' },
+];
+
+/**
+ * 작성 추이 — 일/주/월 토글 + 막대 차트.
+ */
+export function DiaryTrendSection(): React.ReactElement {
+  const [unit, setUnit] = useState<DiaryTrendUnit>('DAY');
+  const { data, isLoading, isError, error } = useDiaryTrend({ unit });
+
+  const points = data?.points ?? [];
+  const chartData: TrendDatum[] = points.map((p) => ({
+    bucket: p.bucket,
+    count: p.count ?? 0,
+    label: formatBucketLabel(p.bucket),
+  }));
+  const totalCount = chartData.reduce((sum, d) => sum + d.count, 0);
+
+  return (
+    <StatisticsCard
+      title="작성 추이"
+      subtitle="기간별 일지 작성 수"
+      action={
+        <SegmentedControl
+          size="sm"
+          options={UNIT_OPTIONS}
+          value={unit}
+          onValueChange={(v) => setUnit(v as DiaryTrendUnit)}
+          aria-label="작성 추이 단위"
+        />
+      }
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+      isEmpty={chartData.length === 0 || totalCount === 0}
+      emptyText="이 기간에 작성한 일지가 없어요."
+      skeletonHeight={160}
+    >
+      <TrendBars data={chartData} />
+    </StatisticsCard>
+  );
+}

--- a/src/app.feature/member/statistics/components/DiaryTrendSection.tsx
+++ b/src/app.feature/member/statistics/components/DiaryTrendSection.tsx
@@ -20,7 +20,9 @@ const UNIT_OPTIONS = [
  */
 export function DiaryTrendSection(): React.ReactElement {
   const [unit, setUnit] = useState<DiaryTrendUnit>('DAY');
-  const { data, isLoading, isError, error } = useDiaryTrend({ unit });
+  const { data, isPending, isSuccess, isError, error } = useDiaryTrend({
+    unit,
+  });
 
   const points = data?.points ?? [];
   const chartData: TrendDatum[] = points.map((p) => ({
@@ -43,10 +45,10 @@ export function DiaryTrendSection(): React.ReactElement {
           aria-label="작성 추이 단위"
         />
       }
-      isLoading={isLoading}
+      isLoading={isPending}
       isError={isError}
       error={error}
-      isEmpty={chartData.length === 0 || totalCount === 0}
+      isEmpty={isSuccess && (chartData.length === 0 || totalCount === 0)}
       emptyText="이 기간에 작성한 일지가 없어요."
       skeletonHeight={160}
     >

--- a/src/app.feature/member/statistics/components/DiaryTrendSection.tsx
+++ b/src/app.feature/member/statistics/components/DiaryTrendSection.tsx
@@ -50,7 +50,10 @@ export function DiaryTrendSection(): React.ReactElement {
       emptyText="이 기간에 작성한 일지가 없어요."
       skeletonHeight={160}
     >
-      <TrendBars data={chartData} />
+      <TrendBars
+        data={chartData}
+        ariaLabel={`작성 추이 막대 차트, 총 ${totalCount}건`}
+      />
     </StatisticsCard>
   );
 }

--- a/src/app.feature/member/statistics/components/DonutChart.tsx
+++ b/src/app.feature/member/statistics/components/DonutChart.tsx
@@ -16,6 +16,8 @@ interface DonutChartProps {
   thickness?: number;
   /** 가운데 노드 */
   centerSlot?: React.ReactNode;
+  /** 스크린리더용 차트 설명 */
+  ariaLabel?: string;
   className?: string;
 }
 
@@ -34,6 +36,7 @@ export function DonutChart({
   size = 160,
   thickness = 26,
   centerSlot,
+  ariaLabel,
   className,
 }: DonutChartProps): React.ReactElement {
   const total = segments.reduce((sum, seg) => sum + Math.max(0, seg.value), 0);
@@ -70,7 +73,13 @@ export function DonutChart({
       className={cn('relative shrink-0', className)}
       style={{ width: size, height: size }}
     >
-      <svg viewBox={`0 0 ${VIEW} ${VIEW}`} width={size} height={size} role="img">
+      <svg
+        viewBox={`0 0 ${VIEW} ${VIEW}`}
+        width={size}
+        height={size}
+        role="img"
+        aria-label={ariaLabel}
+      >
         <circle
           cx={CENTER}
           cy={CENTER}

--- a/src/app.feature/member/statistics/components/DonutChart.tsx
+++ b/src/app.feature/member/statistics/components/DonutChart.tsx
@@ -1,0 +1,92 @@
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+export interface DonutSegment {
+  key: string;
+  value: number;
+  color: string;
+  label: string;
+}
+
+interface DonutChartProps {
+  segments: DonutSegment[];
+  /** 직경(px) */
+  size?: number;
+  /** 도넛 두께(px) */
+  thickness?: number;
+  /** 가운데 노드 */
+  centerSlot?: React.ReactNode;
+  className?: string;
+}
+
+// 100x100 viewBox 좌표계. 렌더 크기(size)와 무관하게 SVG가 스케일된다.
+const VIEW = 100;
+const CENTER = VIEW / 2;
+const RADIUS = 40;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+/**
+ * 순수 SVG 도넛 차트 (외부 의존성 없음).
+ * 값 합이 0이면 회색 트랙만 그린다.
+ */
+export function DonutChart({
+  segments,
+  size = 160,
+  thickness = 26,
+  centerSlot,
+  className,
+}: DonutChartProps): React.ReactElement {
+  const total = segments.reduce((sum, seg) => sum + Math.max(0, seg.value), 0);
+  // px 두께를 viewBox 단위로 환산 (scale = size/VIEW).
+  const strokeWidth = (thickness / size) * VIEW;
+
+  let offset = 0;
+  const arcs =
+    total > 0
+      ? segments
+          .filter((seg) => seg.value > 0)
+          .map((seg) => {
+            const dash = (seg.value / total) * CIRCUMFERENCE;
+            const arc = (
+              <circle
+                key={seg.key}
+                cx={CENTER}
+                cy={CENTER}
+                r={RADIUS}
+                fill="none"
+                stroke={seg.color}
+                strokeWidth={strokeWidth}
+                strokeDasharray={`${dash} ${CIRCUMFERENCE - dash}`}
+                strokeDashoffset={-offset}
+              />
+            );
+            offset += dash;
+            return arc;
+          })
+      : [];
+
+  return (
+    <div
+      className={cn('relative shrink-0', className)}
+      style={{ width: size, height: size }}
+    >
+      <svg viewBox={`0 0 ${VIEW} ${VIEW}`} width={size} height={size} role="img">
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill="none"
+          stroke="var(--gray-100)"
+          strokeWidth={strokeWidth}
+        />
+        {/* -90deg 회전으로 12시 방향에서 시작 */}
+        <g transform={`rotate(-90 ${CENTER} ${CENTER})`}>{arcs}</g>
+      </svg>
+      {centerSlot ? (
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          {centerSlot}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
+++ b/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
@@ -57,6 +57,7 @@ export function FeelingDistributionSection(): React.ReactElement {
         <DonutChart
           segments={segments}
           size={160}
+          ariaLabel={`감정 분포 도넛 차트, 전체 ${total}건`}
           centerSlot={
             <>
               <Text size="heading2" weight="extrabold">

--- a/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
+++ b/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
@@ -20,7 +20,8 @@ import { StatisticsCard } from './StatisticsCard';
  * 감정 분포 — 도넛 + 감정별 비율 범례.
  */
 export function FeelingDistributionSection(): React.ReactElement {
-  const { data, isLoading, isError, error } = useFeelingStatistics();
+  const { data, isPending, isSuccess, isError, error } =
+    useFeelingStatistics();
 
   const total = data?.total ?? 0;
   const countByFeeling = new Map<Feeling, number>();
@@ -41,10 +42,10 @@ export function FeelingDistributionSection(): React.ReactElement {
     <StatisticsCard
       title="감정 분포"
       subtitle="일지에 기록한 감정 비율"
-      isLoading={isLoading}
+      isLoading={isPending}
       isError={isError}
       error={error}
-      isEmpty={total === 0}
+      isEmpty={isSuccess && total === 0}
       emptyText="아직 기록된 감정이 없어요."
       skeletonHeight={180}
     >

--- a/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
+++ b/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import type { Feeling } from '@feature/diary/board/type/diary';
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+import { useFeelingStatistics } from '../hooks/useStatisticsQueries';
+import {
+  FEELING_COLOR,
+  FEELING_EMOJI,
+  FEELING_LABEL,
+  FEELING_ORDER,
+  formatPercent,
+} from '../utils/statisticsView';
+import { DonutChart, type DonutSegment } from './DonutChart';
+import { StatisticsCard } from './StatisticsCard';
+
+/**
+ * 감정 분포 — 도넛 + 감정별 비율 범례.
+ */
+export function FeelingDistributionSection(): React.ReactElement {
+  const { data, isLoading, isError, error } = useFeelingStatistics();
+
+  const total = data?.total ?? 0;
+  const countByFeeling = new Map<Feeling, number>();
+  const ratioByFeeling = new Map<Feeling, number>();
+  (data?.distribution ?? []).forEach((item) => {
+    countByFeeling.set(item.feeling, item.count);
+    ratioByFeeling.set(item.feeling, item.ratio);
+  });
+
+  const segments: DonutSegment[] = FEELING_ORDER.map((feeling) => ({
+    key: feeling,
+    value: countByFeeling.get(feeling) ?? 0,
+    color: FEELING_COLOR[feeling],
+    label: FEELING_LABEL[feeling],
+  }));
+
+  return (
+    <StatisticsCard
+      title="감정 분포"
+      subtitle="일지에 기록한 감정 비율"
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+      isEmpty={total === 0}
+      emptyText="아직 기록된 감정이 없어요."
+      skeletonHeight={180}
+    >
+      <div
+        className={cn(
+          'flex flex-col items-center gap-5',
+          'sm:flex-row sm:items-center sm:gap-6'
+        )}
+      >
+        <DonutChart
+          segments={segments}
+          size={160}
+          centerSlot={
+            <>
+              <Text size="heading2" weight="extrabold">
+                {total}
+              </Text>
+              <Text size="caption4" className="text-gray-500">
+                전체 일지
+              </Text>
+            </>
+          }
+        />
+
+        <ul className="w-full flex-1 space-y-2.5">
+          {FEELING_ORDER.map((feeling) => {
+            const count = countByFeeling.get(feeling) ?? 0;
+            const ratio =
+              ratioByFeeling.get(feeling) ??
+              (total > 0 ? count / total : 0);
+            return (
+              <li
+                key={feeling}
+                className="flex items-center gap-2.5"
+              >
+                <span
+                  aria-hidden
+                  className="h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: FEELING_COLOR[feeling] }}
+                />
+                <span aria-hidden>{FEELING_EMOJI[feeling]}</span>
+                <Text size="caption1" className="flex-1 text-gray-700">
+                  {FEELING_LABEL[feeling]}
+                </Text>
+                <Text
+                  size="caption1"
+                  weight="bold"
+                  className="text-gray-900"
+                >
+                  {formatPercent(ratio)}
+                </Text>
+                <Text size="caption3" className="w-10 text-right text-gray-400">
+                  {count}개
+                </Text>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </StatisticsCard>
+  );
+}

--- a/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
+++ b/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { SegmentedControl, Tag, Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import React, { useState } from 'react';
+
+import { useFriendComparison } from '../hooks/useStatisticsQueries';
+import type { FriendComparisonPeriod } from '../type/statistics';
+import { StatisticsCard } from './StatisticsCard';
+
+const PERIOD_OPTIONS = [
+  { value: 'WEEK', label: '주간' },
+  { value: 'MONTH', label: '월간' },
+];
+
+function Bar({
+  value,
+  max,
+  color,
+  caption,
+}: {
+  value: number;
+  max: number;
+  color: string;
+  caption: string;
+}): React.ReactElement {
+  const widthPct = max > 0 ? Math.max(4, (value / max) * 100) : 4;
+  return (
+    <div className="flex items-center gap-2">
+      <Text size="caption4" className="w-14 shrink-0 text-gray-400">
+        {caption}
+      </Text>
+      <div className="h-3 flex-1 overflow-hidden rounded-full bg-gray-100">
+        <div
+          className="h-full rounded-full"
+          style={{ width: `${widthPct}%`, backgroundColor: color }}
+        />
+      </div>
+      <Text size="caption3" weight="bold" className="w-6 text-right">
+        {value}
+      </Text>
+    </div>
+  );
+}
+
+interface CompareRowProps {
+  label: string;
+  mine: number;
+  average: number;
+}
+
+function CompareRow({
+  label,
+  mine,
+  average,
+}: CompareRowProps): React.ReactElement {
+  const max = Math.max(mine, average, 1);
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <Text size="caption1" weight="medium" className="text-gray-700">
+          {label}
+        </Text>
+        <Text size="caption3" className="text-gray-400">
+          나 {mine} · 친구 평균 {average}
+        </Text>
+      </div>
+      <div className="mt-2 space-y-1.5">
+        <Bar value={mine} max={max} color="var(--main-500)" caption="나" />
+        <Bar
+          value={average}
+          max={max}
+          color="var(--gray-300)"
+          caption="친구 평균"
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 친구 비교 — 나 vs 친구 평균 + 순위. 개별 친구는 노출하지 않는다.
+ */
+export function FriendComparisonSection(): React.ReactElement {
+  const [period, setPeriod] = useState<FriendComparisonPeriod>('WEEK');
+  const { data, isLoading, isError, error } = useFriendComparison(period);
+
+  const friendCount = data?.friendCount ?? 0;
+  const me = data?.me;
+  const average = data?.friendsAverage;
+  const rank = data?.myRank;
+
+  return (
+    <StatisticsCard
+      title="친구 비교"
+      subtitle="친구 평균과 나의 활동 비교"
+      action={
+        <SegmentedControl
+          size="sm"
+          options={PERIOD_OPTIONS}
+          value={period}
+          onValueChange={(v) => setPeriod(v as FriendComparisonPeriod)}
+          aria-label="친구 비교 기간"
+        />
+      }
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+      isEmpty={!isLoading && !isError && friendCount === 0}
+      emptyText="친구를 추가하면 평균과 순위를 비교할 수 있어요."
+      skeletonHeight={200}
+    >
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Tag tone="gray" size="sm">
+            친구 {friendCount}명
+          </Tag>
+          {rank && rank.outOf > 0 ? (
+            <Tag tone="brand" size="sm" icon="🏆">
+              일지 순위 {rank.byDiaryCount}/{rank.outOf}
+            </Tag>
+          ) : null}
+        </div>
+
+        <div
+          className={cn(
+            'space-y-4 rounded-[12px] border border-gray-100',
+            'bg-gray-50 p-4'
+          )}
+        >
+          <CompareRow
+            label="작성한 일지"
+            mine={me?.diaryCount ?? 0}
+            average={average?.diaryCount ?? 0}
+          />
+          <CompareRow
+            label="달성한 목표"
+            mine={me?.completedGoalCount ?? 0}
+            average={average?.completedGoalCount ?? 0}
+          />
+        </div>
+      </div>
+    </StatisticsCard>
+  );
+}

--- a/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
+++ b/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
@@ -84,7 +84,8 @@ function CompareRow({
  */
 export function FriendComparisonSection(): React.ReactElement {
   const [period, setPeriod] = useState<FriendComparisonPeriod>('WEEK');
-  const { data, isLoading, isError, error } = useFriendComparison(period);
+  const { data, isPending, isSuccess, isError, error } =
+    useFriendComparison(period);
 
   const friendCount = data?.friendCount ?? 0;
   const me = data?.me;
@@ -104,10 +105,10 @@ export function FriendComparisonSection(): React.ReactElement {
           aria-label="친구 비교 기간"
         />
       }
-      isLoading={isLoading}
+      isLoading={isPending}
       isError={isError}
       error={error}
-      isEmpty={!isLoading && !isError && friendCount === 0}
+      isEmpty={isSuccess && friendCount === 0}
       emptyText="친구를 추가하면 평균과 순위를 비교할 수 있어요."
       skeletonHeight={200}
     >

--- a/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
+++ b/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react';
 
 import { useFriendComparison } from '../hooks/useStatisticsQueries';
 import type { FriendComparisonPeriod } from '../type/statistics';
+import { formatCount } from '../utils/statisticsView';
 import { StatisticsCard } from './StatisticsCard';
 
 const PERIOD_OPTIONS = [
@@ -36,8 +37,8 @@ function Bar({
           style={{ width: `${widthPct}%`, backgroundColor: color }}
         />
       </div>
-      <Text size="caption3" weight="bold" className="w-6 text-right">
-        {value}
+      <Text size="caption3" weight="bold" className="w-8 text-right">
+        {formatCount(value)}
       </Text>
     </div>
   );
@@ -62,7 +63,7 @@ function CompareRow({
           {label}
         </Text>
         <Text size="caption3" className="text-gray-400">
-          나 {mine} · 친구 평균 {average}
+          나 {formatCount(mine)} · 친구 평균 {formatCount(average)}
         </Text>
       </div>
       <div className="mt-2 space-y-1.5">

--- a/src/app.feature/member/statistics/components/MyPageStatisticsEntry.tsx
+++ b/src/app.feature/member/statistics/components/MyPageStatisticsEntry.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { BarChart3, ChevronRight } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+/**
+ * 마이페이지에서 통계 화면으로 진입하는 카드.
+ */
+export function MyPageStatisticsEntry(): React.ReactElement {
+  const router = useRouter();
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.push('/mypage/statistics')}
+      className={cn(
+        'group flex w-full items-center gap-3 rounded-[14px]',
+        'border border-gray-200 bg-white px-4 py-4 text-left',
+        'transition-colors hover:bg-gray-50'
+      )}
+    >
+      <span
+        className={cn(
+          'flex h-10 w-10 shrink-0 items-center justify-center',
+          'rounded-full bg-gray-100 text-gray-700'
+        )}
+        aria-hidden
+      >
+        <BarChart3 className="h-5 w-5" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <Text as="div" size="body1" weight="medium" className="text-gray-900">
+          통계
+        </Text>
+        <Text as="div" size="caption2" className="text-gray-500">
+          감정 분포·작성 추이·친구 비교
+        </Text>
+      </div>
+      <ChevronRight className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
+    </button>
+  );
+}

--- a/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
+++ b/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import {
+  SegmentedControl,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  StatCard,
+  Tag,
+  Text,
+} from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+
+import {
+  useStatisticsPeriods,
+  useStatisticsSummary,
+} from '../hooks/useStatisticsQueries';
+import type { StatisticsPeriodUnit } from '../type/statistics';
+import {
+  FEELING_EMOJI,
+  FEELING_LABEL,
+  FEELING_ORDER,
+  formatBucketLabel,
+  formatDelta,
+  formatPercent,
+} from '../utils/statisticsView';
+import { StatisticsCard } from './StatisticsCard';
+import { TrendBars, type TrendDatum } from './TrendBars';
+
+const UNIT_OPTIONS = [
+  { value: 'WEEK', label: '주' },
+  { value: 'MONTH', label: '월' },
+  { value: 'YEAR', label: '연' },
+];
+
+// 가장 활발한 구간 라벨 — 연간은 "달", 그 외는 "날".
+const PEAK_LABEL: Record<StatisticsPeriodUnit, string> = {
+  WEEK: '가장 활발한 날',
+  MONTH: '가장 활발한 날',
+  YEAR: '가장 활발한 달',
+};
+
+function NavButton({
+  direction,
+  disabled,
+  onClick,
+}: {
+  direction: 'prev' | 'next';
+  disabled: boolean;
+  onClick(): void;
+}): React.ReactElement {
+  const Icon = direction === 'prev' ? ChevronLeft : ChevronRight;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={direction === 'prev' ? '이전 기간' : '다음 기간'}
+      className={cn(
+        'flex h-9 w-9 shrink-0 items-center justify-center',
+        'rounded-full border border-gray-200 bg-white text-gray-600',
+        'transition-colors hover:bg-gray-50',
+        'disabled:cursor-not-allowed disabled:opacity-40'
+      )}
+    >
+      <Icon className="h-4 w-4" aria-hidden />
+    </button>
+  );
+}
+
+interface PeriodNavProps {
+  periods: Array<{ key: string; label: string }>;
+  activeKey?: string;
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPrev(): void;
+  onNext(): void;
+  onJump(key: string): void;
+}
+
+function PeriodNav({
+  periods,
+  activeKey,
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+  onJump,
+}: PeriodNavProps): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2">
+      <NavButton direction="prev" disabled={!hasPrev} onClick={onPrev} />
+      <div className="min-w-0 flex-1">
+        <Select value={activeKey} onValueChange={onJump}>
+          <SelectTrigger size="sm" className="w-full justify-center">
+            <SelectValue placeholder="기간 선택" />
+          </SelectTrigger>
+          <SelectContent>
+            {periods.map((period) => (
+              <SelectItem key={period.key} value={period.key}>
+                {period.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <NavButton direction="next" disabled={!hasNext} onClick={onNext} />
+    </div>
+  );
+}
+
+/**
+ * 기간 요약 — 주/월/연 토글 + 이전/다음 네비 + 기간 점프 + KPI 카드.
+ */
+export function PeriodSummarySection(): React.ReactElement {
+  const [unit, setUnit] = useState<StatisticsPeriodUnit>('WEEK');
+  const [periodKey, setPeriodKey] = useState<string | undefined>(undefined);
+
+  const periodsQuery = useStatisticsPeriods(unit);
+  const summaryQuery = useStatisticsSummary({ unit, periodKey });
+
+  const summary = summaryQuery.data;
+
+  // start 기준 오름차순 정렬 → 서버 배열 순서와 무관하게 이전/다음 결정.
+  const sortedPeriods = useMemo(() => {
+    const list = periodsQuery.data?.periods ?? [];
+    return [...list].sort((first, second) =>
+      first.start.localeCompare(second.start)
+    );
+  }, [periodsQuery.data]);
+
+  // 실제 로드된 기간 키를 우선 사용 (초기 undefined → 서버가 최신 반환).
+  const activeKey = summary?.periodKey ?? periodKey;
+  const activeIndex = sortedPeriods.findIndex((item) => item.key === activeKey);
+
+  const changeUnit = (next: StatisticsPeriodUnit): void => {
+    setUnit(next);
+    setPeriodKey(undefined);
+  };
+
+  const goPrev = (): void => {
+    if (activeIndex > 0) {
+      setPeriodKey(sortedPeriods[activeIndex - 1].key);
+    }
+  };
+  const goNext = (): void => {
+    if (activeIndex >= 0 && activeIndex < sortedPeriods.length - 1) {
+      setPeriodKey(sortedPeriods[activeIndex + 1].key);
+    }
+  };
+
+  const subTrend: TrendDatum[] = (summary?.subTrend ?? []).map((point) => ({
+    bucket: point.bucket,
+    count: point.count ?? 0,
+    label: formatBucketLabel(point.bucket),
+  }));
+
+  const isLoading = summaryQuery.isLoading || periodsQuery.isLoading;
+
+  return (
+    <StatisticsCard
+      title="기간 요약"
+      subtitle="주·월·연 단위 활동 리포트"
+      action={
+        <SegmentedControl
+          size="sm"
+          options={UNIT_OPTIONS}
+          value={unit}
+          onValueChange={(value) => changeUnit(value as StatisticsPeriodUnit)}
+          aria-label="요약 기간 단위"
+        />
+      }
+      isLoading={isLoading}
+      isError={summaryQuery.isError}
+      error={summaryQuery.error}
+      isEmpty={!isLoading && !summary}
+      emptyText="아직 요약할 활동이 없어요."
+      skeletonHeight={320}
+    >
+      {summary ? (
+        <div className="space-y-5">
+          <PeriodNav
+            periods={sortedPeriods}
+            activeKey={activeKey}
+            hasPrev={summary.hasPrev ?? false}
+            hasNext={summary.hasNext ?? false}
+            onPrev={goPrev}
+            onNext={goNext}
+            onJump={setPeriodKey}
+          />
+
+          <div className="grid grid-cols-2 gap-2.5 lg:grid-cols-4">
+            <StatCard
+              label="작성한 일지"
+              value={summary.diaryCount}
+              helper={`전기간 대비 ${formatDelta(summary.diaryCountDelta)}`}
+              tone="brand"
+            />
+            <StatCard label="활동일수" value={summary.activeDays} />
+            <StatCard
+              label="목표 달성률"
+              value={formatPercent(summary.goalCompletionRate)}
+              helper={`달성 ${summary.completedGoalCount}개`}
+              tone="mint"
+            />
+            <StatCard
+              label="기간 내 최장 스트릭"
+              value={summary.maxStreakInPeriod}
+              tone="blue"
+            />
+          </div>
+
+          <div
+            className={cn(
+              'flex flex-wrap items-center gap-2 rounded-[12px]',
+              'bg-gray-50 px-4 py-3'
+            )}
+          >
+            <Text size="caption2" className="text-gray-500">
+              {PEAK_LABEL[summary.unit]}
+            </Text>
+            <Text size="caption1" weight="bold" className="text-gray-900">
+              {summary.peakBucket && summary.peakBucket.count > 0
+                ? `${formatBucketLabel(summary.peakBucket.key)} · ` +
+                  `${summary.peakBucket.count}개`
+                : '없음'}
+            </Text>
+          </div>
+
+          <div>
+            <Text size="caption2" className="mb-2 block text-gray-500">
+              감정 구성
+            </Text>
+            <div className="flex flex-wrap gap-1.5">
+              {FEELING_ORDER.map((feeling) => {
+                const item = (summary.feelingBreakdown ?? []).find(
+                  (entry) => entry.feeling === feeling
+                );
+                return (
+                  <Tag key={feeling} tone="gray" size="sm">
+                    {FEELING_EMOJI[feeling]} {FEELING_LABEL[feeling]}{' '}
+                    {item?.count ?? 0}
+                  </Tag>
+                );
+              })}
+            </div>
+          </div>
+
+          {subTrend.length > 0 ? (
+            <div>
+              <Text size="caption2" className="mb-2 block text-gray-500">
+                기간 내 추이
+              </Text>
+              <TrendBars data={subTrend} compact />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </StatisticsCard>
+  );
+}

--- a/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
+++ b/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
@@ -168,7 +168,9 @@ export function PeriodSummarySection(): React.ReactElement {
     label: formatBucketLabel(point.bucket),
   }));
 
-  const isLoading = summaryQuery.isLoading || periodsQuery.isLoading;
+  // 로그인 확정 전(enabled: false)에는 isLoading 이 false 라서 빈상태로
+  // 새는 문제가 있어, settled 전까지는 isPending 으로 스켈레톤을 유지한다.
+  const isPending = summaryQuery.isPending || periodsQuery.isPending;
 
   return (
     <StatisticsCard
@@ -183,10 +185,10 @@ export function PeriodSummarySection(): React.ReactElement {
           aria-label="요약 기간 단위"
         />
       }
-      isLoading={isLoading}
+      isLoading={isPending}
       isError={summaryQuery.isError}
       error={summaryQuery.error}
-      isEmpty={!isLoading && !summary}
+      isEmpty={summaryQuery.isSuccess && !summary}
       emptyText="아직 요약할 활동이 없어요."
       skeletonHeight={320}
     >

--- a/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
+++ b/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
@@ -137,6 +137,15 @@ export function PeriodSummarySection(): React.ReactElement {
   const activeKey = summary?.periodKey ?? periodKey;
   const activeIndex = sortedPeriods.findIndex((item) => item.key === activeKey);
 
+  // 버튼 활성은 서버 신호(hasPrev/hasNext)와 실제 목록 내 이동 가능 여부를
+  // 함께 만족할 때만. 키 포맷 불일치·로딩 레이스로 activeIndex 를 못 찾으면
+  // 활성화돼도 클릭이 무의미하므로 비활성 처리한다.
+  const canPrev = (summary?.hasPrev ?? false) && activeIndex > 0;
+  const canNext =
+    (summary?.hasNext ?? false) &&
+    activeIndex >= 0 &&
+    activeIndex < sortedPeriods.length - 1;
+
   const changeUnit = (next: StatisticsPeriodUnit): void => {
     setUnit(next);
     setPeriodKey(undefined);
@@ -186,8 +195,8 @@ export function PeriodSummarySection(): React.ReactElement {
           <PeriodNav
             periods={sortedPeriods}
             activeKey={activeKey}
-            hasPrev={summary.hasPrev ?? false}
-            hasNext={summary.hasNext ?? false}
+            hasPrev={canPrev}
+            hasNext={canNext}
             onPrev={goPrev}
             onNext={goNext}
             onJump={setPeriodKey}
@@ -255,7 +264,11 @@ export function PeriodSummarySection(): React.ReactElement {
               <Text size="caption2" className="mb-2 block text-gray-500">
                 기간 내 추이
               </Text>
-              <TrendBars data={subTrend} compact />
+              <TrendBars
+                data={subTrend}
+                compact
+                ariaLabel="기간 내 작성 추이 막대 차트"
+              />
             </div>
           ) : null}
         </div>

--- a/src/app.feature/member/statistics/components/StatisticsCard.tsx
+++ b/src/app.feature/member/statistics/components/StatisticsCard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Text } from '@1d1s/design-system';
 import { Skeleton } from '@component/Skeleton';
 import { normalizeApiError } from '@module/api/error';

--- a/src/app.feature/member/statistics/components/StatisticsCard.tsx
+++ b/src/app.feature/member/statistics/components/StatisticsCard.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { Skeleton } from '@component/Skeleton';
+import { normalizeApiError } from '@module/api/error';
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+interface StatisticsCardProps {
+  title: string;
+  subtitle?: string;
+  /** 제목 우측 컨트롤 (토글 등) */
+  action?: React.ReactNode;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: unknown;
+  /** 데이터가 비었는지 (0건) */
+  isEmpty?: boolean;
+  emptyText?: string;
+  /** 로딩 스켈레톤 높이(px) */
+  skeletonHeight?: number;
+  children: React.ReactNode;
+}
+
+function StatisticsMessage({
+  tone,
+  children,
+}: {
+  tone: 'error' | 'empty';
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div
+      className={cn(
+        'flex min-h-[120px] items-center justify-center',
+        'rounded-[12px] bg-gray-50 px-4 py-8 text-center'
+      )}
+    >
+      <Text
+        size="caption1"
+        className={cn(tone === 'error' ? 'text-red-500' : 'text-gray-500')}
+      >
+        {children}
+      </Text>
+    </div>
+  );
+}
+
+/**
+ * 통계 섹션 공통 카드 — 헤더 + 로딩/에러/빈 상태 처리.
+ */
+export function StatisticsCard({
+  title,
+  subtitle,
+  action,
+  isLoading,
+  isError,
+  error,
+  isEmpty,
+  emptyText = '데이터가 아직 없어요.',
+  skeletonHeight = 160,
+  children,
+}: StatisticsCardProps): React.ReactElement {
+  return (
+    <section
+      className={cn(
+        'rounded-[16px] border border-gray-200 bg-white',
+        'p-5 lg:p-6'
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <Text as="h2" size="body1" weight="bold" className="text-gray-900">
+            {title}
+          </Text>
+          {subtitle ? (
+            <Text
+              as="p"
+              size="caption2"
+              className="mt-0.5 block text-gray-500"
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+
+      <div className="mt-4">
+        {isLoading ? (
+          <Skeleton style={{ height: skeletonHeight }} className="w-full" />
+        ) : isError ? (
+          <StatisticsMessage tone="error">
+            {normalizeApiError(error).message}
+          </StatisticsMessage>
+        ) : isEmpty ? (
+          <StatisticsMessage tone="empty">{emptyText}</StatisticsMessage>
+        ) : (
+          children
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app.feature/member/statistics/components/TrendBars.tsx
+++ b/src/app.feature/member/statistics/components/TrendBars.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import React from 'react';

--- a/src/app.feature/member/statistics/components/TrendBars.tsx
+++ b/src/app.feature/member/statistics/components/TrendBars.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+export interface TrendDatum {
+  bucket: string;
+  count: number;
+  label: string;
+}
+
+interface TrendBarsProps {
+  data: TrendDatum[];
+  /** 막대 색 (CSS color) */
+  color?: string;
+  /** 미니 모드: 라벨/값 숨김, 높이 축소 */
+  compact?: boolean;
+  className?: string;
+}
+
+/**
+ * CSS flex 기반 막대 차트 (외부 의존성 없음).
+ * 각 bucket 을 최대값 기준 비율 높이 막대로 그린다.
+ */
+export function TrendBars({
+  data,
+  color = 'var(--main-500)',
+  compact = false,
+  className,
+}: TrendBarsProps): React.ReactElement {
+  const max = data.reduce((m, d) => Math.max(m, d.count), 0);
+  const areaHeight = compact ? 56 : 128;
+
+  return (
+    <div className={cn('w-full', className)}>
+      <div
+        className="flex items-end gap-1"
+        style={{ height: areaHeight }}
+        role="img"
+      >
+        {data.map((d, i) => {
+          const ratio = max > 0 ? d.count / max : 0;
+          // 값이 있으면 최소 6% 높이로 보이게, 0이면 얇은 흔적만.
+          const heightPct =
+            d.count > 0 ? Math.max(6, ratio * 100) : 2;
+          return (
+            <div
+              key={`${d.bucket}-${i}`}
+              className="flex min-w-0 flex-1 flex-col items-center justify-end"
+              title={`${d.label}: ${d.count}`}
+            >
+              {!compact && d.count > 0 ? (
+                <Text
+                  size="caption5"
+                  className="mb-1 block text-gray-500"
+                >
+                  {d.count}
+                </Text>
+              ) : null}
+              <div
+                className="w-full rounded-[3px] transition-[height]"
+                style={{
+                  height: `${heightPct}%`,
+                  backgroundColor: d.count > 0 ? color : 'var(--gray-200)',
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {!compact ? (
+        <div className="mt-2 flex gap-1">
+          {data.map((d, i) => (
+            <div
+              key={`${d.bucket}-label-${i}`}
+              className="min-w-0 flex-1 text-center"
+            >
+              <Text
+                size="caption5"
+                className="block truncate text-gray-400"
+              >
+                {d.label}
+              </Text>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app.feature/member/statistics/components/TrendBars.tsx
+++ b/src/app.feature/member/statistics/components/TrendBars.tsx
@@ -16,6 +16,8 @@ interface TrendBarsProps {
   color?: string;
   /** 미니 모드: 라벨/값 숨김, 높이 축소 */
   compact?: boolean;
+  /** 스크린리더용 차트 설명 */
+  ariaLabel?: string;
   className?: string;
 }
 
@@ -27,6 +29,7 @@ export function TrendBars({
   data,
   color = 'var(--main-500)',
   compact = false,
+  ariaLabel,
   className,
 }: TrendBarsProps): React.ReactElement {
   const max = data.reduce((m, d) => Math.max(m, d.count), 0);
@@ -38,6 +41,7 @@ export function TrendBars({
         className="flex items-end gap-1"
         style={{ height: areaHeight }}
         role="img"
+        aria-label={ariaLabel}
       >
         {data.map((d, i) => {
           const ratio = max > 0 ? d.count / max : 0;

--- a/src/app.feature/member/statistics/consts/queryKeys.ts
+++ b/src/app.feature/member/statistics/consts/queryKeys.ts
@@ -1,0 +1,21 @@
+import type {
+  DiaryTrendParams,
+  FeelingStatisticsParams,
+  FriendComparisonPeriod,
+  StatisticsPeriodUnit,
+  StatisticsSummaryParams,
+} from '../type/statistics';
+
+export const STATISTICS_QUERY_KEYS = {
+  all: ['member', 'statistics'] as const,
+  feelings: (params: FeelingStatisticsParams) =>
+    [...STATISTICS_QUERY_KEYS.all, 'feelings', params] as const,
+  diaryTrend: (params: DiaryTrendParams) =>
+    [...STATISTICS_QUERY_KEYS.all, 'diary-trend', params] as const,
+  periods: (unit: StatisticsPeriodUnit) =>
+    [...STATISTICS_QUERY_KEYS.all, 'periods', unit] as const,
+  summary: (params: StatisticsSummaryParams) =>
+    [...STATISTICS_QUERY_KEYS.all, 'summary', params] as const,
+  friendComparison: (period: FriendComparisonPeriod) =>
+    [...STATISTICS_QUERY_KEYS.all, 'friend-comparison', period] as const,
+};

--- a/src/app.feature/member/statistics/hooks/useStatisticsQueries.ts
+++ b/src/app.feature/member/statistics/hooks/useStatisticsQueries.ts
@@ -1,0 +1,80 @@
+import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { statisticsApi } from '../api/statisticsApi';
+import { STATISTICS_QUERY_KEYS } from '../consts/queryKeys';
+import type {
+  DiaryTrendParams,
+  DiaryTrendStatistics,
+  FeelingStatistics,
+  FeelingStatisticsParams,
+  FriendComparison,
+  FriendComparisonPeriod,
+  StatisticsPeriods,
+  StatisticsPeriodUnit,
+  StatisticsSummary,
+  StatisticsSummaryParams,
+} from '../type/statistics';
+
+// 통계는 자주 바뀌지 않으므로 5분간 stale 유지 (재패칭 최소화).
+const STATISTICS_STALE_TIME = 5 * 60 * 1000;
+
+export function useFeelingStatistics(
+  params: FeelingStatisticsParams = {}
+): UseQueryResult<FeelingStatistics, Error> {
+  const isLoggedIn = useIsLoggedIn();
+  return useQuery({
+    queryKey: STATISTICS_QUERY_KEYS.feelings(params),
+    queryFn: () => statisticsApi.getFeelings(params),
+    enabled: isLoggedIn,
+    staleTime: STATISTICS_STALE_TIME,
+  });
+}
+
+export function useDiaryTrend(
+  params: DiaryTrendParams
+): UseQueryResult<DiaryTrendStatistics, Error> {
+  const isLoggedIn = useIsLoggedIn();
+  return useQuery({
+    queryKey: STATISTICS_QUERY_KEYS.diaryTrend(params),
+    queryFn: () => statisticsApi.getDiaryTrend(params),
+    enabled: isLoggedIn,
+    staleTime: STATISTICS_STALE_TIME,
+  });
+}
+
+export function useStatisticsPeriods(
+  unit: StatisticsPeriodUnit
+): UseQueryResult<StatisticsPeriods, Error> {
+  const isLoggedIn = useIsLoggedIn();
+  return useQuery({
+    queryKey: STATISTICS_QUERY_KEYS.periods(unit),
+    queryFn: () => statisticsApi.getPeriods(unit),
+    enabled: isLoggedIn,
+    staleTime: STATISTICS_STALE_TIME,
+  });
+}
+
+export function useStatisticsSummary(
+  params: StatisticsSummaryParams
+): UseQueryResult<StatisticsSummary, Error> {
+  const isLoggedIn = useIsLoggedIn();
+  return useQuery({
+    queryKey: STATISTICS_QUERY_KEYS.summary(params),
+    queryFn: () => statisticsApi.getSummary(params),
+    enabled: isLoggedIn,
+    staleTime: STATISTICS_STALE_TIME,
+  });
+}
+
+export function useFriendComparison(
+  period: FriendComparisonPeriod
+): UseQueryResult<FriendComparison, Error> {
+  const isLoggedIn = useIsLoggedIn();
+  return useQuery({
+    queryKey: STATISTICS_QUERY_KEYS.friendComparison(period),
+    queryFn: () => statisticsApi.getFriendComparison(period),
+    enabled: isLoggedIn,
+    staleTime: STATISTICS_STALE_TIME,
+  });
+}

--- a/src/app.feature/member/statistics/screen/StatisticsScreen.tsx
+++ b/src/app.feature/member/statistics/screen/StatisticsScreen.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { SubPageShell } from '@component/layout/SubPageShell';
+import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { NOOP_SUBSCRIBE } from '@module/hooks/useHasMounted';
+import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useSyncExternalStore } from 'react';
+
+import { DiaryTrendSection } from '../components/DiaryTrendSection';
+import { FeelingDistributionSection } from '../components/FeelingDistributionSection';
+import { FriendComparisonSection } from '../components/FriendComparisonSection';
+import { PeriodSummarySection } from '../components/PeriodSummarySection';
+
+/**
+ * 회원 통계 화면 — 기간 요약 / 감정 분포 / 작성 추이 / 친구 비교.
+ * 각 섹션이 독립적으로 로딩·에러·빈 상태를 처리한다.
+ */
+export default function StatisticsScreen(): React.ReactElement | null {
+  const router = useRouter();
+  const hasMounted = useSyncExternalStore(
+    NOOP_SUBSCRIBE,
+    () => true,
+    () => false
+  );
+  const isLoggedIn = useIsLoggedIn();
+
+  useEffect(() => {
+    if (hasMounted && !isLoggedIn) {
+      router.replace(loginUrlFromCurrentLocation());
+    }
+  }, [hasMounted, isLoggedIn, router]);
+
+  if (hasMounted && !isLoggedIn) {
+    return null;
+  }
+
+  return (
+    <SubPageShell title="통계" description="나의 활동을 한눈에">
+      <div className="data-fade-in space-y-4 pb-10">
+        <PeriodSummarySection />
+        <FeelingDistributionSection />
+        <DiaryTrendSection />
+        <FriendComparisonSection />
+      </div>
+    </SubPageShell>
+  );
+}

--- a/src/app.feature/member/statistics/type/statistics.ts
+++ b/src/app.feature/member/statistics/type/statistics.ts
@@ -1,0 +1,111 @@
+import type { Feeling } from '@feature/diary/board/type/diary';
+
+// 서버 통계 API 계약 (1D1S-server-v2 #315). 전부 GET, 본인 인증.
+
+export type StatisticsPeriodUnit = 'WEEK' | 'MONTH' | 'YEAR';
+export type DiaryTrendUnit = 'DAY' | 'WEEK' | 'MONTH';
+export type FriendComparisonPeriod = 'WEEK' | 'MONTH';
+
+// 1. 감정 분포
+export interface FeelingDistributionItem {
+  feeling: Feeling; // HAPPY | SAD | NORMAL | NONE(미선택)
+  count: number;
+  ratio: number; // 0~1
+}
+
+export interface FeelingStatistics {
+  total: number;
+  distribution: FeelingDistributionItem[];
+}
+
+export interface FeelingStatisticsParams {
+  from?: string;
+  to?: string;
+  challengeId?: number;
+}
+
+// 2. 작성 추이
+export interface DiaryTrendPoint {
+  bucket: string;
+  count: number;
+}
+
+export interface DiaryTrendStatistics {
+  unit: DiaryTrendUnit;
+  from: string;
+  to: string;
+  points: DiaryTrendPoint[];
+}
+
+export interface DiaryTrendParams {
+  unit: DiaryTrendUnit;
+  from?: string;
+  to?: string;
+}
+
+// 3. 기간 목록
+export interface StatisticsPeriod {
+  key: string;
+  start: string;
+  end: string;
+  label: string;
+}
+
+export interface StatisticsPeriods {
+  unit: StatisticsPeriodUnit;
+  signupDate: string;
+  periods: StatisticsPeriod[];
+}
+
+// 4. 기간 요약
+export interface FeelingBreakdownItem {
+  feeling: Feeling;
+  count: number;
+}
+
+export interface PeakBucket {
+  key: string;
+  count: number;
+}
+
+export interface StatisticsSummary {
+  unit: StatisticsPeriodUnit;
+  periodKey: string;
+  start: string;
+  end: string;
+  diaryCount: number;
+  diaryCountDelta: number; // 전기간 대비 증감
+  activeDays: number;
+  completedGoalCount: number;
+  goalCompletionRate: number; // 0~1
+  feelingBreakdown: FeelingBreakdownItem[];
+  maxStreakInPeriod: number;
+  peakBucket: PeakBucket; // 가장 활발한 날(연간은 달)
+  subTrend: DiaryTrendPoint[];
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+export interface StatisticsSummaryParams {
+  unit: StatisticsPeriodUnit;
+  periodKey?: string;
+}
+
+// 5. 친구 비교
+export interface FriendComparisonMetrics {
+  diaryCount: number;
+  completedGoalCount: number;
+}
+
+export interface FriendComparisonRank {
+  byDiaryCount: number;
+  outOf: number;
+}
+
+export interface FriendComparison {
+  period: FriendComparisonPeriod;
+  friendCount: number;
+  me: FriendComparisonMetrics;
+  friendsAverage: FriendComparisonMetrics;
+  myRank: FriendComparisonRank;
+}

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -32,6 +32,15 @@ export function formatPercent(ratio: number): string {
   return `${Math.round(ratio * 100)}%`;
 }
 
+// 평균 등 소수가 섞일 수 있는 값 표시 — 최대 1자리, 정수는 소수점 제거.
+// friendsAverage 처럼 서버가 실수를 내려줄 수 있는 값에 사용한다.
+export function formatCount(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+  return String(Math.round(value * 10) / 10);
+}
+
 // 증감값 표시 — +N / -N / ±0.
 export function formatDelta(delta: number): string {
   if (delta > 0) {

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -1,0 +1,67 @@
+import type { Feeling } from '@feature/diary/board/type/diary';
+
+// 감정 표시 메타 — 라벨/이모지/차트 색(colors.css 변수).
+export const FEELING_ORDER: Feeling[] = ['HAPPY', 'NORMAL', 'SAD', 'NONE'];
+
+export const FEELING_LABEL: Record<Feeling, string> = {
+  HAPPY: '좋음',
+  NORMAL: '보통',
+  SAD: '아쉬움',
+  NONE: '미선택',
+};
+
+export const FEELING_EMOJI: Record<Feeling, string> = {
+  HAPPY: '😊',
+  NORMAL: '😌',
+  SAD: '🥲',
+  NONE: '⚪',
+};
+
+// SVG/inline 스타일용 색상 (colors.css 토큰 참조).
+export const FEELING_COLOR: Record<Feeling, string> = {
+  HAPPY: 'var(--main-500)',
+  NORMAL: 'var(--blue-400)',
+  SAD: 'var(--red-400)',
+  NONE: 'var(--gray-300)',
+};
+
+export function formatPercent(ratio: number): string {
+  if (!Number.isFinite(ratio) || ratio <= 0) {
+    return '0%';
+  }
+  return `${Math.round(ratio * 100)}%`;
+}
+
+// 증감값 표시 — +N / -N / ±0.
+export function formatDelta(delta: number): string {
+  if (delta > 0) {
+    return `+${delta}`;
+  }
+  if (delta < 0) {
+    return `${delta}`;
+  }
+  return '±0';
+}
+
+// bucket 문자열을 사람이 읽는 짧은 라벨로. 서버 포맷을 방어적으로 처리한다.
+export function formatBucketLabel(bucket: string): string {
+  if (!bucket) {
+    return '';
+  }
+  // YYYY-MM-DD → M/D
+  const day = /^(\d{4})-(\d{2})-(\d{2})$/.exec(bucket);
+  if (day) {
+    return `${Number(day[2])}/${Number(day[3])}`;
+  }
+  // YYYY-MM → M월
+  const month = /^(\d{4})-(\d{2})$/.exec(bucket);
+  if (month) {
+    return `${Number(month[2])}월`;
+  }
+  // YYYY-Www → W주
+  const week = /^(\d{4})-W(\d{1,2})$/.exec(bucket);
+  if (week) {
+    return `${Number(week[2])}주`;
+  }
+  return bucket;
+}

--- a/src/app/mypage/statistics/page.tsx
+++ b/src/app/mypage/statistics/page.tsx
@@ -1,0 +1,8 @@
+import StatisticsScreen from '@feature/member/statistics/screen/StatisticsScreen';
+import React from 'react';
+
+// 인증 가드는 `src/app.module/middleware/auth.ts` 의 미들웨어가 처리한다
+// (`/mypage/*` login-redirect). RSC 단순 wrapper.
+export default function StatisticsPage(): React.ReactElement {
+  return <StatisticsScreen />;
+}


### PR DESCRIPTION
## 요약
회원 통계 프론트 뷰를 신규 라우트 `/mypage/statistics` 로 구현했습니다.
서버 통계 API(1D1S-server-v2 #315, dev 미배포)의 **확정 계약 타입 기준**으로
화면·데이터 훅·로딩/에러/빈 상태까지 구현했으며, 실제 응답 QA는 서버 배포 후
진행합니다. 값 부재에 대한 옵셔널 체이닝·기본값 방어를 전 구간에 적용했습니다.

## 배치 결정
- 기존 마이페이지 서브 라우트(`/mypage/diary`, `/mypage/challenge`,
  `/mypage/friend`)와 일관되게 **신규 라우트 `/mypage/statistics`** 로 배치.
- 마이페이지 상단(친구 진입 카드 옆)에 **통계 진입 카드** 추가.
- 인증 가드는 기존 미들웨어(`^/mypage(/.*)?$` login-redirect)가 그대로 커버.
- 재패칭 최소화 방향에 맞춰 클라이언트 **React Query**(`staleTime` 5분) 사용,
  `useEffect` 데이터 페칭 없음.

## 섹션 구성
1. **기간 요약** — 주/월/연 `SegmentedControl` + 이전/다음 네비(`hasPrev`/
   `hasNext` 로 버튼 비활성) + `periods` 목록으로 기간 점프(`Select`).
   카드: 일지수(전기간 대비 증감)·활동일수·목표 달성률·기간 내 최장 스트릭·
   감정 구성·가장 활발한 날(연간은 달)·`subTrend` 미니 막대 차트.
   - 이전/다음은 `periods` 를 `start` 오름차순 정렬해 서버 배열 순서와
     무관하게 결정.
2. **감정 분포** — SVG 도넛 + 감정별 비율/개수 범례
   (HAPPY/NORMAL/SAD/미선택(NONE)).
3. **작성 추이** — 일/월/주 토글 + 막대 차트.
4. **친구 비교** — 나 vs 친구 평균(일지수·달성 목표) + 일지 순위.
   개별 친구는 노출하지 않으며 `friendCount === 0` 이면 안내 문구.

## 차트 방식 / 의존성
- 레포에 차트 라이브러리 없음 → **의존성 추가 없이 순수 SVG·CSS**로
  도넛/막대 차트를 직접 구현(`DonutChart`, `TrendBars`). 색상은 디자인
  시스템 토큰(`--main-500`, `--blue-400`, `--red-400`, `--gray-300`) 사용.
- **추가된 의존성 없음.**

## 상태 처리
- 각 섹션 공통 `StatisticsCard` 래퍼가 로딩 스켈레톤 / 에러
  (`normalizeApiError`) / 빈 상태(데이터 0)를 개별 처리. 모바일 우선 레이아웃.

## 변경 파일
- 신규 라우트: `src/app/mypage/statistics/page.tsx`
- 신규 피처 모듈 `src/app.feature/member/statistics/`
  - `type/statistics.ts` (계약 타입 5종)
  - `consts/queryKeys.ts` (Query Key Factory)
  - `api/statisticsApi.ts` (GET 5종)
  - `hooks/useStatisticsQueries.ts` (React Query 훅 5종)
  - `utils/statisticsView.ts` (감정 메타/색·라벨 포맷)
  - `components/` : `StatisticsCard`, `DonutChart`, `TrendBars`,
    `PeriodSummarySection`, `FeelingDistributionSection`,
    `DiaryTrendSection`, `FriendComparisonSection`, `MyPageStatisticsEntry`
  - `screen/StatisticsScreen.tsx`
- 진입점 연결: `src/app.feature/member/mypage/screen/MyPageScreen.tsx`

## 검증
- `tsc --noEmit` 통과, `eslint . --max-warnings=-1` 통과(에러 0), `knip` 통과.
- 유틸 파싱/포맷 로직(`formatBucketLabel`/`formatDelta`/`formatPercent`,
  도넛 dash 합) 단위 self-check 통과.
- ⚠️ 서버 미배포로 **실제 API 응답 연동은 미확인**. 브라우저 QA는 서버 dev
  배포 후 진행 예정(프로젝트 정책상 preview 도구 미사용).

## 남은 리스크
- `periods`/`summary`의 `bucket`·`key` 문자열 실제 포맷은 계약 문서에 명시가
  없어 방어적으로 파싱(`YYYY-MM-DD`/`YYYY-MM`/`YYYY-Www`) — 서버 실제 포맷과
  다르면 라벨 표기만 원문 노출되며 동작에는 영향 없음.
