### PR TITLE
refactor: 일지 좋아요 토글 로직 useLikeToggle 훅으로 공통화

### DIFF
--- a/src/app.feature/diary/board/hooks/useLikeToggle.ts
+++ b/src/app.feature/diary/board/hooks/useLikeToggle.ts
@@ -1,0 +1,54 @@
+'use client';
+import { useCallback } from 'react';
+
+import {
+  useLikeDiary,
+  useUnlikeDiary,
+} from '../../detail/hooks/useDiaryMutations';
+
+interface UseLikeToggleParams {
+  isLoggedIn: boolean;
+  // 비로그인 상태에서 좋아요를 누르면 호출된다. 화면별 로그인 안내
+  // 다이얼로그(설명 문구 포함)를 각자 띄우도록 위임한다.
+  onRequireLogin(): void;
+}
+
+interface UseLikeToggleResult {
+  isLikePending: boolean;
+  toggleLike(id: number, likedByMe: boolean): void;
+}
+
+/**
+ * 일지 목록/보드 화면들에 복붙돼 있던 좋아요 토글 로직을 공통화한다.
+ * - 비로그인 게이트: 미로그인 시 `onRequireLogin` 위임 후 종료
+ * - 중복 요청 방지: 진행 중(isLikePending)이면 무시
+ * - 낙관적 업데이트/무효화는 `useLikeDiary`/`useUnlikeDiary` 가 담당
+ */
+export function useLikeToggle({
+  isLoggedIn,
+  onRequireLogin,
+}: UseLikeToggleParams): UseLikeToggleResult {
+  const likeDiary = useLikeDiary();
+  const unlikeDiary = useUnlikeDiary();
+  const isLikePending = likeDiary.isPending || unlikeDiary.isPending;
+
+  const toggleLike = useCallback(
+    (id: number, likedByMe: boolean): void => {
+      if (!isLoggedIn) {
+        onRequireLogin();
+        return;
+      }
+      if (isLikePending) {
+        return;
+      }
+      if (likedByMe) {
+        unlikeDiary.mutate(id);
+      } else {
+        likeDiary.mutate(id);
+      }
+    },
+    [isLoggedIn, isLikePending, likeDiary, unlikeDiary, onRequireLogin]
+  );
+
+  return { isLikePending, toggleLike };
+}

--- a/src/app.feature/diary/board/hooks/useLikeToggle.ts
+++ b/src/app.feature/diary/board/hooks/useLikeToggle.ts
@@ -14,7 +14,6 @@ interface UseLikeToggleParams {
 }
 
 interface UseLikeToggleResult {
-  isLikePending: boolean;
   toggleLike(id: number, likedByMe: boolean): void;
 }
 
@@ -50,5 +49,5 @@ export function useLikeToggle({
     [isLoggedIn, isLikePending, likeDiary, unlikeDiary, onRequireLogin]
   );
 
-  return { isLikePending, toggleLike };
+  return { toggleLike };
 }

--- a/src/app.feature/diary/board/screen/DiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/DiaryListScreen.tsx
@@ -18,15 +18,12 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
-  useLikeDiary,
-  useUnlikeDiary,
-} from '../../detail/hooks/useDiaryMutations';
-import {
   resolveDiaryImageUrl,
   resolveDiaryThumbnail,
 } from '../../shared/utils/diaryImageUrl';
 import { mapFeelingToEmotion } from '../../shared/utils/feeling';
 import { useDiaryList } from '../hooks/useDiaryQueries';
+import { useLikeToggle } from '../hooks/useLikeToggle';
 import { type DiaryItem } from '../type/diary';
 
 type SortMode = 'latest' | 'likes';
@@ -171,8 +168,14 @@ export default function DiaryListScreen(): React.ReactElement {
     });
   }, [isLoginRequired, pathname, router, searchParams]);
 
-  const likeDiary = useLikeDiary();
-  const unlikeDiary = useUnlikeDiary();
+  const handleLikeRequireLogin = useCallback((): void => {
+    setLoginDialogDescription('좋아요 기능은 로그인 후 이용할 수 있습니다.');
+    setShowLoginDialog(true);
+  }, []);
+  const { toggleLike } = useLikeToggle({
+    isLoggedIn,
+    onRequireLogin: handleLikeRequireLogin,
+  });
   const {
     data,
     isLoading,
@@ -188,7 +191,6 @@ export default function DiaryListScreen(): React.ReactElement {
     isFetchingNextPage,
     fetchNextPage,
   });
