### PR TITLE
refactor: 챌린지 미리보기 카드 공통 프레젠테이션 뷰 추출

### DIFF
--- a/src/app.feature/challenge/write/components/ChallengeCreatePreviewCard.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeCreatePreviewCard.tsx
@@ -1,22 +1,10 @@
-import { Icon, Stripe, Tag, Text } from '@1d1s/design-system';
-import { CATEGORY_OPTIONS } from '@constants/categories';
-import { cn } from '@module/utils/cn';
 import { formatDateKR } from '@module/utils/date';
 import { add } from 'date-fns';
-import Image from 'next/image';
+import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { ChallengeCreateFormValues } from '../hooks/useChallengeCreateForm';
-
-const CATEGORY_TONE: Record<string, string> = {
-  DEV: 'blue',
-  EXERCISE: 'peach',
-  BOOK: 'mint',
-  MUSIC: 'rose',
-  STUDY: 'cream',
-  LEISURE: 'sky',
-  ECONOMY: 'gray',
-};
+import { ChallengePreviewCardView } from './ChallengePreviewCardView';
 
 function resolveDays(values: ChallengeCreateFormValues): number {
   if (values.periodType !== 'LIMITED') {
@@ -64,139 +52,21 @@ export function ChallengeCreatePreviewCard(): React.ReactElement {
   const { watch } = useFormContext<ChallengeCreateFormValues>();
   const values = watch();
 
-  const category = CATEGORY_OPTIONS.find(
-    (option) => option.value === values.category
-  );
-  const tone = values.category ? CATEGORY_TONE[values.category] : 'cream';
   const filledGoals = (values.goals ?? [])
     .map((goal) => goal.value)
     .filter(Boolean);
-  const isFlexible = values.goalType === 'FLEXIBLE';
 
   return (
-    <div
-      className={cn(
-        'rounded-3 overflow-hidden border border-gray-200 bg-white'
-      )}
-    >
-      <div className="relative aspect-[21/9] w-full">
-        {values.thumbnailPreviewUrl ? (
-          <Image
-            src={values.thumbnailPreviewUrl}
-            alt="챌린지 대표 사진 미리보기"
-            fill
-            className="object-cover"
-          />
-        ) : (
-          <Stripe tone={tone} label={category?.label ?? '카테고리'} />
-        )}
-        <div
-          className={cn(
-            'text-main-800 absolute top-2.5 right-2.5 rounded-full',
-            'bg-white px-2.5 py-0.5 text-[10px] font-bold'
-          )}
-        >
-          {values.participationType === 'INDIVIDUAL' ? '개인' : '단체'}
-        </div>
-      </div>
-
-      <div className="p-4">
-        {category ? (
-          <Tag
-            tone="brand"
-            size="sm"
-            icon={<Icon name={category.iconName} className="h-3 w-3" />}
-          >
-            {category.label}
-          </Tag>
-        ) : null}
-
-        <Text
-          size="heading2"
-          weight="bold"
-          className="mt-2.5 mb-1.5 block min-h-[22px] -tracking-[0.3px] text-gray-900"
-        >
-          {values.title || <span className="text-gray-400">챌린지 제목</span>}
-        </Text>
-
-        <Text
-          size="caption1"
-          weight="regular"
-          className="block min-h-9 leading-relaxed text-gray-600"
-        >
-          {values.description || (
-            <span className="text-gray-400">한 줄 설명이 여기 표시돼요</span>
-          )}
-        </Text>
-
-        <div
-          className={cn(
-            'mt-3 grid grid-cols-2 gap-2.5 border-t border-dashed',
-            'border-gray-200 pt-3 text-[11px]'
-          )}
-        >
-          <div>
-            <div className="mb-0.5 text-gray-500">인원</div>
-            <div className="font-bold text-gray-900">
-              {resolveMemberLabel(values)}
-            </div>
-          </div>
-          <div>
-            <div className="mb-0.5 text-gray-500">목표 유형</div>
-            <div className="font-bold text-gray-900">
-              {isFlexible ? '자유 목표' : '고정 목표'}
-            </div>
-          </div>
-          <div className="col-span-2">
-            <div className="mb-0.5 text-gray-500">기간</div>
-            <div className="font-bold text-gray-900">
-              {resolveDurationLabel(values)}
-            </div>
-          </div>
-        </div>
-
-        <div
-          className={cn(
-            'border-main-200 bg-main-100 rounded-2 mt-3 border px-3 py-2.5'
-          )}
-        >
-          <Text
-            size="caption2"
-            weight="bold"
-            className="text-main-800 block tracking-[0.3px]"
-          >
-            목표
-          </Text>
-          {isFlexible ? (
-            <Text
-              size="body2"
-              weight="bold"
-              className="mt-1 block text-gray-900"
-            >
-              참여자가 자신만의 목표를 설정해요
-            </Text>
-          ) : filledGoals.length > 0 ? (
-            <ul className="mt-1 space-y-0.5">
-              {filledGoals.map((goal, index) => (
-                <li
-                  key={`${index}-${goal}`}
-                  className="text-[12px] font-bold text-gray-900"
-                >
-                  · {goal}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <Text
-              size="body2"
-              weight="regular"
-              className="mt-1 block text-gray-400"
-            >
-              공통 목표를 설정해 주세요
-            </Text>
-          )}
-        </div>
-      </div>
-    </div>
+    <ChallengePreviewCardView
+      categoryValue={values.category}
+      thumbnailPreviewUrl={values.thumbnailPreviewUrl}
+      title={values.title}
+      description={values.description}
+      isGroup={values.participationType === 'GROUP'}
+      memberLabel={resolveMemberLabel(values)}
+      durationLabel={resolveDurationLabel(values)}
+      isFlexible={values.goalType === 'FLEXIBLE'}
+      filledGoals={filledGoals}
+    />
   );
 }

--- a/src/app.feature/challenge/write/components/ChallengeEditPreviewCard.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeEditPreviewCard.tsx
@@ -1,22 +1,10 @@
-import { Icon, Stripe, Tag, Text } from '@1d1s/design-system';
-import { CATEGORY_OPTIONS } from '@constants/categories';
-import { cn } from '@module/utils/cn';
 import { formatDateKR } from '@module/utils/date';
-import Image from 'next/image';
+import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { isInfiniteChallengeEndDate } from '../../board/utils/challengePeriod';
 import { ChallengeEditFormValues } from '../hooks/useChallengeEditForm';
-
-const CATEGORY_TONE: Record<string, string> = {
-  DEV: 'blue',
-  EXERCISE: 'peach',
-  BOOK: 'mint',
-  MUSIC: 'rose',
-  STUDY: 'cream',
-  LEISURE: 'sky',
-  ECONOMY: 'gray',
-};
+import { ChallengePreviewCardView } from './ChallengePreviewCardView';
 
 interface ChallengeEditPreviewCardProps {
   startDate: string;
@@ -61,142 +49,21 @@ export function ChallengeEditPreviewCard({
   const { watch } = useFormContext<ChallengeEditFormValues>();
   const values = watch();
 
-  const category = CATEGORY_OPTIONS.find(
-    (option) => option.value === values.category
-  );
-  const tone = values.category ? CATEGORY_TONE[values.category] : 'cream';
   const filledGoals = (values.goals ?? [])
     .map((goal) => goal.value)
     .filter(Boolean);
-  const isFlexible = !values.isFixedGoal;
 
   return (
-    <div
-      className={cn(
-        'rounded-3 overflow-hidden border border-gray-200 bg-white'
-      )}
-    >
-      <div className="relative aspect-[21/9] w-full">
-        {values.thumbnailPreviewUrl ? (
-          <Image
-            src={values.thumbnailPreviewUrl}
-            alt="챌린지 대표 사진 미리보기"
-            fill
-            className="object-cover"
-          />
-        ) : (
-          <Stripe tone={tone} label={category?.label ?? '카테고리'} />
-        )}
-        <div
-          className={cn(
-            'text-main-800 absolute top-2.5 right-2.5 rounded-full',
-            'bg-white px-2.5 py-0.5 text-[10px] font-bold'
-          )}
-        >
-          {values.isGroup ? '단체' : '개인'}
-        </div>
-      </div>
-
-      <div className="p-4">
-        {category ? (
-          <Tag
-            tone="brand"
-            size="sm"
-            icon={<Icon name={category.iconName} className="h-3 w-3" />}
-          >
-            {category.label}
-          </Tag>
-        ) : null}
-
-        <Text
-          size="heading2"
-          weight="bold"
-          className={cn(
-            'mt-2.5 mb-1.5 block min-h-[22px]',
-            '-tracking-[0.3px] text-gray-900'
-          )}
-        >
-          {values.title || <span className="text-gray-400">챌린지 제목</span>}
-        </Text>
-
-        <Text
-          size="caption1"
-          weight="regular"
-          className="block min-h-9 leading-relaxed text-gray-600"
-        >
-          {values.description || (
-            <span className="text-gray-400">한 줄 설명이 여기 표시돼요</span>
-          )}
-        </Text>
-
-        <div
-          className={cn(
-            'mt-3 grid grid-cols-2 gap-2.5 border-t border-dashed',
-            'border-gray-200 pt-3 text-[11px]'
-          )}
-        >
-          <div>
-            <div className="mb-0.5 text-gray-500">인원</div>
-            <div className="font-bold text-gray-900">
-              {resolveMemberLabel(values)}
-            </div>
-          </div>
-          <div>
-            <div className="mb-0.5 text-gray-500">목표 유형</div>
-            <div className="font-bold text-gray-900">
-              {isFlexible ? '자유 목표' : '고정 목표'}
-            </div>
-          </div>
-          <div className="col-span-2">
-            <div className="mb-0.5 text-gray-500">기간</div>
-            <div className="font-bold text-gray-900">
-              {resolveDurationLabel(startDate, endDate)}
-            </div>
-          </div>
-        </div>
-
-        <div
-          className={cn(
-            'border-main-200 bg-main-100 rounded-2 mt-3 border px-3 py-2.5'
-          )}
-        >
-          <Text
-            size="caption2"
-            weight="bold"
-            className="text-main-800 block tracking-[0.3px]"
-          >
-            목표
-          </Text>
-          {isFlexible ? (
-            <Text
-              size="body2"
-              weight="bold"
-              className="mt-1 block text-gray-900"
-            >
-              참여자가 자신만의 목표를 설정해요
-            </Text>
-          ) : filledGoals.length > 0 ? (
-            <ul className="mt-1 space-y-0.5">
-              {filledGoals.map((goal, index) => (
-                <li
-                  key={`${index}-${goal}`}
-                  className="text-[12px] font-bold text-gray-900"
-                >
-                  · {goal}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <Text
-              size="body2"
-              weight="regular"
-              className="mt-1 block text-gray-400"
-            >
-              공통 목표를 설정해 주세요
-            </Text>
-          )}
-        </div>
-      </div>
-    </div>
+    <ChallengePreviewCardView
+      categoryValue={values.category}
+      thumbnailPreviewUrl={values.thumbnailPreviewUrl}
+      title={values.title}
+      description={values.description}
+      isGroup={values.isGroup}
+      memberLabel={resolveMemberLabel(values)}
+      durationLabel={resolveDurationLabel(startDate, endDate)}
+      isFlexible={!values.isFixedGoal}
+      filledGoals={filledGoals}
+    />
   );
 }

--- a/src/app.feature/challenge/write/components/ChallengePreviewCardView.tsx
+++ b/src/app.feature/challenge/write/components/ChallengePreviewCardView.tsx
@@ -1,0 +1,179 @@
+import { Icon, Stripe, Tag, Text } from '@1d1s/design-system';
+import { CATEGORY_OPTIONS } from '@constants/categories';
+import { cn } from '@module/utils/cn';
+import Image from 'next/image';
+import React from 'react';
+
+const CATEGORY_TONE: Record<string, string> = {
+  DEV: 'blue',
+  EXERCISE: 'peach',
+  BOOK: 'mint',
+  MUSIC: 'rose',
+  STUDY: 'cream',
+  LEISURE: 'sky',
+  ECONOMY: 'gray',
+};
+
+export interface ChallengePreviewCardViewProps {
+  /** values.category (미선택 시 undefined) */
+  categoryValue?: string;
+  thumbnailPreviewUrl?: string;
+  title?: string;
+  description?: string;
+  /** 단체 챌린지 여부 — 배지 '개인'/'단체' 표기 */
+  isGroup: boolean;
+  memberLabel: string;
+  durationLabel: string;
+  isFlexible: boolean;
+  filledGoals: string[];
+}
+
+/**
+ * 챌린지 생성/수정 미리보기 카드의 공통 프레젠테이션 뷰.
+ *
+ * Create/Edit 폼은 값 모델이 서로 달라(enum vs boolean/기간) 폼 자체는
+ * 통합하지 않되, 미리보기 카드의 "표시(chrome)"는 동일하므로 각 폼이
+ * 원시값으로 변환해 이 뷰에 주입한다. 출력은 기존과 완전히 동일하다.
+ */
+export function ChallengePreviewCardView({
+  categoryValue,
+  thumbnailPreviewUrl,
+  title,
+  description,
+  isGroup,
+  memberLabel,
+  durationLabel,
+  isFlexible,
+  filledGoals,
+}: ChallengePreviewCardViewProps): React.ReactElement {
+  const category = CATEGORY_OPTIONS.find(
+    (option) => option.value === categoryValue
+  );
+  const tone = categoryValue ? CATEGORY_TONE[categoryValue] : 'cream';
+
+  return (
+    <div
+      className={cn(
+        'rounded-3 overflow-hidden border border-gray-200 bg-white'
+      )}
+    >
+      <div className="relative aspect-[21/9] w-full">
+        {thumbnailPreviewUrl ? (
+          <Image
+            src={thumbnailPreviewUrl}
+            alt="챌린지 대표 사진 미리보기"
+            fill
+            className="object-cover"
+          />
+        ) : (
+          <Stripe tone={tone} label={category?.label ?? '카테고리'} />
+        )}
+        <div
+          className={cn(
+            'text-main-800 absolute top-2.5 right-2.5 rounded-full',
+            'bg-white px-2.5 py-0.5 text-[10px] font-bold'
+          )}
+        >
+          {isGroup ? '단체' : '개인'}
+        </div>
+      </div>
+
+      <div className="p-4">
+        {category ? (
+          <Tag
+            tone="brand"
+            size="sm"
+            icon={<Icon name={category.iconName} className="h-3 w-3" />}
+          >
+            {category.label}
+          </Tag>
+        ) : null}
+
+        <Text
+          size="heading2"
+          weight="bold"
+          className={cn(
+            'mt-2.5 mb-1.5 block min-h-[22px]',
+            '-tracking-[0.3px] text-gray-900'
+          )}
+        >
+          {title || <span className="text-gray-400">챌린지 제목</span>}
+        </Text>
+
+        <Text
+          size="caption1"
+          weight="regular"
+          className="block min-h-9 leading-relaxed text-gray-600"
+        >
+          {description || (
+            <span className="text-gray-400">한 줄 설명이 여기 표시돼요</span>
+          )}
+        </Text>
+
+        <div
+          className={cn(
+            'mt-3 grid grid-cols-2 gap-2.5 border-t border-dashed',
+            'border-gray-200 pt-3 text-[11px]'
+          )}
+        >
+          <div>
+            <div className="mb-0.5 text-gray-500">인원</div>
+            <div className="font-bold text-gray-900">{memberLabel}</div>
+          </div>
+          <div>
+            <div className="mb-0.5 text-gray-500">목표 유형</div>
+            <div className="font-bold text-gray-900">
+              {isFlexible ? '자유 목표' : '고정 목표'}
+            </div>
+          </div>
+          <div className="col-span-2">
+            <div className="mb-0.5 text-gray-500">기간</div>
+            <div className="font-bold text-gray-900">{durationLabel}</div>
+          </div>
+        </div>
+
+        <div
+          className={cn(
+            'border-main-200 bg-main-100 rounded-2 mt-3 border px-3 py-2.5'
+          )}
+        >
+          <Text
+            size="caption2"
+            weight="bold"
+            className="text-main-800 block tracking-[0.3px]"
+          >
+            목표
+          </Text>
+          {isFlexible ? (
+            <Text
+              size="body2"
+              weight="bold"
+              className="mt-1 block text-gray-900"
+            >
+              참여자가 자신만의 목표를 설정해요
+            </Text>
+          ) : filledGoals.length > 0 ? (
+            <ul className="mt-1 space-y-0.5">
+              {filledGoals.map((goal, index) => (
+                <li
+                  key={`${index}-${goal}`}
+                  className="text-[12px] font-bold text-gray-900"
+                >
+                  · {goal}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <Text
+              size="body2"
+              weight="regular"
+              className="mt-1 block text-gray-400"
+            >
+              공통 목표를 설정해 주세요
+            </Text>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요
로드맵 8 (⚠️ 리스크 높음) — 챌린지 Create/Edit 폼의 섹션 통합을 검토한 결과, **값 모델이 근본적으로 달라 `mode` prop 통합은 안전하지 않다**고 판단했다. 대신 값 모델과 무관하게 출력이 동일한 **미리보기 카드의 표시(chrome)** 만 공통 프레젠테이션 뷰로 안전하게 추출했다.

## 변경 내용 (안전한 부분만 통합)
- **ChallengePreviewCardView** 신설 — 미리보기 카드의 공통 JSX/스타일 + 카테고리·톤 계산
- `ChallengeCreatePreviewCard` / `ChallengeEditPreviewCard` 는 각 폼 값 → 원시값(라벨/불리언/목록) 변환만 하는 얇은 어댑터로 축소
- 출력·동작 완전 동일, 중복 JSX 약 130줄 제거 (각 202줄 → ~70줄)

## 통합하지 않은 이유 (폼 섹션 mode 통합 보류)
Create/Edit 폼은 스키마 자체가 다릅니다.
- **Create**: `periodType`·`participationType`·`goalType` enum + `period`/`periodNumber`
- **Edit**: `isGroup`·`isFixedGoal` boolean + **`isStarted` 게이트 기반 필드 잠금**(예: `canEditGoals = isFixedGoal && !isStarted`, "목표 유형은 변경할 수 없어요" 힌트, Participation/Period/Goal 비활성)

`mode` prop 로 섹션을 통합하려면 두 Zod 스키마를 먼저 병합하고 edit 전용 잠금 정책을 분기로 1:1 이관해야 하는데, 이는:
1. **잠금 정책 회귀 위험**이 크고 (런타임 테스트 부재),
2. 두 데이터 모델을 분기하는 mega-component 가 오히려 더 복잡해집니다(ponytail 관점에서도 손해).

공통 프리미티브인 `ChallengeCreateSectionCard` 는 **이미 Edit 섹션들이 재사용** 중이라 별도 통합이 불필요합니다.

권장 후속: 폼 스키마 통합을 별도 과제로 먼저 다룬 뒤에야 섹션 `mode` 통합이 안전해집니다. Banner/Goal/Participation/Period/Dialog/SuccessDialog 는 그 전까지 분리 유지.

## 검증
- `vitest run` (78 passed) / `tsc --noEmit` / `pnpm lint` / `pnpm knip` / `pnpm build` 통과