### PR TITLE
test: vitest 배선 및 순수 함수 특성화 테스트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,29 @@ jobs:
       - name: Run Knip
         run: pnpm knip --reporter=compact
 
+  test:
+    name: Vitest
+    runs-on: ubuntu-latest
+    if: github.repository != 'NOGUEN/1D1S-client'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Vitest
+        run: pnpm test
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint": "eslint src",
     "knip": "knip",
     "knip:report": "knip --reporter=json",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky"
   },
   "dependencies": {
@@ -77,6 +79,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19.1.5",
+    "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.39.2",
     "eslint-config-next": "16.1.5",
@@ -96,7 +99,8 @@
     "tailwindcss": "^4.0.17",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2",
-    "typescript-eslint": "^8.54.0"
+    "typescript-eslint": "^8.54.0",
+    "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@10.11.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.5
         version: 19.1.5(@types/react@19.0.12)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3))
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -243,6 +246,9 @@ importers:
       typescript-eslint:
         specifier: ^8.54.0
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.2)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.17.28)(jsdom@26.1.0)(vite@8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3))
 
 packages:
 
@@ -465,8 +471,14 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
@@ -476,6 +488,9 @@ packages:
 
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -722,6 +737,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -736,6 +754,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -934,6 +958,9 @@ packages:
 
   '@oxc-project/types@0.121.0':
     resolution: {integrity: sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==}
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
@@ -1676,8 +1703,103 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -1993,14 +2115,23 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2217,6 +2348,48 @@ packages:
       vue-router:
         optional: true
 
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
@@ -2334,6 +2507,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -2416,6 +2593,10 @@ packages:
 
   caniuse-lite@1.0.30001802:
     resolution: {integrity: sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2693,6 +2874,9 @@ packages:
     resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2860,6 +3044,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2870,6 +3057,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -2968,6 +3159,11 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3376,8 +3572,20 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -3388,8 +3596,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.1:
     resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -3400,8 +3620,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.1:
     resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -3412,8 +3644,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -3424,8 +3668,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -3436,8 +3692,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.1:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -3526,6 +3792,9 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -3668,6 +3937,10 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -4002,6 +4275,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
@@ -4092,6 +4370,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4118,6 +4399,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4236,8 +4523,15 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
@@ -4246,6 +4540,14 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -4388,6 +4690,90 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -4434,6 +4820,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4823,9 +5214,20 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.4.3':
     dependencies:
       '@emnapi/wasi-threads': 1.0.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -4840,6 +5242,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.0.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5060,6 +5467,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -5087,6 +5496,13 @@ snapshots:
       '@emnapi/core': 1.4.3
       '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@next/env@16.2.10': {}
@@ -5203,6 +5619,8 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.121.0': {}
+
+  '@oxc-project/types@0.139.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
@@ -5910,7 +6328,60 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -6226,6 +6697,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
@@ -6233,9 +6709,16 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
       '@types/node': 20.17.28
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -6423,6 +6906,52 @@ snapshots:
       next: 16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
+  '@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3)
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -6574,6 +7103,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -6660,6 +7191,8 @@ snapshots:
   caniuse-lite@1.0.30001720: {}
 
   caniuse-lite@1.0.30001802: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6831,8 +7364,7 @@ snapshots:
 
   detect-libc@2.0.4: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -7018,6 +7550,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -7273,6 +7807,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
@@ -7288,6 +7826,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -7378,6 +7918,9 @@ snapshots:
       fd-package-json: 2.0.0
 
   fraction.js@4.3.7: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -7799,34 +8342,67 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.1:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.1:
@@ -7843,6 +8419,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.1
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -7939,6 +8531,10 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-error@1.3.6: {}
 
@@ -8071,6 +8667,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  obug@2.1.3: {}
 
   onetime@6.0.0:
     dependencies:
@@ -8419,6 +9017,27 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
   rope-sequence@1.3.4: {}
 
   rrweb-cssom@0.8.0: {}
@@ -8551,6 +9170,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slice-ansi@5.0.0:
@@ -8570,6 +9191,10 @@ snapshots:
   split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -8700,7 +9325,11 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.12:
     dependencies:
@@ -8711,6 +9340,13 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@6.1.86: {}
 
@@ -8885,6 +9521,47 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
+  vite@8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.17.28
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      yaml: 2.8.3
+
+  vitest@4.1.10(@types/node@20.17.28)(jsdom@26.1.0)(vite@8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.17.28
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
   w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
@@ -8950,6 +9627,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
@@ -26,85 +26,11 @@ import {
   ChallengeCreateFormValues,
   useChallengeCreateForm,
 } from '@feature/challenge/write/hooks/useChallengeCreateForm';
+import { formatFormValues } from '@feature/challenge/write/utils/challengeCreatePayload';
 import { cn } from '@module/utils/cn';
-import { add, format } from 'date-fns';
 import { ArrowLeft, Check, Lightbulb, Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-
-import { CreateChallengeRequest } from '../../board/type/challenge';
-
-const ENDLESS_CHALLENGE_END_DATE = '9999-12-31';
-
-function resolveChallengeDurationDays(
-  values: ChallengeCreateFormValues
-): number {
-  if (values.periodType !== 'LIMITED') {
-    return 0;
-  }
-  const raw = values.period === 'etc' ? values.periodNumber : values.period;
-  const parsed = Number(raw);
-  if (Number.isNaN(parsed)) {
-    return 7;
-  }
-  return Math.max(1, parsed);
-}
-
-function resolveMaxParticipantCnt(
-  values: ChallengeCreateFormValues
-): number | null {
-  if (values.participationType !== 'GROUP') {
-    return null;
-  }
-  if (values.memberCount === 'unlimited') {
-    return null;
-  }
-  const raw =
-    values.memberCount === 'etc'
-      ? values.memberCountNumber
-      : values.memberCount;
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
-
-function formatFormValues(
-  values: ChallengeCreateFormValues
-): CreateChallengeRequest {
-  const safeStartDate = values.startDate ?? new Date();
-  const challengeDurationDays = resolveChallengeDurationDays(values);
-  const endDate =
-    values.periodType === 'ENDLESS'
-      ? ENDLESS_CHALLENGE_END_DATE
-      : format(
-          add(safeStartDate, {
-            days: Math.max(0, challengeDurationDays - 1),
-          }),
-          'yyyy-MM-dd'
-        );
-
-  return {
-    title: values.title,
-    category: values.category,
-    description: values.description ?? '',
-    startDate: format(safeStartDate, 'yyyy-MM-dd'),
-    endDate,
-    maxParticipantCnt: resolveMaxParticipantCnt(values),
-    goalType: values.goalType,
-    participationType: values.participationType,
-    goals: values.goals.map((goal) => goal.value),
-    allowMidJoin:
-      values.participationType === 'INDIVIDUAL' ? false : values.allowMidJoin,
-    // 와이어(서버) 키는 photoRequired, 폼 내부 필드명은 isPhotoRequired.
-    photoRequired: values.isPhotoRequired,
-    thumbnailImage: values.thumbnailImageKey,
-    challengeType: values.challengeType,
-    // 비공개일 때만 비밀번호를 동봉한다.
-    password:
-      values.challengeType === 'PRIVATE'
-        ? values.password?.trim()
-        : undefined,
-  };
-}
 
 export default function ChallengeCreateScreen(): React.ReactElement {
   const router = useRouter();

--- a/src/app.feature/challenge/write/utils/challengeCreatePayload.test.ts
+++ b/src/app.feature/challenge/write/utils/challengeCreatePayload.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChallengeCreateFormValues } from '../hooks/useChallengeCreateForm';
+import {
+  formatFormValues,
+  resolveChallengeDurationDays,
+  resolveMaxParticipantCnt,
+} from './challengeCreatePayload';
+
+function makeValues(
+  overrides: Partial<ChallengeCreateFormValues> = {}
+): ChallengeCreateFormValues {
+  return {
+    title: '테스트 챌린지',
+    category: 'DEV',
+    description: '설명',
+    periodType: 'ENDLESS',
+    participationType: 'INDIVIDUAL',
+    goalType: 'FIXED',
+    allowMidJoin: true,
+    isPhotoRequired: false,
+    challengeType: 'PUBLIC',
+    startDate: new Date(2026, 6, 10),
+    goals: [{ value: '매일 커밋' }],
+    ...overrides,
+  };
+}
+
+describe('resolveChallengeDurationDays', () => {
+  it('returns 0 for a non-LIMITED period', () => {
+    expect(resolveChallengeDurationDays(makeValues())).toBe(0);
+  });
+
+  it('returns the preset period as a number', () => {
+    const values = makeValues({ periodType: 'LIMITED', period: '30' });
+    expect(resolveChallengeDurationDays(values)).toBe(30);
+  });
+
+  it('uses periodNumber when period is etc', () => {
+    const values = makeValues({
+      periodType: 'LIMITED',
+      period: 'etc',
+      periodNumber: '45',
+    });
+    expect(resolveChallengeDurationDays(values)).toBe(45);
+  });
+
+  it('falls back to 7 when the etc number is missing', () => {
+    const values = makeValues({ periodType: 'LIMITED', period: 'etc' });
+    expect(resolveChallengeDurationDays(values)).toBe(7);
+  });
+
+  it('clamps to a minimum of 1', () => {
+    const values = makeValues({
+      periodType: 'LIMITED',
+      period: 'etc',
+      periodNumber: '0',
+    });
+    expect(resolveChallengeDurationDays(values)).toBe(1);
+  });
+});
+
+describe('resolveMaxParticipantCnt', () => {
+  it('returns null for an individual challenge', () => {
+    expect(resolveMaxParticipantCnt(makeValues())).toBeNull();
+  });
+
+  it('returns null for an unlimited group', () => {
+    const values = makeValues({
+      participationType: 'GROUP',
+      memberCount: 'unlimited',
+    });
+    expect(resolveMaxParticipantCnt(values)).toBeNull();
+  });
+
+  it('returns the preset member count', () => {
+    const values = makeValues({
+      participationType: 'GROUP',
+      memberCount: '10',
+    });
+    expect(resolveMaxParticipantCnt(values)).toBe(10);
+  });
+
+  it('uses memberCountNumber when member count is etc', () => {
+    const values = makeValues({
+      participationType: 'GROUP',
+      memberCount: 'etc',
+      memberCountNumber: '7',
+    });
+    expect(resolveMaxParticipantCnt(values)).toBe(7);
+  });
+
+  it('returns null for a non-positive custom count', () => {
+    const values = makeValues({
+      participationType: 'GROUP',
+      memberCount: 'etc',
+      memberCountNumber: '0',
+    });
+    expect(resolveMaxParticipantCnt(values)).toBeNull();
+  });
+});
+
+describe('formatFormValues', () => {
+  it('builds an endless individual payload', () => {
+    const payload = formatFormValues(makeValues());
+    expect(payload).toMatchObject({
+      title: '테스트 챌린지',
+      category: 'DEV',
+      description: '설명',
+      startDate: '2026-07-10',
+      endDate: '9999-12-31',
+      maxParticipantCnt: null,
+      goalType: 'FIXED',
+      participationType: 'INDIVIDUAL',
+      goals: ['매일 커밋'],
+      photoRequired: false,
+      challengeType: 'PUBLIC',
+    });
+  });
+
+  it('forces allowMidJoin to false for an individual challenge', () => {
+    const payload = formatFormValues(makeValues({ allowMidJoin: true }));
+    expect(payload.allowMidJoin).toBe(false);
+  });
+
+  it('keeps allowMidJoin for a group challenge', () => {
+    const values = makeValues({
+      participationType: 'GROUP',
+      memberCount: '5',
+      allowMidJoin: true,
+    });
+    expect(formatFormValues(values).allowMidJoin).toBe(true);
+  });
+
+  it('computes the end date as start + (duration - 1) days', () => {
+    const values = makeValues({ periodType: 'LIMITED', period: '7' });
+    expect(formatFormValues(values).endDate).toBe('2026-07-16');
+  });
+
+  it('omits the password for a public challenge', () => {
+    const payload = formatFormValues(makeValues({ password: 'secret' }));
+    expect(payload.password).toBeUndefined();
+  });
+
+  it('trims the password for a private challenge', () => {
+    const values = makeValues({
+      challengeType: 'PRIVATE',
+      password: '  secret  ',
+    });
+    expect(formatFormValues(values).password).toBe('secret');
+  });
+
+  it('defaults an empty description to an empty string', () => {
+    const payload = formatFormValues(makeValues({ description: undefined }));
+    expect(payload.description).toBe('');
+  });
+});

--- a/src/app.feature/challenge/write/utils/challengeCreatePayload.ts
+++ b/src/app.feature/challenge/write/utils/challengeCreatePayload.ts
@@ -1,0 +1,76 @@
+import { add, format } from 'date-fns';
+
+import { CreateChallengeRequest } from '../../board/type/challenge';
+import { ChallengeCreateFormValues } from '../hooks/useChallengeCreateForm';
+
+const ENDLESS_CHALLENGE_END_DATE = '9999-12-31';
+
+export function resolveChallengeDurationDays(
+  values: ChallengeCreateFormValues
+): number {
+  if (values.periodType !== 'LIMITED') {
+    return 0;
+  }
+  const raw = values.period === 'etc' ? values.periodNumber : values.period;
+  const parsed = Number(raw);
+  if (Number.isNaN(parsed)) {
+    return 7;
+  }
+  return Math.max(1, parsed);
+}
+
+export function resolveMaxParticipantCnt(
+  values: ChallengeCreateFormValues
+): number | null {
+  if (values.participationType !== 'GROUP') {
+    return null;
+  }
+  if (values.memberCount === 'unlimited') {
+    return null;
+  }
+  const raw =
+    values.memberCount === 'etc'
+      ? values.memberCountNumber
+      : values.memberCount;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function formatFormValues(
+  values: ChallengeCreateFormValues
+): CreateChallengeRequest {
+  const safeStartDate = values.startDate ?? new Date();
+  const challengeDurationDays = resolveChallengeDurationDays(values);
+  const endDate =
+    values.periodType === 'ENDLESS'
+      ? ENDLESS_CHALLENGE_END_DATE
+      : format(
+          add(safeStartDate, {
+            days: Math.max(0, challengeDurationDays - 1),
+          }),
+          'yyyy-MM-dd'
+        );
+
+  return {
+    title: values.title,
+    category: values.category,
+    description: values.description ?? '',
+    startDate: format(safeStartDate, 'yyyy-MM-dd'),
+    endDate,
+    maxParticipantCnt: resolveMaxParticipantCnt(values),
+    goalType: values.goalType,
+    participationType: values.participationType,
+    goals: values.goals.map((goal) => goal.value),
+    allowMidJoin:
+      values.participationType === 'INDIVIDUAL' ? false : values.allowMidJoin,
+    // 와이어(서버) 키는 photoRequired, 폼 내부 필드명은 isPhotoRequired.
+    photoRequired: values.isPhotoRequired,
+    thumbnailImage: values.thumbnailImageKey,
+    challengeType: values.challengeType,
+    // 비공개일 때만 비밀번호를 동봉한다.
+    password:
+      values.challengeType === 'PRIVATE'
+        ? values.password?.trim()
+        : undefined,
+  };
+}

--- a/src/app.feature/diary/detail/utils/diaryViewData.test.ts
+++ b/src/app.feature/diary/detail/utils/diaryViewData.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DiaryDetail } from '../../board/type/diary';
+import type { DiaryComment } from '../type/comment';
+import {
+  feelingToMoodImage,
+  hasVisibleHtmlContent,
+  mapDiaryToViewData,
+  parseCommentTimestamp,
+  parsePositiveInteger,
+  resolveSidebarMemberId,
+  sortCommentsByOldest,
+} from './diaryViewData';
+
+describe('feelingToMoodImage', () => {
+  it('maps each mood to its image, NONE to null', () => {
+    expect(feelingToMoodImage('HAPPY')?.src).toBe('/images/mood-happy.svg');
+    expect(feelingToMoodImage('SAD')?.src).toBe('/images/mood-sad.svg');
+    expect(feelingToMoodImage('NORMAL')?.src).toBe('/images/mood-soso.svg');
+    expect(feelingToMoodImage('NONE')).toBeNull();
+  });
+});
+
+describe('hasVisibleHtmlContent', () => {
+  it('is false for empty and whitespace-only content', () => {
+    expect(hasVisibleHtmlContent('')).toBe(false);
+    expect(hasVisibleHtmlContent('<p></p>')).toBe(false);
+    expect(hasVisibleHtmlContent('<p>&nbsp;</p>')).toBe(false);
+    expect(hasVisibleHtmlContent('<p>   </p>')).toBe(false);
+  });
+
+  it('is true for visible text', () => {
+    expect(hasVisibleHtmlContent('<p>안녕</p>')).toBe(true);
+  });
+
+  it('is true when an image tag is present', () => {
+    expect(hasVisibleHtmlContent('<img src="x" />')).toBe(true);
+  });
+});
+
+describe('parsePositiveInteger', () => {
+  it('accepts positive integers and numeric strings', () => {
+    expect(parsePositiveInteger(5)).toBe(5);
+    expect(parsePositiveInteger('7')).toBe(7);
+  });
+
+  it('rejects zero, negatives, decimals and junk', () => {
+    expect(parsePositiveInteger(0)).toBeNull();
+    expect(parsePositiveInteger(-1)).toBeNull();
+    expect(parsePositiveInteger(3.5)).toBeNull();
+    expect(parsePositiveInteger('x')).toBeNull();
+    expect(parsePositiveInteger(true)).toBeNull();
+  });
+});
+
+describe('resolveSidebarMemberId', () => {
+  it('reads the first positive id-like key in order', () => {
+    expect(resolveSidebarMemberId({ memberId: 5 })).toBe(5);
+    expect(resolveSidebarMemberId({ member_id: '8' })).toBe(8);
+    expect(resolveSidebarMemberId({ userId: 2, id: 9 })).toBe(2);
+  });
+
+  it('returns null for non-objects and empty ids', () => {
+    expect(resolveSidebarMemberId(null)).toBeNull();
+    expect(resolveSidebarMemberId({})).toBeNull();
+    expect(resolveSidebarMemberId({ id: 0 })).toBeNull();
+  });
+});
+
+describe('parseCommentTimestamp', () => {
+  it('returns 0 for an empty value', () => {
+    expect(parseCommentTimestamp('')).toBe(0);
+  });
+
+  it('parses an ISO timestamp', () => {
+    expect(parseCommentTimestamp('2026-07-10T00:00:00Z')).toBe(
+      new Date('2026-07-10T00:00:00Z').getTime()
+    );
+  });
+
+  it('truncates sub-millisecond precision before parsing', () => {
+    expect(parseCommentTimestamp('2026-07-10T00:00:00.123456Z')).toBe(
+      new Date('2026-07-10T00:00:00.123Z').getTime()
+    );
+  });
+});
+
+describe('sortCommentsByOldest', () => {
+  it('sorts oldest first and breaks ties by id', () => {
+    const comments = [
+      { id: 3, createdAt: '2026-07-10T10:00:00Z' },
+      { id: 1, createdAt: '2026-07-10T09:00:00Z' },
+      { id: 2, createdAt: '2026-07-10T09:00:00Z' },
+    ] as DiaryComment[];
+    const ids = sortCommentsByOldest(comments).map((item) => item.id);
+    expect(ids).toEqual([1, 2, 3]);
+  });
+});
+
+describe('mapDiaryToViewData', () => {
+  it('maps a diary with no linked challenge', () => {
+    const diary = {
+      id: 42,
+      title: '',
+      content: '<p>오늘의 일지</p>',
+      achievementRate: 150,
+      likeInfo: { likedByMe: true, likeCnt: 7 },
+      diaryInfoDto: {
+        createdAt: '2026-07-10',
+        feeling: 'HAPPY',
+      },
+    } as unknown as DiaryDetail;
+
+    const view = mapDiaryToViewData(diary);
+
+    expect(view.id).toBe(42);
+    expect(view.title).toBe('제목 없는 일지');
+    expect(view.feeling).toBe('HAPPY');
+    expect(view.feelingLabel).toBe('아주 좋음');
+    expect(view.feelingEmoji).toBe('😊');
+    expect(view.achievementPercent).toBe(100);
+    expect(view.likedByMe).toBe(true);
+    expect(view.likeCount).toBe(7);
+    expect(view.hasContentHtml).toBe(true);
+    expect(view.connectedChallengeId).toBeNull();
+    expect(view.connectedChallengeTitle).toBe('연동된 챌린지가 없습니다.');
+    expect(view.contentImageUrls).toEqual([]);
+  });
+});

--- a/src/app.feature/diary/write/utils/diaryFormHelpers.test.ts
+++ b/src/app.feature/diary/write/utils/diaryFormHelpers.test.ts
@@ -1,0 +1,231 @@
+import type { SidebarChallenge } from '@feature/member/type/member';
+import { formatDateISO } from '@module/utils/date';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ChallengeSummary as DiaryChallengeSummary } from '../../board/type/diary';
+import {
+  getDiaryImageUrls,
+  getFirstSelectableAchievedDate,
+  getSubmitButtonLabel,
+  hasSelectableAchievedDate,
+  isSelectableAchievedDate,
+  mapDiaryChallengeToChallengeListItem,
+  mapSidebarChallengeToChallengeListItem,
+  parseDateValue,
+  parsePositiveInteger,
+  revokeObjectUrlIfNeeded,
+} from './diaryFormHelpers';
+
+describe('parsePositiveInteger', () => {
+  it('parses a positive integer string', () => {
+    expect(parsePositiveInteger('5')).toBe(5);
+  });
+
+  it('returns null for zero', () => {
+    expect(parsePositiveInteger('0')).toBeNull();
+  });
+
+  it('returns null for a negative number', () => {
+    expect(parsePositiveInteger('-3')).toBeNull();
+  });
+
+  it('returns null for a non-integer', () => {
+    expect(parsePositiveInteger('3.5')).toBeNull();
+  });
+
+  it('returns null for null', () => {
+    expect(parsePositiveInteger(null)).toBeNull();
+  });
+});
+
+describe('parseDateValue', () => {
+  it('parses a date-only string as local midnight', () => {
+    expect(parseDateValue('2026-07-10')?.getTime()).toBe(
+      new Date(2026, 6, 10).getTime()
+    );
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(parseDateValue(null)).toBeNull();
+    expect(parseDateValue(undefined)).toBeNull();
+  });
+
+  it('returns null for an invalid string', () => {
+    expect(parseDateValue('nope')).toBeNull();
+  });
+});
+
+describe('achieved-date selection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 10, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('accepts today', () => {
+    expect(isSelectableAchievedDate(new Date(2026, 6, 10))).toBe(true);
+  });
+
+  it('accepts two days back (the min)', () => {
+    expect(isSelectableAchievedDate(new Date(2026, 6, 8))).toBe(true);
+  });
+
+  it('rejects three days back', () => {
+    expect(isSelectableAchievedDate(new Date(2026, 6, 7))).toBe(false);
+  });
+
+  it('rejects a future date', () => {
+    expect(isSelectableAchievedDate(new Date(2026, 6, 11))).toBe(false);
+  });
+
+  it('rejects dates before the challenge start', () => {
+    const result = isSelectableAchievedDate(
+      new Date(2026, 6, 9),
+      '2026-07-10'
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns today as the first selectable date', () => {
+    const result = getFirstSelectableAchievedDate(new Set());
+    expect(result && formatDateISO(result)).toBe('2026-07-10');
+  });
+
+  it('skips disabled dates to the next selectable one', () => {
+    const disabled = new Set(['2026-07-10']);
+    const result = getFirstSelectableAchievedDate(disabled);
+    expect(result && formatDateISO(result)).toBe('2026-07-09');
+  });
+
+  it('reports availability via hasSelectableAchievedDate', () => {
+    const allDisabled = new Set([
+      '2026-07-10',
+      '2026-07-09',
+      '2026-07-08',
+    ]);
+    expect(hasSelectableAchievedDate(new Set())).toBe(true);
+    expect(hasSelectableAchievedDate(allDisabled)).toBe(false);
+  });
+});
+
+describe('getSubmitButtonLabel', () => {
+  const base = {
+    isCreating: false,
+    isUpdating: false,
+    isUploadingImage: false,
+    isEditMode: false,
+  };
+
+  it('prioritizes the creating state', () => {
+    expect(getSubmitButtonLabel({ ...base, isCreating: true })).toBe(
+      '작성 중...'
+    );
+  });
+
+  it('shows the updating state', () => {
+    expect(getSubmitButtonLabel({ ...base, isUpdating: true })).toBe(
+      '수정 중...'
+    );
+  });
+
+  it('shows the image upload state', () => {
+    expect(getSubmitButtonLabel({ ...base, isUploadingImage: true })).toBe(
+      '이미지 업로드 중...'
+    );
+  });
+
+  it('shows the edit-mode idle label', () => {
+    expect(getSubmitButtonLabel({ ...base, isEditMode: true })).toBe(
+      '수정 완료'
+    );
+  });
+
+  it('shows the create idle label', () => {
+    expect(getSubmitButtonLabel(base)).toBe('작성 완료');
+  });
+});
+
+const likeInfo = { likedByMe: true, likeCnt: 3 };
+
+describe('mapDiaryChallengeToChallengeListItem', () => {
+  it('maps and normalizes a diary challenge summary', () => {
+    const summary: DiaryChallengeSummary = {
+      challengeId: 1,
+      title: '챌린지',
+      category: 'UNKNOWN',
+      startDate: '2026-07-01',
+      endDate: '2026-07-31',
+      maxParticipantCnt: 10,
+      goalType: 'SOMETHING',
+      participationType: 'SOLO',
+      participantCnt: 4,
+      thumbnailImage: null,
+      likeInfo,
+    };
+    expect(mapDiaryChallengeToChallengeListItem(summary)).toEqual({
+      challengeId: 1,
+      title: '챌린지',
+      category: 'DEV',
+      startDate: '2026-07-01',
+      endDate: '2026-07-31',
+      maxParticipantCnt: 10,
+      goalType: 'FLEXIBLE',
+      participationType: 'INDIVIDUAL',
+      participantCnt: 4,
+      liked: true,
+      likeCnt: 3,
+      thumbnailImage: undefined,
+    });
+  });
+});
+
+describe('mapSidebarChallengeToChallengeListItem', () => {
+  it('maps a sidebar challenge, keeping known enum values', () => {
+    const sidebar: SidebarChallenge = {
+      challengeId: 2,
+      title: '사이드바',
+      category: 'EXERCISE',
+      startDate: '2026-07-01',
+      endDate: '2026-07-31',
+      maxParticipantCnt: 5,
+      goalType: 'FIXED',
+      participationType: 'GROUP',
+      participantCnt: 2,
+      thumbnailImage: 'thumb.png',
+      likeInfo: { likedByMe: false, likeCnt: 0 },
+    };
+    expect(mapSidebarChallengeToChallengeListItem(sidebar)).toMatchObject({
+      category: 'EXERCISE',
+      goalType: 'FIXED',
+      participationType: 'GROUP',
+      liked: false,
+      likeCnt: 0,
+      thumbnailImage: 'thumb.png',
+    });
+  });
+});
+
+describe('getDiaryImageUrls', () => {
+  it('returns an empty array for a null diary', () => {
+    expect(getDiaryImageUrls(null)).toEqual([]);
+  });
+
+  it('extracts raw image strings without resolving', () => {
+    const diary = { imgUrl: 'bucket/a.png' };
+    expect(getDiaryImageUrls(diary as never)).toEqual(['bucket/a.png']);
+  });
+});
+
+describe('revokeObjectUrlIfNeeded', () => {
+  it('revokes blob urls only', () => {
+    const spy = vi.fn();
+    URL.revokeObjectURL = spy;
+    revokeObjectUrlIfNeeded('blob:abc');
+    revokeObjectUrlIfNeeded('https://a.com/x.png');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('blob:abc');
+  });
+});

--- a/src/app.module/utils/date.test.ts
+++ b/src/app.module/utils/date.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  formatDateISO,
+  formatDateKR,
+  formatMonthDayKR,
+  getDateTimestamp,
+  getRelativeTimeLabel,
+  toStartOfDay,
+} from './date';
+
+describe('toStartOfDay', () => {
+  it('zeroes out the time component', () => {
+    const result = toStartOfDay(new Date(2026, 6, 10, 13, 45, 30, 500));
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+    expect(result.getDate()).toBe(10);
+  });
+
+  it('does not mutate the input date', () => {
+    const input = new Date(2026, 6, 10, 13, 45);
+    toStartOfDay(input);
+    expect(input.getHours()).toBe(13);
+  });
+});
+
+describe('formatDateISO', () => {
+  it('pads month and day to two digits', () => {
+    expect(formatDateISO(new Date(2026, 0, 5))).toBe('2026-01-05');
+  });
+
+  it('keeps two-digit month and day as-is', () => {
+    expect(formatDateISO(new Date(2026, 11, 25))).toBe('2026-12-25');
+  });
+});
+
+describe('formatDateKR', () => {
+  it('formats month and day in Korean', () => {
+    expect(formatDateKR(new Date(2026, 4, 13))).toBe('5월 13일');
+  });
+});
+
+describe('formatMonthDayKR', () => {
+  it('parses an ISO date string without timezone shift', () => {
+    expect(formatMonthDayKR('2026-07-06')).toBe('7월 6일');
+  });
+
+  it('parses a full ISO timestamp', () => {
+    expect(formatMonthDayKR('2026-12-01T09:00:00Z')).toBe('12월 1일');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(formatMonthDayKR(undefined)).toBe('');
+  });
+
+  it('returns empty string for a malformed value', () => {
+    expect(formatMonthDayKR('not-a-date')).toBe('');
+  });
+});
+
+describe('getDateTimestamp', () => {
+  it('returns epoch ms for a date-only string (local midnight)', () => {
+    expect(getDateTimestamp('2026-07-10')).toBe(
+      new Date(2026, 6, 10).getTime()
+    );
+  });
+
+  it('returns 0 for an unparseable value', () => {
+    expect(getDateTimestamp('nonsense')).toBe(0);
+  });
+
+  it('returns 0 for an empty string', () => {
+    expect(getDateTimestamp('')).toBe(0);
+  });
+});
+
+describe('getRelativeTimeLabel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 10, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the fallback for an empty value', () => {
+    expect(getRelativeTimeLabel('')).toBe('방금 전');
+  });
+
+  it('uses a custom fallback for an empty value', () => {
+    expect(getRelativeTimeLabel('', '없음')).toBe('없음');
+  });
+
+  it('labels today for a date-only string of the same day', () => {
+    expect(getRelativeTimeLabel('2026-07-10')).toBe('오늘');
+  });
+
+  it('labels yesterday for a date-only string one day back', () => {
+    expect(getRelativeTimeLabel('2026-07-09')).toBe('어제');
+  });
+
+  it('labels just now for a sub-30-second timestamp', () => {
+    expect(getRelativeTimeLabel('2026-07-10T12:00:10')).toBe('방금 전');
+  });
+
+  it('labels minutes ago for a timestamp within the hour', () => {
+    expect(getRelativeTimeLabel('2026-07-10T11:30:00')).toBe('30분 전');
+  });
+});

