### PR TITLE
refactor: ChallengeDetailScreen God 컴포넌트 훅/컴포넌트 분해

### DIFF
--- a/src/app.feature/challenge/detail/components/ChallengeDetailCompactHeader.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDetailCompactHeader.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { ArrowLeft } from 'lucide-react';
+import React from 'react';
+
+interface ChallengeDetailCompactHeaderProps {
+  /** 스크롤 임계값 초과 시 true — 페이드인 노출 */
+  visible: boolean;
+  title: string;
+  onBack(): void;
+}
+
+/**
+ * 챌린지 상세 모바일 sliver-style sticky 헤더 — 스크롤 시 페이드인.
+ *
+ * data-fade-in 래퍼 밖에 둔다: 래퍼의 transform 이 containing block 을
+ * 만들어 position: fixed 가 뷰포트 대신 래퍼 기준이 되는 문제를 피한다.
+ * 네이티브 쉘에선 AppBackBar 가 같은 역할을 하므로 data-native-hide 로
+ * 가린다. globals.css 의 sticky 일괄 룰은 fixed 는 안 잡는다.
+ *
+ * (PR A 의 MobileStickyHeader 와 달리 fixed + 스크롤 페이드인 동작이라
+ * 별도 컴포넌트로 둔다.)
+ */
+export function ChallengeDetailCompactHeader({
+  visible,
+  title,
+  onBack,
+}: ChallengeDetailCompactHeaderProps): React.ReactElement {
+  return (
+    <div
+      data-native-hide
+      className={cn(
+        'fixed top-0 right-0 left-0 z-30 flex h-14 items-center',
+        'gap-3 border-b border-gray-100 bg-white/95 px-4',
+        'backdrop-blur transition-all duration-200 lg:hidden',
+        visible
+          ? 'translate-y-0 opacity-100'
+          : 'pointer-events-none -translate-y-full opacity-0'
+      )}
+    >
+      <button
+        type="button"
+        aria-label="뒤로가기"
+        onClick={onBack}
+        className={cn(
+          'flex h-8 w-8 shrink-0 items-center justify-center',
+          'rounded-lg text-gray-700 transition-colors hover:bg-gray-100'
+        )}
+      >
+        <ArrowLeft className="h-5 w-5" />
+      </button>
+      <Text
+        size="body1"
+        weight="extrabold"
+        className={cn(
+          'line-clamp-1 min-w-0 flex-1 tracking-[-0.3px] text-gray-900'
+        )}
+      >
+        {title}
+      </Text>
+    </div>
+  );
+}

