### PR TITLE
refactor: 보드 화면 공통 셸 추출 및 무한스크롤/로그인게이트 훅 공통화

### DIFF
--- a/src/app.component/layout/BoardScreenLayout.tsx
+++ b/src/app.component/layout/BoardScreenLayout.tsx
@@ -1,0 +1,69 @@
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+interface BoardScreenLayoutProps {
+  /** 데스크탑 헤더 타이틀 */
+  title: string;
+  /** 데스크탑 헤더 보조 설명 */
+  description?: string;
+  /** 데스크탑 헤더 우측 액션 */
+  action?: React.ReactNode;
+  /** 모바일 sticky 헤더 슬롯 (화면별로 상이) */
+  mobileHeader?: React.ReactNode;
+  /** 최상위 래퍼 className (기본값: min-h-screen w-full) */
+  outerClassName?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * 보드/리스트 화면의 공통 셸 — 최상위 래퍼 + 중앙 정렬 컨테이너 +
+ * 데스크탑 헤더(타이틀/설명/액션)를 책임진다. 모바일 헤더와 본문은
+ * 화면별로 상이하므로 슬롯/children 으로 주입한다.
+ */
+export function BoardScreenLayout({
+  title,
+  description,
+  action,
+  mobileHeader,
+  outerClassName = 'min-h-screen w-full',
+  children,
+}: BoardScreenLayoutProps): React.ReactElement {
+  return (
+    <div className={outerClassName}>
+      {mobileHeader}
+
+      <div
+        className={cn(
+          'mx-auto w-full max-w-[1200px]',
+          'px-5 py-5 lg:px-8 lg:py-10'
+        )}
+      >
+        <header
+          className={cn(
+            'hidden flex-col gap-4 border-b border-gray-100 pb-5',
+            'lg:flex lg:flex-row lg:items-end lg:justify-between'
+          )}
+        >
+          <div className="flex flex-col gap-1.5">
+            <Text
+              size="pageTitle"
+              weight="extrabold"
+              className="tracking-tight text-gray-900"
+            >
+              {title}
+            </Text>
+            {description ? (
+              <Text size="body2" weight="regular" className="text-gray-500">
+                {description}
+              </Text>
+            ) : null}
+          </div>
+          {action}
+        </header>
+
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app.component/layout/MobileStickyHeader.tsx
+++ b/src/app.component/layout/MobileStickyHeader.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { ArrowLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+interface MobileStickyHeaderProps {
+  /** 헤더 타이틀 */
+  title: string;
+  /** 뒤로가기 동작 (기본값: router.back) */
+  onBack?(): void;
+  /** 타이틀 Text size (기본값: heading2) */
+  titleSize?: React.ComponentProps<typeof Text>['size'];
+  /** 타이틀 우측 액션 슬롯 */
+  right?: React.ReactNode;
+}
+
+/**
+ * 모바일 전용 sticky 상단 헤더 — `← + 타이틀 (+ 우측 액션)`.
+ *
+ * 서브/리스트 페이지 20여 곳에서 반복되던 뒤로가기 sticky 헤더를
+ * 단일 컴포넌트로 공통화한 것. safe-area(pt-safe-top)까지 책임진다.
+ */
+export function MobileStickyHeader({
+  title,
+  onBack,
+  titleSize = 'heading2',
+  right,
+}: MobileStickyHeaderProps): React.ReactElement {
+  const router = useRouter();
+  const handleBack = onBack ?? ((): void => router.back());
+
+  return (
+    <div
+      className={cn(
+        'sticky top-0 z-30 flex items-center gap-3',
+        'h-14-safe pt-safe-top',
+        'border-b border-gray-100 bg-white/95 px-4 backdrop-blur',
+        'lg:hidden'
+      )}
+    >
+      <button
+        type="button"
+        aria-label="뒤로가기"
+        onClick={handleBack}
+        className={cn(
+          'flex h-8 w-8 items-center justify-center rounded-lg',
+          'text-gray-700 transition-colors hover:bg-gray-100'
+        )}
+      >
+        <ArrowLeft className="h-5 w-5" />
+      </button>
+      <Text
+        size={titleSize}
+        weight="extrabold"
+        className="flex-1 tracking-[-0.3px] text-gray-900"
+      >
+        {title}
+      </Text>
+      {right}
+    </div>
+  );
+}

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -3,6 +3,7 @@
 import { Button, Icon, Text, TextField } from '@1d1s/design-system';
 import ChallengeCard from '@component/cards/ChallengeCard';
 import EmptyState from '@component/EmptyState';
+import { BoardScreenLayout } from '@component/layout/BoardScreenLayout';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import {
   ChallengeCardSkeleton,
@@ -15,11 +16,11 @@ import {
 } from '@constants/categories';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
+import { useLoginRequiredParam } from '@module/hooks/useLoginRequiredParam';
 import { cn } from '@module/utils/cn';
-import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import { X } from 'lucide-react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { ChallengeBoardFilters } from '../components/ChallengeBoardFilters';
 import { toCategoryParam } from '../consts/categoryFilters';
@@ -93,9 +94,7 @@ ChallengeBoardCardItem.displayName = 'ChallengeBoardCardItem';
 
 export default function ChallengeBoardScreen(): React.ReactElement {
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const isLoginRequired = searchParams.get('loginRequired') === 'true';
+  const { isLoginRequired, returnTo } = useLoginRequiredParam();
   const isLoggedIn = useIsLoggedIn();
 
   const [showLoginDialog, setShowLoginDialog] = useState(false);
@@ -121,20 +120,9 @@ export default function ChallengeBoardScreen(): React.ReactElement {
     if (isLoginRequired && !isLoggedIn) {
       setShowLoginDialog(true);
       setLoginDialogDescription('챌린지 상세는 로그인 후 이용할 수 있습니다.');
-      setLoginReturnTo(sanitizeReturnTo(searchParams.get(RETURN_TO_PARAM)));
+      setLoginReturnTo(returnTo);
     }
   }
-
-  useEffect(() => {
-    if (!isLoginRequired) {
-      return;
-    }
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('loginRequired');
-    params.delete(RETURN_TO_PARAM);
-    const next = params.toString();
-    router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
-  }, [isLoginRequired, pathname, router, searchParams]);
 
   const requireAuth = useCallback(
     (description: string, action: () => void): void => {
@@ -224,7 +212,92 @@ export default function ChallengeBoardScreen(): React.ReactElement {
   );
 
   return (
-    <div className="w-full">
+    <BoardScreenLayout
+      outerClassName="w-full"
+      title="챌린지 보드"
+      description="새로운 습관을 만들고 함께 성장할 챌린지를 찾아보세요."
+      action={
+        <Button
+          size="md"
+          onClick={handleCreateChallenge}
+          className="self-start whitespace-nowrap lg:self-auto"
+        >
+          <span className="flex items-center gap-1">
+            <Icon name="Plus" size={16} />새 챌린지
+          </span>
+        </Button>
+      }
+      mobileHeader={
+        // 모바일 sticky 헤더 — 타이틀 + 새 챌린지 + 검색바.
+        // 네이티브 쉘에서는 AppTopNav + sliver AppBar 가 동일 영역을
+        // 책임지고, FAB 가 "챌린지 추가" 액션을 제공하므로 이 헤더는
+        // 글로벌 sticky 차단 룰로 함께 가린다 (data-native-keep 제거).
+        <div
+          className={cn(
+            'sticky top-0 z-20 border-b border-gray-100',
+            'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
+            'backdrop-blur lg:hidden'
+          )}
+        >
+          <div className="mb-3 flex items-center justify-between">
+            <Text
+              as="h1"
+              size="heading1"
+              weight="extrabold"
+              className="tracking-[-0.5px] text-gray-900"
+            >
+              챌린지
+            </Text>
+            <button
+              type="button"
+              onClick={handleCreateChallenge}
+              data-native-hide
+              className={cn(
+                // bg-brand ≡ bg-main-800 — 의미 토큰으로 통일
+                'bg-brand inline-flex items-center gap-1 rounded-full',
+                'px-3 py-1.5 text-[11px] font-extrabold text-white',
+                'transition hover:brightness-105'
+              )}
+            >
+              <Icon name="Plus" size={12} />새 챌린지
+            </button>
+          </div>
+          <TextField
+            className="w-full"
+            placeholder="챌린지 검색"
+            value={inputValue}
+            iconLeft={<Icon name="Search" size={15} />}
+            iconRight={
+              inputValue ? (
+                <button
+                  type="button"
+                  aria-label="검색어 지우기"
+                  onClick={handleClear}
+                  className="text-gray-400 hover:text-gray-600"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              ) : undefined
+            }
+            onChange={(event) => setInputValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                handleSearch();
+              }
+            }}
+          />
+          <ChallengeBoardFilters
+            category={category}
+            onCategoryChange={handleCategoryChange}
+            challengeType={challengeType}
+            onChallengeTypeChange={handleChallengeTypeChange}
+            statuses={statuses}
+            onStatusesChange={handleStatusesChange}
+            className="mt-3"
+          />
+        </div>
+      }
+    >
       <LoginRequiredDialog
         open={showLoginDialog}
         onOpenChange={(open) => {
@@ -237,64 +310,45 @@ export default function ChallengeBoardScreen(): React.ReactElement {
         returnTo={loginReturnTo}
       />
 
-      {/* 모바일 sticky 헤더 — 타이틀 + 새 챌린지 + 검색바.
-          네이티브 쉘에서는 AppTopNav + sliver AppBar 가 동일 영역을
-          책임지고, FAB 가 "챌린지 추가" 액션을 제공하므로 이 헤더는
-          글로벌 sticky 차단 룰로 함께 가린다 (data-native-keep 제거). */}
-      <div
-        className={cn(
-          'sticky top-0 z-20 border-b border-gray-100',
-          'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
-          'backdrop-blur lg:hidden'
-        )}
-      >
-        <div className="mb-3 flex items-center justify-between">
-          <Text
-            as="h1"
-            size="heading1"
-            weight="extrabold"
-            className="tracking-[-0.5px] text-gray-900"
+      <div className="mt-2 flex flex-col gap-4 lg:mt-6">
+        {/* 데스크탑 검색바 — 모바일은 sticky 헤더에 있음 */}
+        <div className="hidden w-full max-w-[480px] gap-2 lg:flex">
+          <div className="w-full">
+            <TextField
+              className="w-full"
+              placeholder="챌린지 검색"
+              value={inputValue}
+              iconLeft={<Icon name="Search" size={15} />}
+              iconRight={
+                inputValue ? (
+                  <button
+                    type="button"
+                    aria-label="검색어 지우기"
+                    onClick={handleClear}
+                    className="text-gray-400 hover:text-gray-600"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                ) : undefined
+              }
+              onChange={(event) => setInputValue(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  handleSearch();
+                }
+              }}
+            />
+          </div>
+          <Button
+            size="md"
+            onClick={handleSearch}
+            className="h-10 whitespace-nowrap"
           >
-            챌린지
-          </Text>
-          <button
-            type="button"
-            onClick={handleCreateChallenge}
-            data-native-hide
-            className={cn(
-              // bg-brand ≡ bg-main-800 — 의미 토큰으로 통일
-              'bg-brand inline-flex items-center gap-1 rounded-full',
-              'px-3 py-1.5 text-[11px] font-extrabold text-white',
-              'transition hover:brightness-105'
-            )}
-          >
-            <Icon name="Plus" size={12} />새 챌린지
-          </button>
+            검색
+          </Button>
         </div>
-        <TextField
-          className="w-full"
-          placeholder="챌린지 검색"
-          value={inputValue}
-          iconLeft={<Icon name="Search" size={15} />}
-          iconRight={
-            inputValue ? (
-              <button
-                type="button"
-                aria-label="검색어 지우기"
-                onClick={handleClear}
-                className="text-gray-400 hover:text-gray-600"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            ) : undefined
-          }
-          onChange={(event) => setInputValue(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              handleSearch();
-            }
-          }}
-        />
+
+        {/* 필터 — 모바일(<lg)은 sticky 헤더 쪽에서 렌더 */}
         <ChallengeBoardFilters
           category={category}
           onCategoryChange={handleCategoryChange}
@@ -302,148 +356,64 @@ export default function ChallengeBoardScreen(): React.ReactElement {
           onChallengeTypeChange={handleChallengeTypeChange}
           statuses={statuses}
           onStatusesChange={handleStatusesChange}
-          className="mt-3"
+          className="hidden lg:flex"
         />
       </div>
 
-      <div className="mx-auto w-full max-w-[1200px] px-5 py-5 lg:px-8 lg:py-10">
-        <header
-          className={cn(
-            'hidden flex-col gap-4 border-b border-gray-100 pb-5',
-            'lg:flex lg:flex-row lg:items-end lg:justify-between'
-          )}
-        >
-          <div className="flex flex-col gap-1.5">
-            <Text
-              size="pageTitle"
-              weight="extrabold"
-              className="tracking-tight text-gray-900"
-            >
-              챌린지 보드
-            </Text>
-            <Text size="body2" weight="regular" className="text-gray-500">
-              새로운 습관을 만들고 함께 성장할 챌린지를 찾아보세요.
-            </Text>
-          </div>
-          <Button
-            size="md"
-            onClick={handleCreateChallenge}
-            className="self-start whitespace-nowrap lg:self-auto"
-          >
-            <span className="flex items-center gap-1">
-              <Icon name="Plus" size={16} />새 챌린지
-            </span>
-          </Button>
-        </header>
-
-        <div className="mt-2 flex flex-col gap-4 lg:mt-6">
-          {/* 데스크탑 검색바 — 모바일은 sticky 헤더에 있음 */}
-          <div className="hidden w-full max-w-[480px] gap-2 lg:flex">
-            <div className="w-full">
-              <TextField
-                className="w-full"
-                placeholder="챌린지 검색"
-                value={inputValue}
-                iconLeft={<Icon name="Search" size={15} />}
-                iconRight={
-                  inputValue ? (
-                    <button
-                      type="button"
-                      aria-label="검색어 지우기"
-                      onClick={handleClear}
-                      className="text-gray-400 hover:text-gray-600"
-                    >
-                      <X className="h-4 w-4" />
-                    </button>
-                  ) : undefined
-                }
-                onChange={(event) => setInputValue(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    handleSearch();
-                  }
-                }}
-              />
-            </div>
-            <Button
-              size="md"
-              onClick={handleSearch}
-              className="h-10 whitespace-nowrap"
-            >
-              검색
-            </Button>
-          </div>
-
-          {/* 필터 — 모바일(<lg)은 sticky 헤더 쪽에서 렌더 */}
-          <ChallengeBoardFilters
-            category={category}
-            onCategoryChange={handleCategoryChange}
-            challengeType={challengeType}
-            onChallengeTypeChange={handleChallengeTypeChange}
-            statuses={statuses}
-            onStatusesChange={handleStatusesChange}
-            className="hidden lg:flex"
-          />
-        </div>
-
-        <div className="mt-4 lg:mt-6">
-          {isLoading && challenges.length === 0 ? (
-            <ChallengeCardSkeletonGrid count={8} className="gap-4" />
-          ) : challenges.length > 0 ? (
-            <div
-              className={cn(
-                'data-fade-in grid gap-4',
-                'xs:grid-cols-2 grid-cols-1 sm:grid-cols-3'
-              )}
-            >
-              {challenges.map((challenge) => (
-                <ChallengeBoardCardItem
-                  key={challenge.challengeId}
-                  challenge={challenge}
-                  href={
-                    isLoggedIn
-                      ? `/challenge/${challenge.challengeId}`
-                      : undefined
-                  }
-                  onRequireLogin={handleCardRequireLogin}
-                />
-              ))}
-            </div>
-          ) : (
-            <EmptyState
-              variant="challenge"
-              title="조건에 맞는 챌린지가 없어요"
-              description="필터를 바꾸거나 검색어를 다시 입력해 보세요"
-              className="py-16"
-            />
-          )}
-
-          {isFetchingNextPage ? (
-            <div
-              className={cn(
-                'mt-4 grid gap-4',
-                'xs:grid-cols-2 grid-cols-1 sm:grid-cols-3'
-              )}
-            >
-              {Array.from({ length: 4 }).map((_, index) => (
-                <ChallengeCardSkeleton key={index} />
-              ))}
-            </div>
-          ) : null}
-
+      <div className="mt-4 lg:mt-6">
+        {isLoading && challenges.length === 0 ? (
+          <ChallengeCardSkeletonGrid count={8} className="gap-4" />
+        ) : challenges.length > 0 ? (
           <div
-            ref={ref}
-            className="mt-6 flex h-10 w-full items-center justify-center"
+            className={cn(
+              'data-fade-in grid gap-4',
+              'xs:grid-cols-2 grid-cols-1 sm:grid-cols-3'
+            )}
           >
-            {isFetchingNextPage ? null : !hasNextPage &&
-              challenges.length > 0 ? (
-              <Text size="body2" className="text-gray-400">
-                마지막 챌린지입니다.
-              </Text>
-            ) : null}
+            {challenges.map((challenge) => (
+              <ChallengeBoardCardItem
+                key={challenge.challengeId}
+                challenge={challenge}
+                href={
+                  isLoggedIn ? `/challenge/${challenge.challengeId}` : undefined
+                }
+                onRequireLogin={handleCardRequireLogin}
+              />
+            ))}
           </div>
+        ) : (
+          <EmptyState
+            variant="challenge"
+            title="조건에 맞는 챌린지가 없어요"
+            description="필터를 바꾸거나 검색어를 다시 입력해 보세요"
+            className="py-16"
+          />
+        )}
+
+        {isFetchingNextPage ? (
+          <div
+            className={cn(
+              'mt-4 grid gap-4',
+              'xs:grid-cols-2 grid-cols-1 sm:grid-cols-3'
+            )}
+          >
+            {Array.from({ length: 4 }).map((_, index) => (
+              <ChallengeCardSkeleton key={index} />
+            ))}
+          </div>
+        ) : null}
+
+        <div
+          ref={ref}
+          className="mt-6 flex h-10 w-full items-center justify-center"
+        >
+          {isFetchingNextPage ? null : !hasNextPage && challenges.length > 0 ? (
+            <Text size="body2" className="text-gray-400">
+              마지막 챌린지입니다.
+            </Text>
+          ) : null}
         </div>
       </div>
-    </div>
+    </BoardScreenLayout>
   );
 }

--- a/src/app.feature/challenge/board/screen/MemberChallengeListScreen.tsx
+++ b/src/app.feature/challenge/board/screen/MemberChallengeListScreen.tsx
@@ -3,6 +3,8 @@
 import { Text } from '@1d1s/design-system';
 import ChallengeCard from '@component/cards/ChallengeCard';
 import EmptyState from '@component/EmptyState';
+import { BoardScreenLayout } from '@component/layout/BoardScreenLayout';
+import { MobileStickyHeader } from '@component/layout/MobileStickyHeader';
 import { ChallengeCardSkeletonGrid } from '@component/skeletons/ChallengeCardSkeleton';
 import {
   CategoryIcon,
@@ -12,7 +14,6 @@ import {
 import { normalizeApiError } from '@module/api/error';
 import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
-import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -87,103 +88,56 @@ export function MemberChallengeListScreen({
   const hasChallenges = challenges.length > 0;
 
   return (
-    <div className="min-h-screen w-full">
-      {/* 모바일 sticky 헤더 — ← + 챌린지 전체 보기 */}
-      <div
-        className={cn(
-          'sticky top-0 z-30 flex items-center gap-3',
-          'h-14-safe pt-safe-top',
-          'border-b border-gray-100 bg-white/95 px-4 backdrop-blur',
-          'lg:hidden'
-        )}
-      >
-        <button
-          type="button"
-          aria-label="뒤로가기"
-          onClick={() => router.push(`/member/${memberId}`)}
+    <BoardScreenLayout
+      title="챌린지 전체 보기"
+      description="참여 중인 챌린지 전체 목록입니다."
+      mobileHeader={
+        <MobileStickyHeader
+          title="챌린지 전체 보기"
+          onBack={() => router.push(`/member/${memberId}`)}
+        />
+      }
+    >
+      {showSkeleton ? (
+        <ChallengeCardSkeletonGrid
+          count={8}
+          className="data-fade-in mt-6 gap-4"
+        />
+      ) : null}
+
+      {isError && !hasChallenges ? (
+        <div className="mt-10 flex w-full justify-center py-10">
+          <Text size="body1" weight="medium" className="text-red-600">
+            {error
+              ? normalizeApiError(error).message
+              : '챌린지를 불러오지 못했습니다.'}
+          </Text>
+        </div>
+      ) : null}
+
+      {!showSkeleton && hasChallenges ? (
+        <div
           className={cn(
-            'flex h-8 w-8 items-center justify-center rounded-lg',
-            'text-gray-700 transition-colors hover:bg-gray-100'
+            'data-fade-in mt-6 grid gap-4',
+            'xs:grid-cols-2 grid-cols-1 sm:grid-cols-3'
           )}
         >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <Text
-          size="heading2"
-          weight="extrabold"
-          className="flex-1 tracking-[-0.3px] text-gray-900"
-        >
-          챌린지 전체 보기
-        </Text>
-      </div>
+          {challenges.map((challenge) => (
+            <MemberChallengeCardItem
+              key={challenge.challengeId}
+              challenge={challenge}
+            />
+          ))}
+        </div>
+      ) : null}
 
-      <div
-        className={cn(
-          'mx-auto w-full max-w-[1200px]',
-          'px-5 py-5 lg:px-8 lg:py-10'
-        )}
-      >
-        <header
-          className={cn(
-            'hidden flex-col gap-4 border-b border-gray-100 pb-5',
-            'lg:flex lg:flex-row lg:items-end lg:justify-between'
-          )}
-        >
-          <div className="flex flex-col gap-1.5">
-            <Text
-              size="pageTitle"
-              weight="extrabold"
-              className="tracking-tight text-gray-900"
-            >
-              챌린지 전체 보기
-            </Text>
-            <Text size="body2" weight="regular" className="text-gray-500">
-              참여 중인 챌린지 전체 목록입니다.
-            </Text>
-          </div>
-        </header>
-
-        {showSkeleton ? (
-          <ChallengeCardSkeletonGrid
-            count={8}
-            className="data-fade-in mt-6 gap-4"
-          />
-        ) : null}
-
-        {isError && !hasChallenges ? (
-          <div className="mt-10 flex w-full justify-center py-10">
-            <Text size="body1" weight="medium" className="text-red-600">
-              {error
-                ? normalizeApiError(error).message
-                : '챌린지를 불러오지 못했습니다.'}
-            </Text>
-          </div>
-        ) : null}
-
-        {!showSkeleton && hasChallenges ? (
-          <div
-            className={cn(
-              'data-fade-in mt-6 grid gap-4',
-              'xs:grid-cols-2 grid-cols-1 sm:grid-cols-3'
-            )}
-          >
-            {challenges.map((challenge) => (
-              <MemberChallengeCardItem
-                key={challenge.challengeId}
-                challenge={challenge}
-              />
-            ))}
-          </div>
-        ) : null}
-
-        {!showSkeleton && !isError && !hasChallenges ? (
-          <EmptyState
-            variant="challenge"
-            title="참여 중인 챌린지가 없어요"
-            className="mt-10"
-          />
-        ) : null}
-      </div>
-    </div>
+      {!showSkeleton && !isError && !hasChallenges ? (
+        <EmptyState
+          variant="challenge"
+          title="참여 중인 챌린지가 없어요"
+          className="mt-10"
+        />
+      ) : null}
+    </BoardScreenLayout>
   );
 }

--- a/src/app.feature/challenge/board/screen/MyChallengeListScreen.tsx
+++ b/src/app.feature/challenge/board/screen/MyChallengeListScreen.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Text } from '@1d1s/design-system';
 import ChallengeCard, {
   type ChallengeCardGoalType,
 } from '@component/cards/ChallengeCard';
 import EmptyState from '@component/EmptyState';
+import { BoardScreenLayout } from '@component/layout/BoardScreenLayout';
+import { MobileStickyHeader } from '@component/layout/MobileStickyHeader';
 import { ChallengeCardSkeletonGrid } from '@component/skeletons/ChallengeCardSkeleton';
 import {
   CategoryIcon,
@@ -15,7 +16,6 @@ import { useMyPage } from '@feature/member/hooks/useMemberQueries';
 import type { MyPageChallenge } from '@feature/member/type/member';
 import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
-import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -83,93 +83,46 @@ export function MyChallengeListScreen(): React.ReactElement {
   const hasChallenges = challenges.length > 0;
 
   return (
-    <div className="min-h-screen w-full">
-      {/* 모바일 sticky 헤더 — ← + 내 챌린지 전체 보기 */}
-      <div
-        className={cn(
-          'sticky top-0 z-30 flex items-center gap-3',
-          'h-14-safe pt-safe-top',
-          'border-b border-gray-100 bg-white/95 px-4 backdrop-blur',
-          'lg:hidden'
-        )}
-      >
-        <button
-          type="button"
-          aria-label="뒤로가기"
-          onClick={() => router.push('/mypage')}
+    <BoardScreenLayout
+      title="내 챌린지 전체 보기"
+      description="참여 중인 챌린지 전체 목록입니다."
+      mobileHeader={
+        <MobileStickyHeader
+          title="내 챌린지 전체 보기"
+          onBack={() => router.push('/mypage')}
+        />
+      }
+    >
+      {showSkeleton ? (
+        <ChallengeCardSkeletonGrid
+          count={8}
+          className="data-fade-in mt-6 gap-4"
+        />
+      ) : null}
+
+      {!showSkeleton && hasChallenges ? (
+        <div
           className={cn(
-            'flex h-8 w-8 items-center justify-center rounded-lg',
-            'text-gray-700 transition-colors hover:bg-gray-100'
+            'data-fade-in mt-6 grid gap-4',
+            'xs:grid-cols-2 grid-cols-1 sm:grid-cols-3'
           )}
         >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <Text
-          size="heading2"
-          weight="extrabold"
-          className="flex-1 tracking-[-0.3px] text-gray-900"
-        >
-          내 챌린지 전체 보기
-        </Text>
-      </div>
+          {challenges.map((challenge) => (
+            <MyChallengeCardItem
+              key={challenge.challengeId}
+              challenge={challenge}
+            />
+          ))}
+        </div>
+      ) : null}
 
-      <div
-        className={cn(
-          'mx-auto w-full max-w-[1200px]',
-          'px-5 py-5 lg:px-8 lg:py-10'
-        )}
-      >
-        <header
-          className={cn(
-            'hidden flex-col gap-4 border-b border-gray-100 pb-5',
-            'lg:flex lg:flex-row lg:items-end lg:justify-between'
-          )}
-        >
-          <div className="flex flex-col gap-1.5">
-            <Text
-              size="pageTitle"
-              weight="extrabold"
-              className="tracking-tight text-gray-900"
-            >
-              내 챌린지 전체 보기
-            </Text>
-            <Text size="body2" weight="regular" className="text-gray-500">
-              참여 중인 챌린지 전체 목록입니다.
-            </Text>
-          </div>
-        </header>
-
-        {showSkeleton ? (
-          <ChallengeCardSkeletonGrid
-            count={8}
-            className="data-fade-in mt-6 gap-4"
-          />
-        ) : null}
-
-        {!showSkeleton && hasChallenges ? (
-          <div
-            className={cn(
-              'data-fade-in mt-6 grid gap-4',
-              'xs:grid-cols-2 grid-cols-1 sm:grid-cols-3'
-            )}
-          >
-            {challenges.map((challenge) => (
-              <MyChallengeCardItem
-                key={challenge.challengeId}
-                challenge={challenge}
-              />
-            ))}
-          </div>
-        ) : null}
-
-        {!showSkeleton && !hasChallenges ? (
-          <EmptyState
-            variant="challenge"
-            title="참여 중인 챌린지가 없어요"
-            className="mt-10"
-          />
-        ) : null}
-      </div>
-    </div>
+      {!showSkeleton && !hasChallenges ? (
+        <EmptyState
+          variant="challenge"
+          title="참여 중인 챌린지가 없어요"
+          className="mt-10"
+        />
+      ) : null}
+    </BoardScreenLayout>
   );
 }

--- a/src/app.feature/diary/board/components/DiaryInfiniteFooter.tsx
+++ b/src/app.feature/diary/board/components/DiaryInfiniteFooter.tsx
@@ -1,0 +1,53 @@
+import { Text } from '@1d1s/design-system';
+import { DiaryCardSkeletonGrid } from '@component/skeletons/DiaryCardSkeleton';
+import { normalizeApiError } from '@module/api/error';
+import React from 'react';
+
+interface DiaryInfiniteFooterProps {
+  sentinelRef: React.RefObject<HTMLDivElement | null>;
+  isFetchingNextPage: boolean;
+  isError: boolean;
+  error: unknown;
+  hasItems: boolean;
+  hasNextPage: boolean;
+}
+
+/**
+ * 일지 리스트 3개 화면(전체/내/멤버)에서 동일하게 반복되던
+ * 무한스크롤 하단부 — 추가 로딩 스켈레톤 + sentinel + 상태 문구.
+ */
+export function DiaryInfiniteFooter({
+  sentinelRef,
+  isFetchingNextPage,
+  isError,
+  error,
+  hasItems,
+  hasNextPage,
+}: DiaryInfiniteFooterProps): React.ReactElement {
+  return (
+    <>
+      {isFetchingNextPage ? (
+        <DiaryCardSkeletonGrid count={4} className="mt-4" />
+      ) : null}
+
+      <div
+        ref={sentinelRef}
+        className="mt-6 flex h-10 w-full items-center justify-center"
+      >
+        {isFetchingNextPage ? null : isError && hasItems ? (
+          <Text size="body2" className="text-red-500">
+            {error
+              ? normalizeApiError(error).message
+              : '추가 일지를 불러오지 못했습니다.'}
+          </Text>
+        ) : hasNextPage ? (
+          <div />
+        ) : hasItems ? (
+          <Text size="body2" className="text-gray-400">
+            마지막 일지입니다.
+          </Text>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/src/app.feature/diary/board/screen/DiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/DiaryListScreen.tsx
@@ -3,25 +3,28 @@
 import { Icon, Text } from '@1d1s/design-system';
 import DiaryCard from '@component/cards/DiaryCard';
 import EmptyState from '@component/EmptyState';
+import { BoardScreenLayout } from '@component/layout/BoardScreenLayout';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import MasonryColumns from '@component/MasonryColumns';
 import { DiaryCardSkeletonGrid } from '@component/skeletons/DiaryCardSkeleton';
 import { getCategoryLabel } from '@constants/categories';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { normalizeApiError } from '@module/api/error';
+import { useDedupedInfinitePages } from '@module/hooks/useDedupedInfinitePages';
 import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
+import { useLoginRequiredParam } from '@module/hooks/useLoginRequiredParam';
 import { cn } from '@module/utils/cn';
 import { formatMonthDayKR, getDateTimestamp } from '@module/utils/date';
-import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import {
   resolveDiaryImageUrl,
   resolveDiaryThumbnail,
 } from '../../shared/utils/diaryImageUrl';
 import { mapFeelingToEmotion } from '../../shared/utils/feeling';
+import { DiaryInfiniteFooter } from '../components/DiaryInfiniteFooter';
 import { useDiaryList } from '../hooks/useDiaryQueries';
 import { useLikeToggle } from '../hooks/useLikeToggle';
 import { type DiaryItem } from '../type/diary';
@@ -133,9 +136,7 @@ DiaryListItem.displayName = 'DiaryListItem';
 
 export default function DiaryListScreen(): React.ReactElement {
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const isLoginRequired = searchParams.get('loginRequired') === 'true';
+  const { isLoginRequired, returnTo } = useLoginRequiredParam();
   const isLoggedIn = useIsLoggedIn();
   const [sortMode] = useState<SortMode>('latest');
   // isLoginRequired는 URL 파라미터로 첫 렌더에만 true가 되고 즉시 삭제된다.
@@ -145,28 +146,13 @@ export default function DiaryListScreen(): React.ReactElement {
   );
   // 상세 → 목록 바운스 시 원래 가려던 상세 경로. 로그인 후 그리로 복귀한다.
   const [loginReturnTo, setLoginReturnTo] = useState<string | null>(() =>
-    isLoginRequired && !isLoggedIn
-      ? sanitizeReturnTo(searchParams.get(RETURN_TO_PARAM))
-      : null
+    isLoginRequired && !isLoggedIn ? returnTo : null
   );
   const [loginDialogDescription, setLoginDialogDescription] = useState(() =>
     isLoginRequired && !isLoggedIn
       ? '일지 상세는 로그인 후 이용할 수 있습니다.'
       : '로그인 후 이용할 수 있습니다.'
   );
-
-  useEffect(() => {
-    if (!isLoginRequired) {
-      return;
-    }
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete('loginRequired');
-    params.delete(RETURN_TO_PARAM);
-    const query = params.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname, {
-      scroll: false,
-    });
-  }, [isLoginRequired, pathname, router, searchParams]);
 
   const handleLikeRequireLogin = useCallback((): void => {
     setLoginDialogDescription('좋아요 기능은 로그인 후 이용할 수 있습니다.');
@@ -191,17 +177,11 @@ export default function DiaryListScreen(): React.ReactElement {
     isFetchingNextPage,
     fetchNextPage,
   });
-  const diaries = useMemo(() => {
-    const flattenedDiaries =
-      data?.pages?.flatMap((page) => page?.items ?? []) ?? [];
-    const diaryMap = new Map<number, DiaryItem>();
-
-    flattenedDiaries.forEach((diary) => {
-      diaryMap.set(diary.id, diary);
-    });
-
-    return Array.from(diaryMap.values());
-  }, [data]);
+  const diaries = useDedupedInfinitePages(
+    data,
+    (page) => page?.items,
+    (diary) => diary.id
+  );
 
   const sortedDiaries = useMemo(
     () => sortDiaries(diaries, sortMode),
@@ -224,7 +204,50 @@ export default function DiaryListScreen(): React.ReactElement {
   );
 
   return (
-    <div className="min-h-screen w-full">
+    <BoardScreenLayout
+      title="일지 보드"
+      description="다른 챌린저의 일지를 보며 동기부여를 얻어보세요."
+      mobileHeader={
+        // 모바일 sticky 헤더 — 일지.
+        // 네이티브 쉘은 AppTopNav 가 같은 영역을 차지하고 FAB 가
+        // "일지 추가" 를 제공하므로, 이 헤더는 글로벌 sticky 차단 룰로
+        // 함께 가린다 (data-native-keep 제거).
+        <div
+          className={cn(
+            'sticky top-0 z-20 flex items-center justify-between',
+            'gap-3 border-b border-gray-100',
+            'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
+            'backdrop-blur lg:hidden'
+          )}
+        >
+          <Text
+            as="h1"
+            size="heading1"
+            weight="extrabold"
+            className="tracking-[-0.5px] text-gray-900"
+          >
+            일지
+          </Text>
+          {isLoggedIn ? (
+            <button
+              type="button"
+              onClick={() => router.push('/diary/create')}
+              aria-label="일지 쓰기"
+              data-native-hide
+              className={cn(
+                // 챌린지 보드의 "새 챌린지" 버튼과 동일한 모바일 CTA 스타일
+                'bg-brand inline-flex shrink-0 items-center gap-1 rounded-full',
+                'px-3 py-1.5 text-[11px] font-extrabold text-white',
+                'transition hover:brightness-105'
+              )}
+            >
+              <Icon name="Plus" size={12} aria-hidden />
+              일지 쓰기
+            </button>
+          ) : null}
+        </div>
+      }
+    >
       <LoginRequiredDialog
         open={showLoginDialog}
         onOpenChange={(open) => {
@@ -237,131 +260,51 @@ export default function DiaryListScreen(): React.ReactElement {
         returnTo={loginReturnTo}
       />
 
-      {/* 모바일 sticky 헤더 — 일지.
-          네이티브 쉘은 AppTopNav 가 같은 영역을 차지하고 FAB 가
-          "일지 추가" 를 제공하므로, 이 헤더는 글로벌 sticky 차단 룰로
-          함께 가린다 (data-native-keep 제거). */}
-      <div
-        className={cn(
-          'sticky top-0 z-20 flex items-center justify-between',
-          'gap-3 border-b border-gray-100',
-          'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
-          'backdrop-blur lg:hidden'
-        )}
-      >
-        <Text
-          as="h1"
-          size="heading1"
-          weight="extrabold"
-          className="tracking-[-0.5px] text-gray-900"
-        >
-          일지
-        </Text>
-        {isLoggedIn ? (
-          <button
-            type="button"
-            onClick={() => router.push('/diary/create')}
-            aria-label="일지 쓰기"
-            data-native-hide
-            className={cn(
-              // 챌린지 보드의 "새 챌린지" 버튼과 동일한 모바일 헤더 CTA 스타일
-              'bg-brand inline-flex shrink-0 items-center gap-1 rounded-full',
-              'px-3 py-1.5 text-[11px] font-extrabold text-white',
-              'transition hover:brightness-105'
-            )}
-          >
-            <Icon name="Plus" size={12} aria-hidden />
-            일지 쓰기
-          </button>
-        ) : null}
-      </div>
+      {showSkeleton ? (
+        <DiaryCardSkeletonGrid count={12} className="data-fade-in mt-6" />
+      ) : null}
 
-      <div
-        className={cn(
-          'mx-auto w-full max-w-[1200px]',
-          'px-5 py-5 lg:px-8 lg:py-10'
-        )}
-      >
-        <header
-          className={cn(
-            'hidden flex-col gap-4 border-b border-gray-100 pb-5',
-            'lg:flex lg:flex-row lg:items-end lg:justify-between'
-          )}
-        >
-          <div className="flex flex-col gap-1.5">
-            <Text
-              size="pageTitle"
-              weight="extrabold"
-              className="tracking-tight text-gray-900"
-            >
-              일지 보드
-            </Text>
-            <Text size="body2" weight="regular" className="text-gray-500">
-              다른 챌린저의 일지를 보며 동기부여를 얻어보세요.
-            </Text>
-          </div>
-        </header>
-
-        {showSkeleton ? (
-          <DiaryCardSkeletonGrid count={12} className="data-fade-in mt-6" />
-        ) : null}
-
-        {isError && !hasLoadedDiaries ? (
-          <div className="mt-10 flex w-full justify-center py-10">
-            <Text size="body1" weight="medium" className="text-red-600">
-              {error
-                ? normalizeApiError(error).message
-                : '일지를 불러오지 못했습니다.'}
-            </Text>
-          </div>
-        ) : null}
-
-        {!showSkeleton && hasLoadedDiaries ? (
-          <MasonryColumns className="data-fade-in mt-6">
-            {sortedDiaries.map((item) => (
-              <DiaryListItem
-                key={item.id}
-                item={item}
-                href={isLoggedIn ? `/diary/${item.id}` : undefined}
-                onRequireLogin={handleRequireLogin}
-                onLikeToggle={handleLikeToggle}
-              />
-            ))}
-          </MasonryColumns>
-        ) : null}
-
-        {!showSkeleton && !isError && !hasLoadedDiaries ? (
-          <EmptyState
-            variant="diary"
-            title="아직 등록된 일지가 없어요"
-            description="첫 일지를 남기고 스트릭을 시작해 보세요"
-            className="mt-10"
-          />
-        ) : null}
-
-        {isFetchingNextPage ? (
-          <DiaryCardSkeletonGrid count={4} className="mt-4" />
-        ) : null}
-
-        <div
-          ref={ref}
-          className="mt-6 flex h-10 w-full items-center justify-center"
-        >
-          {isFetchingNextPage ? null : isError && hasLoadedDiaries ? (
-            <Text size="body2" className="text-red-500">
-              {error
-                ? normalizeApiError(error).message
-                : '추가 일지를 불러오지 못했습니다.'}
-            </Text>
-          ) : hasNextPage ? (
-            <div />
-          ) : hasLoadedDiaries ? (
-            <Text size="body2" className="text-gray-400">
-              마지막 일지입니다.
-            </Text>
-          ) : null}
+      {isError && !hasLoadedDiaries ? (
+        <div className="mt-10 flex w-full justify-center py-10">
+          <Text size="body1" weight="medium" className="text-red-600">
+            {error
+              ? normalizeApiError(error).message
+              : '일지를 불러오지 못했습니다.'}
+          </Text>
         </div>
-      </div>
-    </div>
+      ) : null}
+
+      {!showSkeleton && hasLoadedDiaries ? (
+        <MasonryColumns className="data-fade-in mt-6">
+          {sortedDiaries.map((item) => (
+            <DiaryListItem
+              key={item.id}
+              item={item}
+              href={isLoggedIn ? `/diary/${item.id}` : undefined}
+              onRequireLogin={handleRequireLogin}
+              onLikeToggle={handleLikeToggle}
+            />
+          ))}
+        </MasonryColumns>
+      ) : null}
+
+      {!showSkeleton && !isError && !hasLoadedDiaries ? (
+        <EmptyState
+          variant="diary"
+          title="아직 등록된 일지가 없어요"
+          description="첫 일지를 남기고 스트릭을 시작해 보세요"
+          className="mt-10"
+        />
+      ) : null}
+
+      <DiaryInfiniteFooter
+        sentinelRef={ref}
+        isFetchingNextPage={isFetchingNextPage}
+        isError={isError}
+        error={error}
+        hasItems={hasLoadedDiaries}
+        hasNextPage={hasNextPage ?? false}
+      />
+    </BoardScreenLayout>
   );
 }

--- a/src/app.feature/diary/board/screen/MemberDiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/MemberDiaryListScreen.tsx
@@ -3,6 +3,8 @@
 import { Text } from '@1d1s/design-system';
 import DiaryCard from '@component/cards/DiaryCard';
 import EmptyState from '@component/EmptyState';
+import { BoardScreenLayout } from '@component/layout/BoardScreenLayout';
+import { MobileStickyHeader } from '@component/layout/MobileStickyHeader';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import MasonryColumns from '@component/MasonryColumns';
 import { DiaryCardSkeletonGrid } from '@component/skeletons/DiaryCardSkeleton';
@@ -17,13 +19,14 @@ import { mapFeelingToEmotion } from '@feature/diary/shared/utils/feeling';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useMemberProfileDiariesInfinite } from '@feature/member/hooks/useMemberQueries';
 import { normalizeApiError } from '@module/api/error';
+import { useDedupedInfinitePages } from '@module/hooks/useDedupedInfinitePages';
 import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
-import { cn } from '@module/utils/cn';
 import { formatMonthDayKR } from '@module/utils/date';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
-import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
+
+import { DiaryInfiniteFooter } from '../components/DiaryInfiniteFooter';
 
 const MEMBER_DIARY_PAGE_SIZE = 12;
 
@@ -113,15 +116,11 @@ export function MemberDiaryListScreen({
     fetchNextPage,
   });
 
-  const diaryItems = useMemo(() => {
-    const flattened =
-      data?.pages?.flatMap((page) => page?.diaryList?.items ?? []) ?? [];
-    const diaryMap = new Map<number, DiaryItem>();
-    flattened.forEach((diary) => {
-      diaryMap.set(diary.id, diary);
-    });
-    return Array.from(diaryMap.values());
-  }, [data]);
+  const diaryItems = useDedupedInfinitePages(
+    data,
+    (page) => page?.diaryList?.items,
+    (diary) => diary.id
+  );
 
   const hasDiaries = diaryItems.length > 0;
 
@@ -132,127 +131,66 @@ export function MemberDiaryListScreen({
   );
 
   return (
-    <div className="min-h-screen w-full">
+    <BoardScreenLayout
+      title="일지 전체 보기"
+      description="작성한 일지 전체 목록입니다."
+      mobileHeader={
+        <MobileStickyHeader
+          title="일지 전체 보기"
+          onBack={() => router.push(`/member/${memberId}`)}
+        />
+      }
+    >
       <LoginRequiredDialog
         open={showLoginDialog}
         onOpenChange={setShowLoginDialog}
       />
 
-      {/* 모바일 sticky 헤더 — ← + 일지 전체 보기 */}
-      <div
-        className={cn(
-          'sticky top-0 z-30 flex items-center gap-3',
-          'h-14-safe pt-safe-top',
-          'border-b border-gray-100 bg-white/95 px-4 backdrop-blur',
-          'lg:hidden'
-        )}
-      >
-        <button
-          type="button"
-          aria-label="뒤로가기"
-          onClick={() => router.push(`/member/${memberId}`)}
-          className={cn(
-            'flex h-8 w-8 items-center justify-center rounded-lg',
-            'text-gray-700 transition-colors hover:bg-gray-100'
-          )}
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <Text
-          size="heading2"
-          weight="extrabold"
-          className="flex-1 tracking-[-0.3px] text-gray-900"
-        >
-          일지 전체 보기
-        </Text>
-      </div>
+      {showSkeleton ? (
+        <DiaryCardSkeletonGrid
+          count={MEMBER_DIARY_PAGE_SIZE}
+          className="data-fade-in mt-6"
+        />
+      ) : null}
 
-      <div
-        className={cn(
-          'mx-auto w-full max-w-[1200px]',
-          'px-5 py-5 lg:px-8 lg:py-10'
-        )}
-      >
-        <header
-          className={cn(
-            'hidden flex-col gap-4 border-b border-gray-100 pb-5',
-            'lg:flex lg:flex-row lg:items-end lg:justify-between'
-          )}
-        >
-          <div className="flex flex-col gap-1.5">
-            <Text
-              size="pageTitle"
-              weight="extrabold"
-              className="tracking-tight text-gray-900"
-            >
-              일지 전체 보기
-            </Text>
-            <Text size="body2" weight="regular" className="text-gray-500">
-              작성한 일지 전체 목록입니다.
-            </Text>
-          </div>
-        </header>
-
-        {showSkeleton ? (
-          <DiaryCardSkeletonGrid
-            count={MEMBER_DIARY_PAGE_SIZE}
-            className="data-fade-in mt-6"
-          />
-        ) : null}
-
-        {isError && !hasDiaries ? (
-          <div className="mt-10 flex w-full justify-center py-10">
-            <Text size="body1" weight="medium" className="text-red-600">
-              {error
-                ? normalizeApiError(error).message
-                : '일지를 불러오지 못했습니다.'}
-            </Text>
-          </div>
-        ) : null}
-
-        {!showSkeleton && hasDiaries ? (
-          <MasonryColumns className="data-fade-in mt-6">
-            {diaryItems.map((diary) => (
-              <MemberDiaryListItem
-                key={diary.id}
-                item={diary}
-                onLikeToggle={handleLikeToggle}
-              />
-            ))}
-          </MasonryColumns>
-        ) : null}
-
-        {!showSkeleton && !isError && !hasDiaries ? (
-          <EmptyState
-            variant="diary"
-            title="아직 작성한 일지가 없어요"
-            className="mt-10"
-          />
-        ) : null}
-
-        {isFetchingNextPage ? (
-          <DiaryCardSkeletonGrid count={4} className="mt-4" />
-        ) : null}
-
-        <div
-          ref={ref}
-          className="mt-6 flex h-10 w-full items-center justify-center"
-        >
-          {isFetchingNextPage ? null : isError && hasDiaries ? (
-            <Text size="body2" className="text-red-500">
-              {error
-                ? normalizeApiError(error).message
-                : '추가 일지를 불러오지 못했습니다.'}
-            </Text>
-          ) : hasNextPage ? (
-            <div />
-          ) : hasDiaries ? (
-            <Text size="body2" className="text-gray-400">
-              마지막 일지입니다.
-            </Text>
-          ) : null}
+      {isError && !hasDiaries ? (
+        <div className="mt-10 flex w-full justify-center py-10">
+          <Text size="body1" weight="medium" className="text-red-600">
+            {error
+              ? normalizeApiError(error).message
+              : '일지를 불러오지 못했습니다.'}
+          </Text>
         </div>
-      </div>
-    </div>
+      ) : null}
+
+      {!showSkeleton && hasDiaries ? (
+        <MasonryColumns className="data-fade-in mt-6">
+          {diaryItems.map((diary) => (
+            <MemberDiaryListItem
+              key={diary.id}
+              item={diary}
+              onLikeToggle={handleLikeToggle}
+            />
+          ))}
+        </MasonryColumns>
+      ) : null}
+
+      {!showSkeleton && !isError && !hasDiaries ? (
+        <EmptyState
+          variant="diary"
+          title="아직 작성한 일지가 없어요"
+          className="mt-10"
+        />
+      ) : null}
+
+      <DiaryInfiniteFooter
+        sentinelRef={ref}
+        isFetchingNextPage={isFetchingNextPage}
+        isError={isError}
+        error={error}
+        hasItems={hasDiaries}
+        hasNextPage={hasNextPage ?? false}
+      />
+    </BoardScreenLayout>
   );
 }

--- a/src/app.feature/diary/board/screen/MyDiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/MyDiaryListScreen.tsx
@@ -3,17 +3,17 @@
 import { Text } from '@1d1s/design-system';
 import DiaryCard from '@component/cards/DiaryCard';
 import EmptyState from '@component/EmptyState';
+import { BoardScreenLayout } from '@component/layout/BoardScreenLayout';
+import { MobileStickyHeader } from '@component/layout/MobileStickyHeader';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import MasonryColumns from '@component/MasonryColumns';
 import { DiaryCardSkeletonGrid } from '@component/skeletons/DiaryCardSkeleton';
-import { DiaryItem } from '@feature/diary/board/type/diary';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { normalizeApiError } from '@module/api/error';
+import { useDedupedInfinitePages } from '@module/hooks/useDedupedInfinitePages';
 import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
-import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
-import { ArrowLeft } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import React, { useCallback, useMemo, useState } from 'react';
 
@@ -21,6 +21,7 @@ import {
   buildDiaryCardViewModels,
   DiaryCardViewModel,
 } from '../../../member/mypage/utils/mypageUtils';
+import { DiaryInfiniteFooter } from '../components/DiaryInfiniteFooter';
 import { useMyDiariesInfinite } from '../hooks/useDiaryQueries';
 import { useLikeToggle } from '../hooks/useLikeToggle';
 
@@ -91,14 +92,11 @@ export function MyDiaryListScreen(): React.ReactElement {
     fetchNextPage,
   });
 
-  const diaryItems = useMemo(() => {
-    const flattened = data?.pages?.flatMap((page) => page?.items ?? []) ?? [];
-    const diaryMap = new Map<number, DiaryItem>();
-    flattened.forEach((diary) => {
-      diaryMap.set(diary.id, diary);
-    });
-    return Array.from(diaryMap.values());
-  }, [data]);
+  const diaryItems = useDedupedInfinitePages(
+    data,
+    (page) => page?.items,
+    (diary) => diary.id
+  );
 
   const diaryCards = useMemo(
     () => buildDiaryCardViewModels(diaryItems, nickname),
@@ -108,128 +106,64 @@ export function MyDiaryListScreen(): React.ReactElement {
   const hasDiaries = diaryCards.length > 0;
 
   return (
-    <div className="min-h-screen w-full">
+    <BoardScreenLayout
+      title="내 일지"
+      description="내가 작성한 일지 전체 목록입니다."
+      mobileHeader={
+        <MobileStickyHeader title="내 일지" onBack={() => router.back()} />
+      }
+    >
       <LoginRequiredDialog
         open={showLoginDialog}
         onOpenChange={setShowLoginDialog}
       />
 
-      {/* 모바일 sticky 헤더 — ← + 내 일지 */}
-      <div
-        className={cn(
-          'sticky top-0 z-30 flex items-center gap-3',
-          'h-14-safe pt-safe-top',
-          'border-b border-gray-100 bg-white/95 px-4 backdrop-blur',
-          'lg:hidden'
-        )}
-      >
-        <button
-          type="button"
-          aria-label="뒤로가기"
-          onClick={() => router.back()}
-          className={cn(
-            'flex h-8 w-8 items-center justify-center rounded-lg',
-            'text-gray-700 transition-colors hover:bg-gray-100'
-          )}
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <Text
-          size="heading2"
-          weight="extrabold"
-          className="flex-1 tracking-[-0.3px] text-gray-900"
-        >
-          내 일지
-        </Text>
-      </div>
+      {showSkeleton ? (
+        <DiaryCardSkeletonGrid
+          count={MY_DIARY_PAGE_SIZE}
+          className="data-fade-in mt-6"
+        />
+      ) : null}
 
-      <div
-        className={cn(
-          'mx-auto w-full max-w-[1200px]',
-          'px-5 py-5 lg:px-8 lg:py-10'
-        )}
-      >
-        <header
-          className={cn(
-            'hidden flex-col gap-4 border-b border-gray-100 pb-5',
-            'lg:flex lg:flex-row lg:items-end lg:justify-between'
-          )}
-        >
-          <div className="flex flex-col gap-1.5">
-            <Text
-              size="pageTitle"
-              weight="extrabold"
-              className="tracking-tight text-gray-900"
-            >
-              내 일지
-            </Text>
-            <Text size="body2" weight="regular" className="text-gray-500">
-              내가 작성한 일지 전체 목록입니다.
-            </Text>
-          </div>
-        </header>
-
-        {showSkeleton ? (
-          <DiaryCardSkeletonGrid
-            count={MY_DIARY_PAGE_SIZE}
-            className="data-fade-in mt-6"
-          />
-        ) : null}
-
-        {isError && !hasDiaries ? (
-          <div className="mt-10 flex w-full justify-center py-10">
-            <Text size="body1" weight="medium" className="text-red-600">
-              {error
-                ? normalizeApiError(error).message
-                : '일지를 불러오지 못했습니다.'}
-            </Text>
-          </div>
-        ) : null}
-
-        {!showSkeleton && hasDiaries ? (
-          <MasonryColumns className="data-fade-in mt-6">
-            {diaryCards.map((diary) => (
-              <MyDiaryListItem
-                key={diary.id}
-                item={diary}
-                onLikeToggle={handleLikeToggle}
-              />
-            ))}
-          </MasonryColumns>
-        ) : null}
-
-        {!showSkeleton && !isError && !hasDiaries ? (
-          <EmptyState
-            variant="diary"
-            title="아직 작성한 일지가 없어요"
-            description="첫 일지를 남기고 기록을 시작해 보세요"
-            className="mt-10"
-          />
-        ) : null}
-
-        {isFetchingNextPage ? (
-          <DiaryCardSkeletonGrid count={4} className="mt-4" />
-        ) : null}
-
-        <div
-          ref={ref}
-          className="mt-6 flex h-10 w-full items-center justify-center"
-        >
-          {isFetchingNextPage ? null : isError && hasDiaries ? (
-            <Text size="body2" className="text-red-500">
-              {error
-                ? normalizeApiError(error).message
-                : '추가 일지를 불러오지 못했습니다.'}
-            </Text>
-          ) : hasNextPage ? (
-            <div />
-          ) : hasDiaries ? (
-            <Text size="body2" className="text-gray-400">
-              마지막 일지입니다.
-            </Text>
-          ) : null}
+      {isError && !hasDiaries ? (
+        <div className="mt-10 flex w-full justify-center py-10">
+          <Text size="body1" weight="medium" className="text-red-600">
+            {error
+              ? normalizeApiError(error).message
+              : '일지를 불러오지 못했습니다.'}
+          </Text>
         </div>
-      </div>
-    </div>
+      ) : null}
+
+      {!showSkeleton && hasDiaries ? (
+        <MasonryColumns className="data-fade-in mt-6">
+          {diaryCards.map((diary) => (
+            <MyDiaryListItem
+              key={diary.id}
+              item={diary}
+              onLikeToggle={handleLikeToggle}
+            />
+          ))}
+        </MasonryColumns>
+      ) : null}
+
+      {!showSkeleton && !isError && !hasDiaries ? (
+        <EmptyState
+          variant="diary"
+          title="아직 작성한 일지가 없어요"
+          description="첫 일지를 남기고 기록을 시작해 보세요"
+          className="mt-10"
+        />
+      ) : null}
+
+      <DiaryInfiniteFooter
+        sentinelRef={ref}
+        isFetchingNextPage={isFetchingNextPage}
+        isError={isError}
+        error={error}
+        hasItems={hasDiaries}
+        hasNextPage={hasNextPage ?? false}
+      />
+    </BoardScreenLayout>
   );
 }

--- a/src/app.module/hooks/useDedupedInfinitePages.test.ts
+++ b/src/app.module/hooks/useDedupedInfinitePages.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { dedupeById } from './useDedupedInfinitePages';
+
+interface Row {
+  id: number;
+  value: string;
+}
+
+const byId = (row: Row): number => row.id;
+
+describe('dedupeById', () => {
+  it('중복 없는 목록은 순서를 유지한다', () => {
+    const rows: Row[] = [
+      { id: 1, value: 'a' },
+      { id: 2, value: 'b' },
+      { id: 3, value: 'c' },
+    ];
+    expect(dedupeById(rows, byId)).toEqual(rows);
+  });
+
+  it('id 중복 시 뒤에 온 항목이 앞을 덮어쓴다', () => {
+    const rows: Row[] = [
+      { id: 1, value: 'old' },
+      { id: 2, value: 'b' },
+      { id: 1, value: 'new' },
+    ];
+    expect(dedupeById(rows, byId)).toEqual([
+      { id: 1, value: 'new' },
+      { id: 2, value: 'b' },
+    ]);
+  });
+
+  it('첫 등장 위치의 순서를 보존한다', () => {
+    const rows: Row[] = [
+      { id: 5, value: 'a' },
+      { id: 3, value: 'b' },
+      { id: 5, value: 'c' },
+      { id: 1, value: 'd' },
+    ];
+    expect(dedupeById(rows, byId).map(byId)).toEqual([5, 3, 1]);
+  });
+
+  it('빈 배열은 빈 배열을 반환한다', () => {
+    expect(dedupeById([] as Row[], byId)).toEqual([]);
+  });
+});

--- a/src/app.module/hooks/useDedupedInfinitePages.ts
+++ b/src/app.module/hooks/useDedupedInfinitePages.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+/**
+ * id 기준으로 중복을 제거한다. 뒤에 온 항목이 앞을 덮어쓴다
+ * (Map.set 의미) — 무한스크롤 페이지 경계에서 재수신된 항목의
+ * 최신 상태가 유지되도록 하는 기존 동작을 그대로 보존한다.
+ */
+export function dedupeById<T>(items: T[], getId: (item: T) => number): T[] {
+  const map = new Map<number, T>();
+  items.forEach((item) => {
+    map.set(getId(item), item);
+  });
+  return Array.from(map.values());
+}
+
+interface InfiniteData<TPage> {
+  pages?: TPage[];
+}
+
+/**
+ * useInfiniteQuery 결과의 pages 를 평탄화한 뒤 id 로 중복을 제거한다.
+ * 일지 리스트 3개 화면에서 반복되던 `flatMap → Map dedupe` 를 공통화.
+ */
+export function useDedupedInfinitePages<TPage, TItem>(
+  data: InfiniteData<TPage> | undefined,
+  getItems: (page: TPage) => TItem[] | undefined,
+  getId: (item: TItem) => number
+): TItem[] {
+  return useMemo(() => {
+    const flattened =
+      data?.pages?.flatMap((page) => getItems(page) ?? []) ?? [];
+    return dedupeById(flattened, getId);
+    // getItems/getId 는 구조적 셀렉터로 의미가 불변 — 기존 화면과
+    // 동일하게 data 변경 시에만 재계산한다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+}

--- a/src/app.module/hooks/useLoginRequiredParam.ts
+++ b/src/app.module/hooks/useLoginRequiredParam.ts
@@ -1,0 +1,38 @@
+import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+interface LoginRequiredParam {
+  /** `?loginRequired=true` 로 진입했는지 여부 */
+  isLoginRequired: boolean;
+  /** 로그인 후 복귀할 상세 경로 (무효면 null) */
+  returnTo: string | null;
+}
+
+/**
+ * 상세 → 목록 바운스 시 붙는 `loginRequired` / `returnTo` 쿼리를 읽고,
+ * 첫 렌더 이후 URL 에서 두 파라미터를 제거한다. 다이얼로그 상태 처리는
+ * 화면마다 상이하므로 반환값만 제공하고 표시 여부는 호출부가 결정한다.
+ */
+export function useLoginRequiredParam(): LoginRequiredParam {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isLoginRequired = searchParams.get('loginRequired') === 'true';
+  const returnTo = sanitizeReturnTo(searchParams.get(RETURN_TO_PARAM));
+
+  useEffect(() => {
+    if (!isLoginRequired) {
+      return;
+    }
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('loginRequired');
+    params.delete(RETURN_TO_PARAM);
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }, [isLoginRequired, pathname, router, searchParams]);
+
+  return { isLoginRequired, returnTo };
+}


### PR DESCRIPTION
## 개요
로드맵 3 — board 계열 6개 화면(일지·챌린지 전체/내/멤버)의 복붙 셸을 공통 컴포넌트/훅으로 추출한다. **동작 보존(behavior-preserving) 리팩토링**으로 화면별 diff를 최소화했으며 UI/UX 변화는 없다.

## 변경 내용
- **MobileStickyHeader** (`app.component/layout`): 뒤로가기 sticky 헤더 컴포넌트화 → 4개 board 서브 화면에 적용
- **BoardScreenLayout** (`app.component/layout`): 최상위 래퍼 + 데스크탑 헤더(타이틀/설명/액션) 공통화 → 6개 화면 치환
- **DiaryInfiniteFooter** (`diary/board/components`): 일지 3개 화면 무한스크롤 하단부 공통화
- **useDedupedInfinitePages** (`app.module/hooks`): `flatMap→Map dedupe` 3중복 제거 + `dedupeById` 순수함수 특성화 테스트 추가
- **useLoginRequiredParam** (`app.module/hooks`): `loginRequired`/`returnTo` 파라미터 처리 및 URL strip 2중복 제거

## 감축
6개 화면 순수 감축 약 -308줄 (공통 파일로 로직 이관).

## 검증
- `vitest run` (82 passed, dedupeById 특성화 테스트 4개 추가)
- `tsc --noEmit` / `pnpm lint` / `pnpm knip` / `pnpm build` 통과

## 후속(별도)
`MobileStickyHeader`는 아직 board 외 ~15개 화면(SubPageShell, 상세/작성 화면 등)에서 동일 패턴이 반복됨 — 타이틀 size 등 미세 차이 검증 후 점진 치환 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent desktop and mobile layouts for challenge and diary screens.
  - Added mobile sticky headers with back navigation and optional actions.
  - Added reusable infinite-scroll footer states for diary lists.

- **Improvements**
  - Improved login-required navigation and return handling.
  - Prevented duplicate items when loading additional list pages.
  - Standardized loading, error, empty, and end-of-list displays across screens.

- **Tests**
  - Added coverage for list deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->