--- a/src/app.module/utils/url.test.ts
+++ b/src/app.module/utils/url.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { trimTrailingSlash } from './url';
+
+describe('trimTrailingSlash', () => {
+  it('removes a single trailing slash', () => {
+    expect(trimTrailingSlash('https://a.com/')).toBe('https://a.com');
+  });
+
+  it('removes multiple trailing slashes', () => {
+    expect(trimTrailingSlash('https://a.com///')).toBe('https://a.com');
+  });
+
+  it('leaves a url without a trailing slash unchanged', () => {
+    expect(trimTrailingSlash('https://a.com/path')).toBe('https://a.com/path');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(trimTrailingSlash('')).toBe('');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url';
+
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+function resolvePath(relativePath: string): string {
+  return fileURLToPath(new URL(relativePath, import.meta.url));
+}
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    // @1d1s/design-system 는 `next/image` 를 bare specifier 로 import 한다.
+    // Node ESM 외부화 상태로는 subpath 해석이 실패하므로 vite 로 인라인
+    // 변환해 별칭/exports 해석을 태운다.
+    server: {
+      deps: {
+        inline: [/@1d1s\/design-system/],
+      },
+    },
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@component\//,
+        replacement: resolvePath('./src/app.component/'),
+      },
+      {
+        find: /^@feature\//,
+        replacement: resolvePath('./src/app.feature/'),
+      },
+      {
+        find: /^@module\//,
+        replacement: resolvePath('./src/app.module/'),
+      },
+      {
+        find: /^@constants\//,
+        replacement: resolvePath('./src/app.constants/'),
+      },
+      { find: /^@\//, replacement: resolvePath('./src/') },
+    ],
+  },
+});