--- a/src/app.feature/challenge/detail/components/ChallengeGoalModals.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeGoalModals.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  GoalAddList,
+  TextField,
+} from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { Trash2 } from 'lucide-react';
+import React from 'react';
+
+import type { ChallengeGoalEditors } from '../hooks/useChallengeGoalEditors';
+
+interface GoalAddListModalProps {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  title: string;
+  description: string;
+  goals: string[];
+  onGoalsChange(goals: string[]): void;
+  submitLabel: string;
+  submitDisabled: boolean;
+  submitMinWidthClass: string;
+  onSubmit(): void;
+}
+
+// 목표 입력/수정 모달의 공통 chrome. 본문은 GoalAddList 로 동일하고
+// 제목·설명·제출 버튼(라벨/너비/핸들러)만 다르다.
+function GoalAddListModal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  goals,
+  onGoalsChange,
+  submitLabel,
+  submitDisabled,
+  submitMinWidthClass,
+  onSubmit,
+}: GoalAddListModalProps): React.ReactElement {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
+        <DialogHeader className="flex-col items-start gap-1.5 pb-2">
+          <DialogTitle className="text-[17px] font-extrabold tracking-[-0.3px] text-gray-900">
+            {title}
+          </DialogTitle>
+          <DialogDescription className="text-[13px] leading-relaxed text-gray-500">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          <GoalAddList
+            goals={goals}
+            onGoalsChange={onGoalsChange}
+            placeholder="목표를 입력하고 Enter를 눌러 추가하세요"
+            inputAriaLabel="목표 입력"
+            maxGoals={5}
+          />
+        </DialogBody>
+        <DialogFooter>
+          <Button
+            size="md"
+            variant="secondary"
+            className="min-w-[80px]"
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button
+            size="md"
+            className={submitMinWidthClass}
+            disabled={submitDisabled}
+            onClick={onSubmit}
+          >
+            {submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ChallengeGoalModalsProps {
+  editors: ChallengeGoalEditors;
+}
+
+/**
+ * 챌린지 상세의 목표 입력/수정 3종 모달. 상태·핸들러는
+ * useChallengeGoalEditors 가 소유하고, 이 컴포넌트는 렌더만 담당한다.
+ */
+export function ChallengeGoalModals({
+  editors,
+}: ChallengeGoalModalsProps): React.ReactElement {
+  return (
+    <>
+      <GoalAddListModal
+        open={editors.showFreeGoalModal}
+        onOpenChange={editors.setShowFreeGoalModal}
+        title="내 목표 입력"
+        description="챌린지에서 달성할 목표를 입력하고 Enter 를 눌러 추가해 주세요. (최대 5개)"
+        goals={editors.freeGoalInputs}
+        onGoalsChange={editors.setFreeGoalInputs}
+        submitLabel={editors.isJoinPending ? '처리 중...' : '참여 신청'}
+        submitDisabled={editors.isJoinPending}
+        submitMinWidthClass="min-w-[112px]"
+        onSubmit={editors.handleFreeGoalSubmit}
+      />
+
+      <GoalAddListModal
+        open={editors.showEditGoalModal}
+        onOpenChange={editors.setShowEditGoalModal}
+        title="내 목표 수정"
+        description="새 목표를 입력하고 Enter 를 눌러 추가해 주세요. (최대 5개)"
+        goals={editors.editGoalInputs}
+        onGoalsChange={editors.setEditGoalInputs}
+        submitLabel={
+          editors.isUpdateParticipantGoalPending ? '저장 중...' : '저장'
+        }
+        submitDisabled={editors.isUpdateParticipantGoalPending}
+        submitMinWidthClass="min-w-[96px]"
+        onSubmit={editors.handleEditGoalSubmit}
+      />
+
+      <Dialog
+        open={editors.showEditChallengeGoalsModal}
+        onOpenChange={editors.setShowEditChallengeGoalsModal}
+      >
+        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
+          <DialogHeader className="flex-col items-start gap-1.5 pb-2">
+            <DialogTitle className="text-[17px] font-extrabold tracking-[-0.3px] text-gray-900">
+              챌린지 목표 수정
+            </DialogTitle>
+            <DialogDescription className="text-[13px] leading-relaxed text-gray-500">
+              챌린지 시작 전에만 목표를 수정할 수 있습니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2">
+              {editors.challengeGoalInputs.map((goal) => (
+                <div key={goal.id} className="flex items-center gap-2">
+                  <TextField
+                    value={goal.value}
+                    onChange={(event) => {
+                      editors.setChallengeGoalInputs((prev) =>
+                        prev.map((entry) =>
+                          entry.id === goal.id
+                            ? { ...entry, value: event.target.value }
+                            : entry
+                        )
+                      );
+                    }}
+                    placeholder="목표를 입력하세요"
+                    className="flex-1"
+                    maxLength={100}
+                  />
+                  <button
+                    type="button"
+                    aria-label="목표 삭제"
+                    className={cn(
+                      'flex h-10 w-10 shrink-0 cursor-pointer',
+                      'items-center justify-center rounded-lg text-gray-500',
+                      'transition-colors hover:bg-gray-100 hover:text-red-600'
+                    )}
+                    onClick={() => {
+                      editors.setChallengeGoalInputs((prev) =>
+                        prev.filter((entry) => entry.id !== goal.id)
+                      );
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              type="button"
+              disabled={editors.challengeGoalInputs.length >= 10}
+              onClick={() =>
+                editors.setChallengeGoalInputs((prev) => [
+                  ...prev,
+                  editors.createGoalEntry(),
+                ])
+              }
+            >
+              + 목표 추가
+            </Button>
+          </DialogBody>
+          <DialogFooter>
+            <Button
+              size="md"
+              variant="secondary"
+              className="min-w-[80px]"
+              onClick={() => editors.setShowEditChallengeGoalsModal(false)}
+            >
+              취소
+            </Button>
+            <Button
+              size="md"
+              className="min-w-[96px]"
+              disabled={editors.isUpdateChallengePending}
+              onClick={editors.handleEditChallengeGoalsSubmit}
+            >
+              {editors.isUpdateChallengePending ? '저장 중...' : '저장'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app.feature/challenge/detail/hooks/useChallengeGoalEditors.ts
+++ b/src/app.feature/challenge/detail/hooks/useChallengeGoalEditors.ts
@@ -1,0 +1,200 @@
+'use client';
+
+import { notifyApiError } from '@module/api/errorNotify';
+import { toast } from '@module/providers/toast';
+import { useState } from 'react';
+
+import type { ChallengeGoal } from '../../board/type/challenge';
+import {
+  useJoinChallenge,
+  useUpdateChallenge,
+  useUpdateParticipantGoal,
+} from './useChallengeMutations';
+
+export interface ChallengeGoalEntry {
+  id: string;
+  value: string;
+}
+
+function createGoalEntry(value = ''): ChallengeGoalEntry {
+  return { id: crypto.randomUUID(), value };
+}
+
+interface UseChallengeGoalEditorsParams {
+  challengeId: number;
+  /** 챌린지 고정 목표 (수정 모달 초기값) */
+  goals: ChallengeGoal[];
+  isChallengeAlreadyEnded: boolean;
+  /** 참여 신청 mutation — 자유 목표 참여와 공유하므로 주입받는다. */
+  joinChallenge: ReturnType<typeof useJoinChallenge>;
+}
+
+export interface ChallengeGoalEditors {
+  // 자유 목표 참여 모달
+  showFreeGoalModal: boolean;
+  setShowFreeGoalModal(open: boolean): void;
+  freeGoalInputs: string[];
+  setFreeGoalInputs(goals: string[]): void;
+  openFreeGoalModal(): void;
+  handleFreeGoalSubmit(): void;
+  // 내 목표 수정 모달 (자유 목표 참여자)
+  showEditGoalModal: boolean;
+  setShowEditGoalModal(open: boolean): void;
+  editGoalInputs: string[];
+  setEditGoalInputs(goals: string[]): void;
+  openEditGoalModal(): void;
+  handleEditGoalSubmit(): void;
+  // 챌린지 목표 수정 모달 (호스트)
+  showEditChallengeGoalsModal: boolean;
+  setShowEditChallengeGoalsModal(open: boolean): void;
+  challengeGoalInputs: ChallengeGoalEntry[];
+  setChallengeGoalInputs(
+    updater: (prev: ChallengeGoalEntry[]) => ChallengeGoalEntry[]
+  ): void;
+  createGoalEntry(value?: string): ChallengeGoalEntry;
+  openEditChallengeGoalsModal(): void;
+  handleEditChallengeGoalsSubmit(): void;
+  // 제출 pending (버튼 라벨/비활성용)
+  isJoinPending: boolean;
+  isUpdateParticipantGoalPending: boolean;
+  isUpdateChallengePending: boolean;
+}
+
+/**
+ * 챌린지 상세의 목표 입력/수정 3종(자유 목표 참여, 내 목표 수정, 챌린지
+ * 목표 수정) 상태·핸들러를 한 곳으로 모은 훅. ChallengeDetailScreen 에서
+ * 분리했으며 동작은 동일하다.
+ */
+export function useChallengeGoalEditors({
+  challengeId,
+  goals,
+  isChallengeAlreadyEnded,
+  joinChallenge,
+}: UseChallengeGoalEditorsParams): ChallengeGoalEditors {
+  const updateChallenge = useUpdateChallenge();
+  const updateParticipantGoal = useUpdateParticipantGoal();
+
+  const [showFreeGoalModal, setShowFreeGoalModal] = useState(false);
+  const [freeGoalInputs, setFreeGoalInputs] = useState<string[]>(['']);
+  const [showEditGoalModal, setShowEditGoalModal] = useState(false);
+  const [editGoalInputs, setEditGoalInputs] = useState<string[]>(['']);
+  const [showEditChallengeGoalsModal, setShowEditChallengeGoalsModal] =
+    useState(false);
+  const [challengeGoalInputs, setChallengeGoalInputs] = useState<
+    ChallengeGoalEntry[]
+  >(() => [createGoalEntry()]);
+
+  const openFreeGoalModal = (): void => {
+    setFreeGoalInputs([]);
+    setShowFreeGoalModal(true);
+  };
+
+  const handleFreeGoalSubmit = (): void => {
+    if (isChallengeAlreadyEnded) {
+      toast.error('종료된 챌린지는 참여 신청을 보낼 수 없습니다.');
+      setShowFreeGoalModal(false);
+      return;
+    }
+    const validGoals = freeGoalInputs
+      .map((goal) => goal.trim())
+      .filter(Boolean);
+    if (validGoals.length === 0) {
+      toast.error('목표를 최소 1개 이상 입력해 주세요.');
+      return;
+    }
+    joinChallenge.mutate(
+      { challengeId, data: validGoals },
+      {
+        onSuccess: () => {
+          setShowFreeGoalModal(false);
+          toast.success('챌린지 참여 신청이 완료되었습니다.');
+        },
+        onError: (mutationError) => {
+          notifyApiError(mutationError);
+        },
+      }
+    );
+  };
+
+  const openEditGoalModal = (): void => {
+    setEditGoalInputs(['']);
+    setShowEditGoalModal(true);
+  };
+
+  const handleEditGoalSubmit = (): void => {
+    const validGoals = editGoalInputs
+      .map((goalInput) => goalInput.trim())
+      .filter(Boolean);
+    if (validGoals.length === 0) {
+      toast.error('목표를 최소 1개 이상 입력해 주세요.');
+      return;
+    }
+    updateParticipantGoal.mutate(
+      { challengeId, goals: validGoals },
+      {
+        onSuccess: () => {
+          setShowEditGoalModal(false);
+          toast.success('목표가 수정되었습니다.');
+        },
+        onError: (mutationError) => {
+          notifyApiError(mutationError);
+        },
+      }
+    );
+  };
+
+  const openEditChallengeGoalsModal = (): void => {
+    const currentGoals = goals.map((goal) => createGoalEntry(goal.content));
+    setChallengeGoalInputs(
+      currentGoals.length > 0 ? currentGoals : [createGoalEntry()]
+    );
+    setShowEditChallengeGoalsModal(true);
+  };
+
+  const handleEditChallengeGoalsSubmit = (): void => {
+    const validGoals = challengeGoalInputs
+      .map((goalInput) => goalInput.value.trim())
+      .filter(Boolean);
+    if (validGoals.length === 0) {
+      toast.error('목표를 최소 1개 이상 입력해 주세요.');
+      return;
+    }
+    updateChallenge.mutate(
+      { challengeId, data: { goals: validGoals } },
+      {
+        onSuccess: () => {
+          setShowEditChallengeGoalsModal(false);
+          toast.success('챌린지 목표가 수정되었습니다.');
+        },
+        onError: (mutationError) => {
+          notifyApiError(mutationError);
+        },
+      }
+    );
+  };
+
+  return {
+    showFreeGoalModal,
+    setShowFreeGoalModal,
+    freeGoalInputs,
+    setFreeGoalInputs,
+    openFreeGoalModal,
+    handleFreeGoalSubmit,
+    showEditGoalModal,
+    setShowEditGoalModal,
+    editGoalInputs,
+    setEditGoalInputs,
+    openEditGoalModal,
+    handleEditGoalSubmit,
+    showEditChallengeGoalsModal,
+    setShowEditChallengeGoalsModal,
+    challengeGoalInputs,
+    setChallengeGoalInputs,
+    createGoalEntry,
+    openEditChallengeGoalsModal,
+    handleEditChallengeGoalsSubmit,
+    isJoinPending: joinChallenge.isPending,
+    isUpdateParticipantGoalPending: updateParticipantGoal.isPending,
+    isUpdateChallengePending: updateChallenge.isPending,
+  };
+}

--- a/src/app.feature/challenge/detail/hooks/usePokeMembers.ts
+++ b/src/app.feature/challenge/detail/hooks/usePokeMembers.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { notifyApiError } from '@module/api/errorNotify';
+import { toast } from '@module/providers/toast';
+import { useState } from 'react';
+
+import { usePokeChallengeMembers } from './useChallengeMutations';
+
+interface UsePokeMembersResult {
+  /** 이번 세션에서 이미 찌른 챌린지원 memberId 목록 */
+  pokedMemberIds: number[];
+  /** 현재 찌르기 요청 중인 대상 memberId (없으면 null) */
+  pokingMemberId: number | null;
+  handlePokeMember(memberId: number): void;
+}
+
+/**
+ * 챌린지원 콕 찌르기 상태/핸들러. ChallengeDetailScreen 에서 분리.
+ */
+export function usePokeMembers(challengeId: number): UsePokeMembersResult {
+  const pokeChallengeMembers = usePokeChallengeMembers();
+  const [pokedMemberIds, setPokedMemberIds] = useState<number[]>([]);
+  const [pokingMemberId, setPokingMemberId] = useState<number | null>(null);
+
+  const handlePokeMember = (memberId: number): void => {
+    if (pokeChallengeMembers.isPending) {
+      return;
+    }
+    setPokingMemberId(memberId);
+    pokeChallengeMembers.mutate(
+      { challengeId, receiverMemberIds: [memberId] },
+      {
+        onSuccess: (result) => {
+          const pokedIds = result?.pokedMemberIds ?? [];
+          if (pokedIds.includes(memberId)) {
+            setPokedMemberIds((prev) =>
+              Array.from(new Set([...prev, ...pokedIds]))
+            );
+            toast.success('콕 찔렀어요!');
+          } else {
+            // 오늘 이미 일지를 썼거나 오늘 이미 찔러 대상에서 제외된 경우
+            toast('오늘은 찌를 수 없는 챌린지원이에요.');
+          }
+        },
+        onError: (mutationError) => {
+          notifyApiError(mutationError);
+        },
+        onSettled: () => {
+          setPokingMemberId(null);
+        },
+      }
+    );
+  };
+
+  return { pokedMemberIds, pokingMemberId, handlePokeMember };
+}

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -1,21 +1,6 @@
 'use client';
 
-import {
-  Button,
-  Card,
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  GoalAddList,
-  Stripe,
-  Tag,
-  Text,
-  TextField,
-} from '@1d1s/design-system';
+import { Button, Card, Stripe, Tag, Text } from '@1d1s/design-system';
 import { AlertDialog } from '@component/AlertDialog';
 import { MobileBottomActionBar } from '@component/layout/MobileBottomActionBar';
 import LikeBurst from '@component/LikeBurst';
@@ -35,7 +20,7 @@ import { toast } from '@module/providers/toast';
 import { cn } from '@module/utils/cn';
 import { formatDateISO } from '@module/utils/date';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
-import { ArrowLeft, CircleAlert, Heart, Trash2 } from 'lucide-react';
+import { ArrowLeft, CircleAlert, Heart } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -52,8 +37,10 @@ import {
   isChallengeOngoing,
   isInfiniteChallengeEndDate,
 } from '../../board/utils/challengePeriod';
+import { ChallengeDetailCompactHeader } from '../components/ChallengeDetailCompactHeader';
 import { ChallengeDetailHero } from '../components/ChallengeDetailHero';
 import { ChallengeDiaryGrid } from '../components/ChallengeDiaryGrid';
+import { ChallengeGoalModals } from '../components/ChallengeGoalModals';
 import { ChallengeLeaderboardCard } from '../components/ChallengeLeaderboardCard';
 import { ChallengePasswordDialog } from '../components/ChallengePasswordDialog';
 import { ChallengeProgressCard } from '../components/ChallengeProgressCard';
@@ -61,21 +48,21 @@ import { ChallengeRulesCard } from '../components/ChallengeRulesCard';
 import { ExpandableText } from '../components/ExpandableText';
 import { PendingMemberItem } from '../components/PendingMemberItem';
 import { useChallengeDiaryList } from '../hooks/useChallengeDiaryQueries';
+import { useChallengeGoalEditors } from '../hooks/useChallengeGoalEditors';
 import {
   useAcceptParticipant,
   useJoinChallenge,
   useLeaveChallenge,
   useLikeChallenge,
-  usePokeChallengeMembers,
   useRejectParticipant,
   useUnlikeChallenge,
-  useUpdateChallenge,
-  useUpdateParticipantGoal,
   useVerifyChallengePassword,
 } from '../hooks/useChallengeMutations';
 import { useChallengePendingParticipants } from '../hooks/useChallengeParticipantQueries';
+import { usePokeMembers } from '../hooks/usePokeMembers';
 import { ChallengeDiaryItem } from '../type/challengeDiary';
 import { buildHeroGradient, getCategoryAccent } from '../utils/challengeAccent';
+import { buildChallengeCta } from '../utils/challengeCta';
 import {
   EMPTY_GOALS,
   EMPTY_PARTICIPANTS,
@@ -94,76 +81,6 @@ interface ChallengeDetailScreenProps {
 // 이 신호를 받으면 비밀번호 다이얼로그를 목표 입력 단계로 전환한다.
 const FREE_GOAL_REQUIRED_CODE = 'CHALLENGE_022';
 
-interface GoalAddListModalProps {
-  open: boolean;
-  onOpenChange(open: boolean): void;
-  title: string;
-  description: string;
-  goals: string[];
-  onGoalsChange(goals: string[]): void;
-  submitLabel: string;
-  submitDisabled: boolean;
-  submitMinWidthClass: string;
-  onSubmit(): void;
-}
-
-// 목표 입력/수정 모달의 공통 chrome. 본문은 GoalAddList 로 동일하고
-// 제목·설명·제출 버튼(라벨/너비/핸들러)만 다르다.
-function GoalAddListModal({
-  open,
-  onOpenChange,
-  title,
-  description,
-  goals,
-  onGoalsChange,
-  submitLabel,
-  submitDisabled,
-  submitMinWidthClass,
-  onSubmit,
-}: GoalAddListModalProps): React.ReactElement {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
-        <DialogHeader className="flex-col items-start gap-1.5 pb-2">
-          <DialogTitle className="text-[17px] font-extrabold tracking-[-0.3px] text-gray-900">
-            {title}
-          </DialogTitle>
-          <DialogDescription className="text-[13px] leading-relaxed text-gray-500">
-            {description}
-          </DialogDescription>
-        </DialogHeader>
-        <DialogBody>
-          <GoalAddList
-            goals={goals}
-            onGoalsChange={onGoalsChange}
-            placeholder="목표를 입력하고 Enter를 눌러 추가하세요"
-            inputAriaLabel="목표 입력"
-            maxGoals={5}
-          />
-        </DialogBody>
-        <DialogFooter>
-          <Button
-            size="md"
-            variant="secondary"
-            className="min-w-[80px]"
-            onClick={() => onOpenChange(false)}
-          >
-            취소
-          </Button>
-          <Button
-            size="md"
-            className={submitMinWidthClass}
-            disabled={submitDisabled}
-            onClick={onSubmit}
-          >
-            {submitLabel}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
 export function ChallengeDetailScreen({
   id,
 }: ChallengeDetailScreenProps): React.ReactElement {
@@ -181,9 +98,6 @@ export function ChallengeDetailScreen({
   const unlikeChallenge = useUnlikeChallenge();
   const acceptParticipant = useAcceptParticipant();
   const rejectParticipant = useRejectParticipant();
-  const updateChallenge = useUpdateChallenge();
-  const updateParticipantGoal = useUpdateParticipantGoal();
-  const pokeChallengeMembers = usePokeChallengeMembers();
   const verifyChallengePassword = useVerifyChallengePassword();
   const likeDiary = useLikeDiary();
   const unlikeDiary = useUnlikeDiary();
@@ -196,9 +110,8 @@ export function ChallengeDetailScreen({
   );
   // memberId 해석 실패 시 닉네임(유일값)으로 내 행을 판별하기 위한 폴백
   const currentNickname = sidebarData?.nickname ?? null;
-  // 이번 세션에서 이미 찌른 챌린지원과 현재 요청 중인 대상 추적
-  const [pokedMemberIds, setPokedMemberIds] = useState<number[]>([]);
-  const [pokingMemberId, setPokingMemberId] = useState<number | null>(null);
+  const { pokedMemberIds, pokingMemberId, handlePokeMember } =
+    usePokeMembers(challengeId);
   // 히어로 위 floating 뒤로가기(top-3.5)가 스크롤로 가려지기 시작하는
   // 시점에 맞춰 sticky 헤더가 즉시 등장하도록 임계값을 8px로 둔다.
   const [isCompactHeaderVisible, setIsCompactHeaderVisible] = useState(false);
@@ -214,25 +127,8 @@ export function ChallengeDetailScreen({
 
   const [showCreateUnavailableDialog, setShowCreateUnavailableDialog] =
     useState(false);
-  const [showFreeGoalModal, setShowFreeGoalModal] = useState(false);
-  const [freeGoalInputs, setFreeGoalInputs] = useState<string[]>(['']);
   // 비공개 챌린지가 자유 목표로 확인돼 목표 입력이 필요한지.
   const [passwordNeedsGoals, setPasswordNeedsGoals] = useState(false);
-  const [showEditGoalModal, setShowEditGoalModal] = useState(false);
-  const [editGoalInputs, setEditGoalInputs] = useState<string[]>(['']);
-  const [showEditChallengeGoalsModal, setShowEditChallengeGoalsModal] =
-    useState(false);
-  interface ChallengeGoalEntry {
-    id: string;
-    value: string;
-  }
-  const createGoalEntry = (value = ''): ChallengeGoalEntry => ({
-    id: crypto.randomUUID(),
-    value,
-  });
-  const [challengeGoalInputs, setChallengeGoalInputs] = useState<
-    ChallengeGoalEntry[]
-  >(() => [createGoalEntry()]);
 
   const { data: challengeDiariesData, isLoading: isDiariesLoading } =
     useChallengeDiaryList(challengeId, 5);
@@ -324,6 +220,13 @@ export function ChallengeDetailScreen({
     likeChallenge.isPending ||
     unlikeChallenge.isPending;
 
+  const goalEditors = useChallengeGoalEditors({
+    challengeId,
+    goals,
+    isChallengeAlreadyEnded,
+    joinChallenge,
+  });
+
   const handleJoinChallenge = (): void => {
     if (isChallengeAlreadyEnded) {
       toast.error('종료된 챌린지는 참여 신청을 보낼 수 없습니다.');
@@ -336,8 +239,7 @@ export function ChallengeDetailScreen({
     }
 
     if (isFreeChallenge) {
-      setFreeGoalInputs([]);
-      setShowFreeGoalModal(true);
+      goalEditors.openFreeGoalModal();
       return;
     }
 
@@ -346,33 +248,6 @@ export function ChallengeDetailScreen({
       { challengeId, data: goalContents },
       {
         onSuccess: () => {
-          toast.success('챌린지 참여 신청이 완료되었습니다.');
-        },
-        onError: (mutationError) => {
-          notifyApiError(mutationError);
-        },
-      }
-    );
-  };
-
-  const handleFreeGoalSubmit = (): void => {
-    if (isChallengeAlreadyEnded) {
-      toast.error('종료된 챌린지는 참여 신청을 보낼 수 없습니다.');
-      setShowFreeGoalModal(false);
-      return;
-    }
-    const validGoals = freeGoalInputs
-      .map((goal) => goal.trim())
-      .filter(Boolean);
-    if (validGoals.length === 0) {
-      toast.error('목표를 최소 1개 이상 입력해 주세요.');
-      return;
-    }
-    joinChallenge.mutate(
-      { challengeId, data: validGoals },
-      {
-        onSuccess: () => {
-          setShowFreeGoalModal(false);
           toast.success('챌린지 참여 신청이 완료되었습니다.');
         },
         onError: (mutationError) => {
@@ -447,93 +322,6 @@ export function ChallengeDetailScreen({
         notifyApiError(mutationError);
       },
     });
-  };
-
-  const handlePokeMember = (memberId: number): void => {
-    if (pokeChallengeMembers.isPending) {
-      return;
-    }
-    setPokingMemberId(memberId);
-    pokeChallengeMembers.mutate(
-      { challengeId, receiverMemberIds: [memberId] },
-      {
-        onSuccess: (result) => {
-          const pokedIds = result?.pokedMemberIds ?? [];
-          if (pokedIds.includes(memberId)) {
-            setPokedMemberIds((prev) =>
-              Array.from(new Set([...prev, ...pokedIds]))
-            );
-            toast.success('콕 찔렀어요!');
-          } else {
-            // 오늘 이미 일지를 썼거나 오늘 이미 찔러 대상에서 제외된 경우
-            toast('오늘은 찌를 수 없는 챌린지원이에요.');
-          }
-        },
-        onError: (mutationError) => {
-          notifyApiError(mutationError);
-        },
-        onSettled: () => {
-          setPokingMemberId(null);
-        },
-      }
-    );
-  };
-
-  const handleOpenEditGoalModal = (): void => {
-    setEditGoalInputs(['']);
-    setShowEditGoalModal(true);
-  };
-
-  const handleEditGoalSubmit = (): void => {
-    const validGoals = editGoalInputs
-      .map((goalInput) => goalInput.trim())
-      .filter(Boolean);
-    if (validGoals.length === 0) {
-      toast.error('목표를 최소 1개 이상 입력해 주세요.');
-      return;
-    }
-    updateParticipantGoal.mutate(
-      { challengeId, goals: validGoals },
-      {
-        onSuccess: () => {
-          setShowEditGoalModal(false);
-          toast.success('목표가 수정되었습니다.');
-        },
-        onError: (mutationError) => {
-          notifyApiError(mutationError);
-        },
-      }
-    );
-  };
-
-  const handleOpenEditChallengeGoalsModal = (): void => {
-    const currentGoals = goals.map((goal) => createGoalEntry(goal.content));
-    setChallengeGoalInputs(
-      currentGoals.length > 0 ? currentGoals : [createGoalEntry()]
-    );
-    setShowEditChallengeGoalsModal(true);
-  };
-
-  const handleEditChallengeGoalsSubmit = (): void => {
-    const validGoals = challengeGoalInputs
-      .map((goalInput) => goalInput.value.trim())
-      .filter(Boolean);
-    if (validGoals.length === 0) {
-      toast.error('목표를 최소 1개 이상 입력해 주세요.');
-      return;
-    }
-    updateChallenge.mutate(
-      { challengeId, data: { goals: validGoals } },
-      {
-        onSuccess: () => {
-          setShowEditChallengeGoalsModal(false);
-          toast.success('챌린지 목표가 수정되었습니다.');
-        },
-        onError: (mutationError) => {
-          notifyApiError(mutationError);
-        },
-      }
-    );
   };
 
   const handleDiaryLikeToggle = (diary: ChallengeDiaryItem): void => {
@@ -633,251 +421,29 @@ export function ChallengeDetailScreen({
       : `${summaryParticipantCnt}명 참여 · 제한없음`;
   const heroMetaLabel = `${participantsLabel} · ${remainingLabel}`;
 
-  // CTA 결정 로직: 호스트 / 참여 중 / 대기 / 신청 가능 / 신청 불가
-  interface ChallengeCtaConfig {
-    label: string;
-    onClick(): void;
-    disabled: boolean;
-    variant: 'primary' | 'secondary';
-    show: boolean;
-    hint?: string;
-    secondary?: {
-      label: string;
-      onClick(): void;
-      variant: 'primary' | 'secondary';
-    };
-  }
-  // 클릭 불가 안내 버튼(대기/종료/중도참여불가)의 공통 형태.
-  const disabledCta = (label: string, hint?: string): ChallengeCtaConfig => ({
-    label,
-    onClick: () => undefined,
-    disabled: true,
-    variant: 'secondary',
-    show: true,
-    hint,
+  const ctaConfig = buildChallengeCta({
+    isHost,
+    isParticipating,
+    isPending,
+    isChallengeCurrentlyOngoing,
+    isCheckWriteDatesLoading,
+    canJoinByStatus,
+    isChallengeAlreadyEnded,
+    isMidJoinBlocked,
+    canJoin,
+    isJoinPending: joinChallenge.isPending,
+    onEditChallenge: () => router.push(`/challenge/${id}/edit`),
+    onDiaryCreate: handleDiaryCreateClick,
+    onJoin: handleJoinChallenge,
   });
-
-  const ctaConfig = ((): ChallengeCtaConfig => {
-    if (isHost) {
-      const editChallenge = {
-        label: '챌린지 수정',
-        onClick: () => router.push(`/challenge/${id}/edit`),
-        variant: 'secondary' as const,
-      };
-      // 호스트도 참여자이므로 진행 중에는 일지 작성을 우선 CTA 로 노출하고
-      // 챌린지 수정은 보조 버튼으로 함께 제공한다.
-      if (isChallengeCurrentlyOngoing) {
-        return {
-          label: '일지 작성하기',
-          onClick: handleDiaryCreateClick,
-          disabled: isCheckWriteDatesLoading,
-          variant: 'primary',
-          show: true,
-          secondary: editChallenge,
-        };
-      }
-      return {
-        ...editChallenge,
-        disabled: false,
-        show: true,
-      };
-    }
-    if (isParticipating) {
-      return {
-        label: isChallengeCurrentlyOngoing
-          ? '일지 작성하기'
-          : '진행 중이 아닙니다',
-        onClick: handleDiaryCreateClick,
-        disabled: !isChallengeCurrentlyOngoing || isCheckWriteDatesLoading,
-        variant: 'primary',
-        show: true,
-      };
-    }
-    if (isPending) {
-      return disabledCta('참여 승인 대기중');
-    }
-    if (canJoinByStatus && isChallengeAlreadyEnded) {
-      return disabledCta('종료된 챌린지');
-    }
-    if (canJoinByStatus && isMidJoinBlocked) {
-      return disabledCta(
-        '중도 참여 불가',
-        '이미 시작된 챌린지는 중도 참여가 불가능합니다'
-      );
-    }
-    if (canJoin) {
-      return {
-        label: '챌린지 참여하기',
-        onClick: handleJoinChallenge,
-        disabled: joinChallenge.isPending,
-        variant: 'primary',
-        show: true,
-      };
-    }
-    return {
-      label: '참여 불가',
-      onClick: () => undefined,
-      disabled: true,
-      variant: 'secondary',
-      show: false,
-    };
-  })();
-
-  const freeGoalModal = (
-    <GoalAddListModal
-      open={showFreeGoalModal}
-      onOpenChange={setShowFreeGoalModal}
-      title="내 목표 입력"
-      description="챌린지에서 달성할 목표를 입력하고 Enter 를 눌러 추가해 주세요. (최대 5개)"
-      goals={freeGoalInputs}
-      onGoalsChange={setFreeGoalInputs}
-      submitLabel={joinChallenge.isPending ? '처리 중...' : '참여 신청'}
-      submitDisabled={joinChallenge.isPending}
-      submitMinWidthClass="min-w-[112px]"
-      onSubmit={handleFreeGoalSubmit}
-    />
-  );
-
-  const editGoalModal = (
-    <GoalAddListModal
-      open={showEditGoalModal}
-      onOpenChange={setShowEditGoalModal}
-      title="내 목표 수정"
-      description="새 목표를 입력하고 Enter 를 눌러 추가해 주세요. (최대 5개)"
-      goals={editGoalInputs}
-      onGoalsChange={setEditGoalInputs}
-      submitLabel={updateParticipantGoal.isPending ? '저장 중...' : '저장'}
-      submitDisabled={updateParticipantGoal.isPending}
-      submitMinWidthClass="min-w-[96px]"
-      onSubmit={handleEditGoalSubmit}
-    />
-  );
-
-  const editChallengeGoalsModal = (
-    <Dialog
-      open={showEditChallengeGoalsModal}
-      onOpenChange={setShowEditChallengeGoalsModal}
-    >
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[460px]">
-        <DialogHeader className="flex-col items-start gap-1.5 pb-2">
-          <DialogTitle className="text-[17px] font-extrabold tracking-[-0.3px] text-gray-900">
-            챌린지 목표 수정
-          </DialogTitle>
-          <DialogDescription className="text-[13px] leading-relaxed text-gray-500">
-            챌린지 시작 전에만 목표를 수정할 수 있습니다.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogBody className="flex flex-col gap-3">
-          <div className="flex flex-col gap-2">
-            {challengeGoalInputs.map((goal) => (
-              <div key={goal.id} className="flex items-center gap-2">
-                <TextField
-                  value={goal.value}
-                  onChange={(event) => {
-                    setChallengeGoalInputs((prev) =>
-                      prev.map((entry) =>
-                        entry.id === goal.id
-                          ? { ...entry, value: event.target.value }
-                          : entry
-                      )
-                    );
-                  }}
-                  placeholder="목표를 입력하세요"
-                  className="flex-1"
-                  maxLength={100}
-                />
-                <button
-                  type="button"
-                  aria-label="목표 삭제"
-                  className={cn(
-                    'flex h-10 w-10 shrink-0 cursor-pointer',
-                    'items-center justify-center rounded-lg text-gray-500',
-                    'transition-colors hover:bg-gray-100 hover:text-red-600'
-                  )}
-                  onClick={() => {
-                    setChallengeGoalInputs((prev) =>
-                      prev.filter((entry) => entry.id !== goal.id)
-                    );
-                  }}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
-            ))}
-          </div>
-          <Button
-            variant="secondary"
-            size="sm"
-            type="button"
-            disabled={challengeGoalInputs.length >= 10}
-            onClick={() =>
-              setChallengeGoalInputs((prev) => [...prev, createGoalEntry()])
-            }
-          >
-            + 목표 추가
-          </Button>
-        </DialogBody>
-        <DialogFooter>
-          <Button
-            size="md"
-            variant="secondary"
-            className="min-w-[80px]"
-            onClick={() => setShowEditChallengeGoalsModal(false)}
-          >
-            취소
-          </Button>
-          <Button
-            size="md"
-            className="min-w-[96px]"
-            disabled={updateChallenge.isPending}
-            onClick={handleEditChallengeGoalsSubmit}
-          >
-            {updateChallenge.isPending ? '저장 중...' : '저장'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
 
   return (
     <>
-      {/* 모바일 sliver-style sticky 헤더 — 스크롤 시 페이드인.
-          data-fade-in 래퍼 밖에 둔다: 래퍼의 transform 이 containing block 을
-          만들어 position: fixed 가 뷰포트 대신 래퍼 기준이 되는 문제를 피한다.
-          네이티브 쉘에선 AppBackBar 가 같은 역할을 하므로 data-native-hide
-          로 가린다. globals.css 의 sticky 일괄 룰은 fixed 는 안 잡는다. */}
-      <div
-        data-native-hide
-        className={cn(
-          'fixed top-0 right-0 left-0 z-30 flex h-14 items-center',
-          'gap-3 border-b border-gray-100 bg-white/95 px-4',
-          'backdrop-blur transition-all duration-200 lg:hidden',
-          isCompactHeaderVisible
-            ? 'translate-y-0 opacity-100'
-            : 'pointer-events-none -translate-y-full opacity-0'
-        )}
-      >
-        <button
-          type="button"
-          aria-label="뒤로가기"
-          onClick={handleBack}
-          className={cn(
-            'flex h-8 w-8 shrink-0 items-center justify-center',
-            'rounded-lg text-gray-700 transition-colors hover:bg-gray-100'
-          )}
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <Text
-          size="body1"
-          weight="extrabold"
-          className={cn(
-            'line-clamp-1 min-w-0 flex-1 tracking-[-0.3px] text-gray-900'
-          )}
-        >
-          {summary.title}
-        </Text>
-      </div>
+      <ChallengeDetailCompactHeader
+        visible={isCompactHeaderVisible}
+        title={summary.title}
+        onBack={handleBack}
+      />
 
       <div
         className={cn(
@@ -886,9 +452,7 @@ export function ChallengeDetailScreen({
           ctaConfig.show ? 'pb-mobile-action-bar lg:pb-12' : 'pb-12'
         )}
       >
-        {freeGoalModal}
-        {editGoalModal}
-        {editChallengeGoalsModal}
+        <ChallengeGoalModals editors={goalEditors} />
         <AlertDialog
           open={showCreateUnavailableDialog}
           onOpenChange={setShowCreateUnavailableDialog}
@@ -1121,12 +685,12 @@ export function ChallengeDetailScreen({
                 }
                 onEdit={
                   isHost && !isChallengeStarted && !isFreeChallenge
-                    ? handleOpenEditChallengeGoalsModal
+                    ? goalEditors.openEditChallengeGoalsModal
                     : !isHost &&
                         isFreeChallenge &&
                         isParticipating &&
                         !isChallengeStarted
-                      ? handleOpenEditGoalModal
+                      ? goalEditors.openEditGoalModal
                       : undefined
                 }
               />
@@ -1221,9 +785,7 @@ export function ChallengeDetailScreen({
                   completedGoalCount: participant.completedGoalCount,
                 }))}
                 totalCount={summaryParticipantCnt}
-                onShowAll={() =>
-                  router.push(`/challenge/${id}/participants`)
-                }
+                onShowAll={() => router.push(`/challenge/${id}/participants`)}
                 onMemberClick={(memberId) => router.push(`/member/${memberId}`)}
                 canPoke={canPokeMembers}
                 currentMemberId={currentMemberId}

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -157,7 +157,7 @@ export function ChallengeDetailScreen({
   // 대기 승인 카드는 status=PENDING 목록을 호스트일 때만 별도 조회한다.
   const { data: pendingParticipants = EMPTY_PARTICIPANTS } =
     useChallengePendingParticipants(challengeId, isHost);
-  const isPending = myStatus === 'PENDING';
+  const isJoinRequestPending = myStatus === 'PENDING';
   const isParticipating = PARTICIPATING_STATUS.includes(myStatus);
   const canJoinByStatus = myStatus === 'NONE' || myStatus === 'REJECTED';
   const isFreeChallenge = summary?.goalType === 'FLEXIBLE';
@@ -424,7 +424,7 @@ export function ChallengeDetailScreen({
   const ctaConfig = buildChallengeCta({
     isHost,
     isParticipating,
-    isPending,
+    isJoinRequestPending,
     isChallengeCurrentlyOngoing,
     isCheckWriteDatesLoading,
     canJoinByStatus,

--- a/src/app.feature/challenge/detail/utils/challengeCta.test.ts
+++ b/src/app.feature/challenge/detail/utils/challengeCta.test.ts
@@ -8,7 +8,7 @@ function makeParams(
   return {
     isHost: false,
     isParticipating: false,
-    isPending: false,
+    isJoinRequestPending: false,
     isChallengeCurrentlyOngoing: false,
     isCheckWriteDatesLoading: false,
     canJoinByStatus: false,
@@ -63,7 +63,7 @@ describe('buildChallengeCta', () => {
   });
 
   it('승인 대기: 비활성 안내', () => {
-    const cta = buildChallengeCta(makeParams({ isPending: true }));
+    const cta = buildChallengeCta(makeParams({ isJoinRequestPending: true }));
     expect(cta.label).toBe('참여 승인 대기중');
     expect(cta.disabled).toBe(true);
     expect(cta.show).toBe(true);

--- a/src/app.feature/challenge/detail/utils/challengeCta.test.ts
+++ b/src/app.feature/challenge/detail/utils/challengeCta.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildChallengeCta, BuildChallengeCtaParams } from './challengeCta';
+
+function makeParams(
+  overrides: Partial<BuildChallengeCtaParams> = {}
+): BuildChallengeCtaParams {
+  return {
+    isHost: false,
+    isParticipating: false,
+    isPending: false,
+    isChallengeCurrentlyOngoing: false,
+    isCheckWriteDatesLoading: false,
+    canJoinByStatus: false,
+    isChallengeAlreadyEnded: false,
+    isMidJoinBlocked: false,
+    canJoin: false,
+    isJoinPending: false,
+    onEditChallenge: vi.fn(),
+    onDiaryCreate: vi.fn(),
+    onJoin: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('buildChallengeCta', () => {
+  it('호스트 + 진행 중: 일지 작성 primary + 수정 secondary', () => {
+    const cta = buildChallengeCta(
+      makeParams({ isHost: true, isChallengeCurrentlyOngoing: true })
+    );
+    expect(cta.label).toBe('일지 작성하기');
+    expect(cta.variant).toBe('primary');
+    expect(cta.secondary?.label).toBe('챌린지 수정');
+  });
+
+  it('호스트 + 종료: 챌린지 수정 단독 노출', () => {
+    const cta = buildChallengeCta(
+      makeParams({ isHost: true, isChallengeCurrentlyOngoing: false })
+    );
+    expect(cta.label).toBe('챌린지 수정');
+    expect(cta.disabled).toBe(false);
+    expect(cta.secondary).toBeUndefined();
+  });
+
+  it('참여 중 + 진행 아님: 비활성 "진행 중이 아닙니다"', () => {
+    const cta = buildChallengeCta(
+      makeParams({ isParticipating: true, isChallengeCurrentlyOngoing: false })
+    );
+    expect(cta.label).toBe('진행 중이 아닙니다');
+    expect(cta.disabled).toBe(true);
+  });
+
+  it('참여 중 + 진행 중 + 날짜 로딩: 일지 작성 비활성', () => {
+    const cta = buildChallengeCta(
+      makeParams({
+        isParticipating: true,
+        isChallengeCurrentlyOngoing: true,
+        isCheckWriteDatesLoading: true,
+      })
+    );
+    expect(cta.label).toBe('일지 작성하기');
+    expect(cta.disabled).toBe(true);
+  });
+
+  it('승인 대기: 비활성 안내', () => {
+    const cta = buildChallengeCta(makeParams({ isPending: true }));
+    expect(cta.label).toBe('참여 승인 대기중');
+    expect(cta.disabled).toBe(true);
+    expect(cta.show).toBe(true);
+  });
+
+  it('신청 가능 + 종료된 챌린지: "종료된 챌린지"', () => {
+    const cta = buildChallengeCta(
+      makeParams({ canJoinByStatus: true, isChallengeAlreadyEnded: true })
+    );
+    expect(cta.label).toBe('종료된 챌린지');
+  });
+
+  it('신청 가능 + 중도 참여 차단: hint 포함', () => {
+    const cta = buildChallengeCta(
+      makeParams({ canJoinByStatus: true, isMidJoinBlocked: true })
+    );
+    expect(cta.label).toBe('중도 참여 불가');
+    expect(cta.hint).toContain('중도 참여');
+  });
+
+  it('참여 가능: 참여하기 CTA + join pending 반영', () => {
+    const cta = buildChallengeCta(
+      makeParams({ canJoin: true, isJoinPending: true })
+    );
+    expect(cta.label).toBe('챌린지 참여하기');
+    expect(cta.disabled).toBe(true);
+    cta.onClick();
+  });
+
+  it('그 외: 참여 불가 + show=false', () => {
+    const cta = buildChallengeCta(makeParams());
+    expect(cta.label).toBe('참여 불가');
+    expect(cta.show).toBe(false);
+  });
+});

--- a/src/app.feature/challenge/detail/utils/challengeCta.ts
+++ b/src/app.feature/challenge/detail/utils/challengeCta.ts
@@ -18,7 +18,9 @@ export interface ChallengeCtaConfig {
 export interface BuildChallengeCtaParams {
   isHost: boolean;
   isParticipating: boolean;
-  isPending: boolean;
+  // 참여 신청 후 호스트 승인 대기 상태 (myStatus === 'PENDING').
+  // 뮤테이션의 isPending 과 혼동되지 않도록 명시적으로 명명한다.
+  isJoinRequestPending: boolean;
   isChallengeCurrentlyOngoing: boolean;
   isCheckWriteDatesLoading: boolean;
   canJoinByStatus: boolean;
@@ -56,7 +58,7 @@ export function buildChallengeCta(
   const {
     isHost,
     isParticipating,
-    isPending,
+    isJoinRequestPending,
     isChallengeCurrentlyOngoing,
     isCheckWriteDatesLoading,
     canJoinByStatus,
@@ -104,7 +106,7 @@ export function buildChallengeCta(
       show: true,
     };
   }
-  if (isPending) {
+  if (isJoinRequestPending) {
     return disabledCta('참여 승인 대기중');
   }
   if (canJoinByStatus && isChallengeAlreadyEnded) {

--- a/src/app.feature/challenge/detail/utils/challengeCta.ts
+++ b/src/app.feature/challenge/detail/utils/challengeCta.ts
@@ -1,0 +1,135 @@
+export type ChallengeCtaVariant = 'primary' | 'secondary';
+
+// CTA 결정 결과: 호스트 / 참여 중 / 대기 / 신청 가능 / 신청 불가
+export interface ChallengeCtaConfig {
+  label: string;
+  onClick(): void;
+  disabled: boolean;
+  variant: ChallengeCtaVariant;
+  show: boolean;
+  hint?: string;
+  secondary?: {
+    label: string;
+    onClick(): void;
+    variant: ChallengeCtaVariant;
+  };
+}
+
+export interface BuildChallengeCtaParams {
+  isHost: boolean;
+  isParticipating: boolean;
+  isPending: boolean;
+  isChallengeCurrentlyOngoing: boolean;
+  isCheckWriteDatesLoading: boolean;
+  canJoinByStatus: boolean;
+  isChallengeAlreadyEnded: boolean;
+  isMidJoinBlocked: boolean;
+  canJoin: boolean;
+  isJoinPending: boolean;
+  /** 호스트 챌린지 수정 이동 */
+  onEditChallenge(): void;
+  /** 일지 작성 플로우 진입 */
+  onDiaryCreate(): void;
+  /** 참여 신청 플로우 진입 */
+  onJoin(): void;
+}
+
+// 클릭 불가 안내 버튼(대기/종료/중도참여불가)의 공통 형태.
+function disabledCta(label: string, hint?: string): ChallengeCtaConfig {
+  return {
+    label,
+    onClick: () => undefined,
+    disabled: true,
+    variant: 'secondary',
+    show: true,
+    hint,
+  };
+}
+
+/**
+ * 챌린지 상세 CTA 버튼 구성 결정. ChallengeDetailScreen 의 인라인 IIFE 를
+ * 순수 함수로 추출 — 상태 플래그와 핸들러만 입력받아 표시 스펙을 반환한다.
+ */
+export function buildChallengeCta(
+  params: BuildChallengeCtaParams
+): ChallengeCtaConfig {
+  const {
+    isHost,
+    isParticipating,
+    isPending,
+    isChallengeCurrentlyOngoing,
+    isCheckWriteDatesLoading,
+    canJoinByStatus,
+    isChallengeAlreadyEnded,
+    isMidJoinBlocked,
+    canJoin,
+    isJoinPending,
+    onEditChallenge,
+    onDiaryCreate,
+    onJoin,
+  } = params;
+
+  if (isHost) {
+    const editChallenge = {
+      label: '챌린지 수정',
+      onClick: onEditChallenge,
+      variant: 'secondary' as const,
+    };
+    // 호스트도 참여자이므로 진행 중에는 일지 작성을 우선 CTA 로 노출하고
+    // 챌린지 수정은 보조 버튼으로 함께 제공한다.
+    if (isChallengeCurrentlyOngoing) {
+      return {
+        label: '일지 작성하기',
+        onClick: onDiaryCreate,
+        disabled: isCheckWriteDatesLoading,
+        variant: 'primary',
+        show: true,
+        secondary: editChallenge,
+      };
+    }
+    return {
+      ...editChallenge,
+      disabled: false,
+      show: true,
+    };
+  }
+  if (isParticipating) {
+    return {
+      label: isChallengeCurrentlyOngoing
+        ? '일지 작성하기'
+        : '진행 중이 아닙니다',
+      onClick: onDiaryCreate,
+      disabled: !isChallengeCurrentlyOngoing || isCheckWriteDatesLoading,
+      variant: 'primary',
+      show: true,
+    };
+  }
+  if (isPending) {
+    return disabledCta('참여 승인 대기중');
+  }
+  if (canJoinByStatus && isChallengeAlreadyEnded) {
+    return disabledCta('종료된 챌린지');
+  }
+  if (canJoinByStatus && isMidJoinBlocked) {
+    return disabledCta(
+      '중도 참여 불가',
+      '이미 시작된 챌린지는 중도 참여가 불가능합니다'
+    );
+  }
+  if (canJoin) {
+    return {
+      label: '챌린지 참여하기',
+      onClick: onJoin,
+      disabled: isJoinPending,
+      variant: 'primary',
+      show: true,
+    };
+  }
+  return {
+    label: '참여 불가',
+    onClick: () => undefined,
+    disabled: true,
+    variant: 'secondary',
+    show: false,
+  };
+}


### PR DESCRIPTION
## 개요
로드맵 5 — 1293줄 God 컴포넌트 `ChallengeDetailScreen`을 **동작 보존**하며 855줄로 축소. 상태·핸들러·표시 로직을 목적별 훅/컴포넌트/순수함수로 분리하고 화면은 조립 위주로 남겼다.

## 변경 내용
- **usePokeMembers** — 콕 찌르기 상태/핸들러 분리
- **useChallengeGoalEditors** — 목표 입력/수정 3종(자유 목표 참여·내 목표·챌린지 목표) 상태·핸들러 통합. 공유 mutation(`joinChallenge`)은 주입받아 중복 인스턴스를 만들지 않음
- **ChallengeGoalModals** — 위 3종 모달 렌더 컴포넌트 (`GoalAddListModal` 포함)
- **buildChallengeCta** — CTA 결정 IIFE를 순수 함수로 추출 + 특성화 테스트 9개
- **ChallengeDetailCompactHeader** — 스크롤 페이드인 fixed 헤더 컴포넌트

## 감축
`ChallengeDetailScreen`: 1293 → 855줄 (-438).

## 검증
- `vitest run` (87 passed, buildChallengeCta 테스트 9개 추가)
- `tsc --noEmit` / `pnpm lint` / `pnpm knip` / `pnpm build` 통과

## 판단/후속
- **뷰모델 훅**은 이번에 뽑지 않음: 파생 플래그(~85줄)가 렌더/잔여 핸들러와 강하게 얽혀 있어 런타임 테스트 없이 통째 이동하면 회귀 위험 대비 이득이 작다고 판단. 별도 후속으로 남김.
- **no-stacking 제약**: PR A의 `MobileStickyHeader`는 `origin/develop`에 아직 없어 재사용 불가. 게다가 이 헤더는 `fixed`+스크롤 페이드인이라 동작이 달라 별도 컴포넌트로 유지.