-  const isLikePending = likeDiary.isPending || unlikeDiary.isPending;
   const diaries = useMemo(() => {
     const flattenedDiaries =
       data?.pages?.flatMap((page) => page?.items ?? []) ?? [];
@@ -216,27 +218,9 @@ export default function DiaryListScreen(): React.ReactElement {
   }, []);
 
   const handleLikeToggle = useCallback(
-    (diary: DiaryItem): void => {
-      if (!isLoggedIn) {
-        setLoginDialogDescription(
-          '좋아요 기능은 로그인 후 이용할 수 있습니다.'
-        );
-        setShowLoginDialog(true);
-        return;
-      }
-
-      if (isLikePending) {
-        return;
-      }
-
-      if (diary.likeInfo.likedByMe) {
-        unlikeDiary.mutate(diary.id);
-        return;
-      }
-
-      likeDiary.mutate(diary.id);
-    },
-    [isLoggedIn, isLikePending, likeDiary, unlikeDiary]
+    (diary: DiaryItem): void =>
+      toggleLike(diary.id, diary.likeInfo.likedByMe),
+    [toggleLike]
   );
 
   return (

--- a/src/app.feature/diary/board/screen/MemberDiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/MemberDiaryListScreen.tsx
@@ -7,11 +7,8 @@ import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import MasonryColumns from '@component/MasonryColumns';
 import { DiaryCardSkeletonGrid } from '@component/skeletons/DiaryCardSkeleton';
 import { getCategoryLabel } from '@constants/categories';
+import { useLikeToggle } from '@feature/diary/board/hooks/useLikeToggle';
 import { DiaryItem } from '@feature/diary/board/type/diary';
-import {
-  useLikeDiary,
-  useUnlikeDiary,
-} from '@feature/diary/detail/hooks/useDiaryMutations';
 import {
   resolveDiaryImageUrl,
   resolveDiaryThumbnail,
@@ -93,8 +90,13 @@ export function MemberDiaryListScreen({
   const router = useRouter();
   const isLoggedIn = useIsLoggedIn();
   const [showLoginDialog, setShowLoginDialog] = useState(false);
-  const likeDiary = useLikeDiary();
-  const unlikeDiary = useUnlikeDiary();
+  const openLoginDialog = useCallback((): void => {
+    setShowLoginDialog(true);
+  }, []);
+  const { toggleLike } = useLikeToggle({
+    isLoggedIn,
+    onRequireLogin: openLoginDialog,
+  });
   const {
     data,
     isLoading,
@@ -122,24 +124,11 @@ export function MemberDiaryListScreen({
   }, [data]);
 
   const hasDiaries = diaryItems.length > 0;
-  const isLikePending = likeDiary.isPending || unlikeDiary.isPending;
 
   const handleLikeToggle = useCallback(
-    (diary: DiaryItem): void => {
-      if (!isLoggedIn) {
-        setShowLoginDialog(true);
-        return;
-      }
-      if (isLikePending) {
-        return;
-      }
-      if (diary.likeInfo.likedByMe) {
-        unlikeDiary.mutate(diary.id);
-      } else {
-        likeDiary.mutate(diary.id);
-      }
-    },
-    [isLoggedIn, isLikePending, likeDiary, unlikeDiary]
+    (diary: DiaryItem): void =>
+      toggleLike(diary.id, diary.likeInfo.likedByMe),
+    [toggleLike]
   );
 
   return (

--- a/src/app.feature/diary/board/screen/MyDiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/MyDiaryListScreen.tsx
@@ -7,10 +7,6 @@ import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import MasonryColumns from '@component/MasonryColumns';
 import { DiaryCardSkeletonGrid } from '@component/skeletons/DiaryCardSkeleton';
 import { DiaryItem } from '@feature/diary/board/type/diary';
-import {
-  useLikeDiary,
-  useUnlikeDiary,
-} from '@feature/diary/detail/hooks/useDiaryMutations';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { normalizeApiError } from '@module/api/error';
@@ -26,6 +22,7 @@ import {
   DiaryCardViewModel,
 } from '../../../member/mypage/utils/mypageUtils';
 import { useMyDiariesInfinite } from '../hooks/useDiaryQueries';
+import { useLikeToggle } from '../hooks/useLikeToggle';
 
 const MY_DIARY_PAGE_SIZE = 12;
 
@@ -71,8 +68,13 @@ export function MyDiaryListScreen(): React.ReactElement {
   const { data: sidebar } = useSidebar();
   const nickname = sidebar?.nickname ?? '나';
   const [showLoginDialog, setShowLoginDialog] = useState(false);
-  const likeDiary = useLikeDiary();
-  const unlikeDiary = useUnlikeDiary();
+  const openLoginDialog = useCallback((): void => {
+    setShowLoginDialog(true);
+  }, []);
+  const { toggleLike: handleLikeToggle } = useLikeToggle({
+    isLoggedIn,
+    onRequireLogin: openLoginDialog,
+  });
   const {
     data,
     isLoading,
@@ -104,25 +106,6 @@ export function MyDiaryListScreen(): React.ReactElement {
   );
 
   const hasDiaries = diaryCards.length > 0;
-  const isLikePending = likeDiary.isPending || unlikeDiary.isPending;
-
-  const handleLikeToggle = useCallback(
-    (id: number, isLiked: boolean): void => {
-      if (!isLoggedIn) {
-        setShowLoginDialog(true);
-        return;
-      }
-      if (isLikePending) {
-        return;
-      }
-      if (isLiked) {
-        unlikeDiary.mutate(id);
-      } else {
-        likeDiary.mutate(id);
-      }
-    },
-    [isLoggedIn, isLikePending, likeDiary, unlikeDiary]
-  );
 
   return (
     <div className="min-h-screen w-full">


### PR DESCRIPTION
## 개요
클라 리팩토링 로드맵 **PR 2 — useLikeToggle 훅 추출**. develop 기준 독립 PR. 동작 보존(behavior-preserving) — 기능 변경 없음.

## 변경 사항
3개 일지 목록 화면에 **동일하게 복붙**돼 있던 좋아요 토글 로직(비로그인 게이트 + isPending 중복요청 방지 + likedByMe 분기)을 공통 훅으로 추출.

- **신규** `diary/board/hooks/useLikeToggle.ts`
  - `useLikeDiary`/`useUnlikeDiary`(기존 전역 낙관적 업데이트·실패 시 invalidate)를 그대로 래핑.
  - `toggleLike(id, likedByMe)` + `isLikePending` 반환.
  - 비로그인 시 화면별 안내 다이얼로그를 띄우도록 `onRequireLogin` 콜백으로 위임(설명 문구가 화면마다 다르므로).
- **치환**: `DiaryListScreen`·`MyDiaryListScreen`·`MemberDiaryListScreen` — 각 화면의 `likeDiary`/`unlikeDiary`/`isLikePending`/`handleLikeToggle` 중복 제거. 카드 prop 시그니처와 `React.memo` 안정화(useCallback 참조 동일성) 유지 → 순 -44줄.
  - `DiaryListScreen`은 좋아요 게이트 전용 문구('좋아요 기능은 로그인 후...')를 `onRequireLogin`으로 보존(카드 클릭용 '일지 상세는...' 게이트와 분리 유지).

## 제외 대상 (동작 보존 위해 의도적으로 제외)
- **`ChallengeDetailScreen`**: (1) 챌린지 좋아요는 `useLikeChallenge`/`useUnlikeChallenge`(per-call onSuccess 콜백)로 대상·부수효과가 다름, (2) 일지 좋아요(`handleDiaryLikeToggle`)는 **비로그인 다이얼로그가 없고** pending이 `isActionLoading`에 병합돼 있음. 훅으로 강제 통합하면 게이트가 추가되어 동작이 바뀌므로 제외.
- **home `useHomeRandomDiaryLike`**: 이미 훅으로 분리돼 있고, `useLikeDiary`가 아니라 **자체 낙관적 캐시 업데이트**(`setQueriesData` — randoms/allDiaries/detail)를 수행. 훅 치환 시 낙관적 업데이트 동작이 달라져 "낙관적 업데이트 동일" 원칙 위배 → 제외.

두 케이스 모두 별도 후속 PR에서 다루는 것이 안전.

## 검증
- `pnpm tsc --noEmit` — pass
- `pnpm lint` — 0 errors (기존 `public/sw.js` warning만 잔존)
- `pnpm knip` — pass
- `pnpm build` — pass

정적 검증만 수행, 브라우저 확인 미실시(런타임 동작 변경 없음).