### PR DESCRIPTION
## 개요
클라 리팩토링 로드맵 **PR 0 — 테스트 인프라 + 순수함수 특성화 테스트(안전망)**.
후속 리팩토링(PR 1·2 등)에서 순수 함수가 추출/이동될 때 회귀를 잡기 위한 기반.

동작 보존(behavior-preserving) 원칙 — 프로덕션 런타임 동작 변경 없음.

## 변경 사항
- **vitest 배선**: `vitest` + `@vitejs/plugin-react` 추가, `vitest.config.ts`(jsdom 환경, `@/@component/@feature/@module/@constants` 별칭, design-system 인라인), `package.json`에 `test`/`test:watch` 스크립트.
- **순수 함수 특성화 테스트 (78 케이스)**:
  - `app.module/utils/date` — `toStartOfDay`·`formatDateISO`·`formatDateKR`·`formatMonthDayKR`·`getDateTimestamp`·`getRelativeTimeLabel`
  - `app.module/utils/url` — `trimTrailingSlash`
  - `diary/detail/utils/diaryViewData` — `feelingToMoodImage`·`hasVisibleHtmlContent`·`parsePositiveInteger`·`resolveSidebarMemberId`·`parseCommentTimestamp`·`sortCommentsByOldest`·`mapDiaryToViewData`
  - `diary/write/utils/diaryFormHelpers` — 날짜 선택·라벨·챌린지 매핑·이미지 추출 등
  - `challenge/write/utils/challengeCreatePayload` — payload/기간/인원 빌더
- **payload 빌더 추출**: `ChallengeCreateScreen`에 인라인이던 `formatFormValues`/`resolveChallengeDurationDays`/`resolveMaxParticipantCnt`를 순수 모듈 `challenge/write/utils/challengeCreatePayload.ts`로 이동(동작 동일). design-system을 끌어오지 않고 격리 테스트하기 위함.
- **CI**: `test`(Vitest) job 추가 — 기존 job과 독립 병렬(build `needs`에는 미포함)이라 기존 파이프라인에 영향 없음.

## 검증
- `pnpm test` (vitest run) — 78 passed
- `pnpm tsc --noEmit` — pass
- `pnpm lint` (eslint) — 0 errors (기존 `public/sw.js` warning만 잔존)
- `pnpm knip` — pass
- `pnpm build` (next build) — pass

로컬 정적 검증만 수행했고 브라우저 확인은 하지 않았습니다(런타임 동작 변경 없음).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated testing with Vitest, including watch mode.
  * Added coverage for challenge creation, diary views and forms, date utilities, and URL handling.
* **Bug Fixes**
  * Improved challenge creation payload formatting, including duration, participant limits, dates, privacy, and optional values.
* **Chores**
  * Integrated automated test execution into continuous integration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->