### PR TITLE
refactor: 응답 타입을 서버 확정 계약에 맞추고 방어적 WithAliases 캐스팅 제거

### DIFF
--- a/src/app.component/cards/DiaryCard.tsx
+++ b/src/app.component/cards/DiaryCard.tsx
@@ -139,7 +139,6 @@ function DiaryCard({
 
   const tone = EMOTION_TONE[emotion];
   const hasImage = isValidNextImageSrc(imageUrl);
-  const hasProfileImage = isValidNextImageSrc(profileImageUrl);
   const excerpt = toPlainExcerpt(content);
   const visibleGoals = (goals ?? []).slice(0, MAX_GOALS);
 
@@ -295,9 +294,9 @@ function DiaryCard({
             )}
             aria-hidden
           >
-            {hasProfileImage ? (
+            {isValidNextImageSrc(profileImageUrl) ? (
               <FadeInImage
-                src={profileImageUrl as string}
+                src={profileImageUrl}
                 alt=""
                 fill
                 sizes="20px"

--- a/src/app.feature/challenge/board/api/challengeBoardApi.ts
+++ b/src/app.feature/challenge/board/api/challengeBoardApi.ts
@@ -45,9 +45,11 @@ export const challengeBoardApi = {
   },
 
   // 챌린지 리스트 불러오기
+  // 서버 envelope({message, data})를 requestData 로 언랩해 diary 목록과 동일하게
+  // { items, pageInfo } 를 반환한다(호출부·훅이 .data 를 다시 벗기지 않도록).
   getChallengeList: async (
     params: ChallengeListParams = {}
-  ): Promise<{ data: ChallengeListResponse; message: string }> => {
+  ): Promise<ChallengeListResponse> => {
     // 미선택 필터는 키 자체를 생략해야 한다(빈 값이면 서버 enum 변환 400).
     // buildQueryString 이 undefined 생략 + 배열을 같은 키 반복(repeat,
     // status=ONGOING&status=UPCOMING)으로 직렬화한다.
@@ -60,13 +62,10 @@ export const challengeBoardApi = {
       status: params.status,
     });
 
-    return requestBody<{ data: ChallengeListResponse; message: string }>(
-      apiClient,
-      {
-        url: query ? `/challenges?${query}` : '/challenges',
-        method: 'GET',
-      }
-    );
+    return requestData<ChallengeListResponse>(apiClient, {
+      url: query ? `/challenges?${query}` : '/challenges',
+      method: 'GET',
+    });
   },
 
   // 특정 멤버가 진행 중인 챌린지 보기

--- a/src/app.feature/challenge/board/hooks/useChallengeQueries.ts
+++ b/src/app.feature/challenge/board/hooks/useChallengeQueries.ts
@@ -55,10 +55,7 @@ export function useRandomChallenges(
 // 챌린지 리스트 불러오기 (무한 스크롤)
 export function useChallengeList(
   params: ChallengeListParams = {}
-): UseInfiniteQueryResult<
-  InfiniteData<{ data: ChallengeListResponse; message: string }>,
-  Error
-> {
+): UseInfiniteQueryResult<InfiniteData<ChallengeListResponse>, Error> {
   return useInfiniteQuery({
     queryKey: CHALLENGE_QUERY_KEYS.list(params),
     queryFn: ({ pageParam }) =>
@@ -68,7 +65,7 @@ export function useChallengeList(
       }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => {
-      const pageInfo = lastPage?.data?.pageInfo;
+      const pageInfo = lastPage?.pageInfo;
       return pageInfo?.hasNextPage ? pageInfo.nextCursor : undefined;
     },
     ...FRESH_ON_RETURN,

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -219,7 +219,7 @@ export default function ChallengeBoardScreen(): React.ReactElement {
   });
 
   const challenges = useMemo(
-    () => data?.pages?.flatMap((page) => page?.data?.items ?? []) ?? [],
+    () => data?.pages?.flatMap((page) => page?.items ?? []) ?? [],
     [data]
   );
 

--- a/src/app.feature/challenge/shared/components/ChallengeListItem.tsx
+++ b/src/app.feature/challenge/shared/components/ChallengeListItem.tsx
@@ -60,7 +60,6 @@ export function ChallengeListItem({
   // 백엔드가 raw 키(예: challenge/xxx.jpg)를 주면 next/image 가 그리지 못해
   // 배경색만 보인다. DiaryCard/StoryRing 과 동일하게 풀 URL 로 변환한다.
   const resolvedImageUrl = resolveDiaryImageUrl(imageUrl) ?? undefined;
-  const hasImage = Boolean(resolvedImageUrl);
   const isIndividual = maxUserCount <= 1;
 
   const hasEnded = isInfiniteChallenge ? isEarlyEnded : isEnded;
@@ -101,9 +100,9 @@ export function ChallengeListItem({
             : 'aspect-video w-[126px] self-center sm:w-[154px]'
         )}
       >
-        {hasImage ? (
+        {resolvedImageUrl ? (
           <FadeInImage
-            src={resolvedImageUrl as string}
+            src={resolvedImageUrl}
             alt={challengeTitle}
             fill
             sizes={

--- a/src/app.feature/diary/board/type/diary.ts
+++ b/src/app.feature/diary/board/type/diary.ts
@@ -1,3 +1,4 @@
+import type { ChallengeSummary as ChallengeSummaryResponse } from '@feature/challenge/board/type/challenge';
 import type { LikeInfo } from '@module/api/types';
 
 export type { LikeInfo };
@@ -62,7 +63,22 @@ export interface DiaryItem {
   diaryInfo?: DiaryInfo | null;
 }
 
-export type DiaryDetail = DiaryItem;
+// 일지 상세 응답 (GET /diaries/{id} → DiaryResponse). 목록 아이템(DiaryItem)과
+// 달리 서버 원본 그대로 내려오므로 필드는 author/diaryInfo(Dto 접미사 없음),
+// challenge 는 ChallengeSummaryResponse(challengeId 키, enum 타입)다.
+export interface DiaryDetail {
+  id: number;
+  challenge: ChallengeSummaryResponse | null;
+  author: AuthorInfo | null;
+  title: string;
+  content: string;
+  imgUrl: string[] | null;
+  thumbnailUrl: string | null;
+  isPublic: boolean;
+  likeInfo: LikeInfo;
+  commentCount: number;
+  diaryInfo: DiaryInfo | null;
+}
 
 export interface CreateDiaryRequest {
   challengeId: number;

--- a/src/app.feature/diary/detail/utils/diaryViewData.test.ts
+++ b/src/app.feature/diary/detail/utils/diaryViewData.test.ts
@@ -54,10 +54,16 @@ describe('parsePositiveInteger', () => {
 });
 
 describe('resolveSidebarMemberId', () => {
-  it('reads the first positive id-like key in order', () => {
+  it('reads memberId first, then id', () => {
     expect(resolveSidebarMemberId({ memberId: 5 })).toBe(5);
-    expect(resolveSidebarMemberId({ member_id: '8' })).toBe(8);
-    expect(resolveSidebarMemberId({ userId: 2, id: 9 })).toBe(2);
+    expect(resolveSidebarMemberId({ id: 9 })).toBe(9);
+    expect(resolveSidebarMemberId({ memberId: 5, id: 9 })).toBe(5);
+  });
+
+  it('ignores disproven keys (member_id, userId, user_id)', () => {
+    expect(resolveSidebarMemberId({ member_id: 8 })).toBeNull();
+    expect(resolveSidebarMemberId({ userId: 2 })).toBeNull();
+    expect(resolveSidebarMemberId({ user_id: 3 })).toBeNull();
   });
 
   it('returns null for non-objects and empty ids', () => {
@@ -99,15 +105,20 @@ describe('sortCommentsByOldest', () => {
 
 describe('mapDiaryToViewData', () => {
   it('maps a diary with no linked challenge', () => {
+    // 서버 확정 계약: 상세 응답은 diaryInfo(Dto 접미사 없음)로 내려온다.
     const diary = {
       id: 42,
+      challenge: null,
+      author: null,
       title: '',
       content: '<p>오늘의 일지</p>',
-      achievementRate: 150,
+      imgUrl: null,
+      thumbnailUrl: null,
       likeInfo: { likedByMe: true, likeCnt: 7 },
-      diaryInfoDto: {
+      diaryInfo: {
         createdAt: '2026-07-10',
         feeling: 'HAPPY',
+        achievementRate: 150,
       },
     } as unknown as DiaryDetail;
 
@@ -125,5 +136,28 @@ describe('mapDiaryToViewData', () => {
     expect(view.connectedChallengeId).toBeNull();
     expect(view.connectedChallengeTitle).toBe('연동된 챌린지가 없습니다.');
     expect(view.contentImageUrls).toEqual([]);
+  });
+
+  it('reads author and challenge.challengeId from the confirmed shape', () => {
+    const diary = {
+      id: 7,
+      challenge: { challengeId: 99, title: '아침 러닝' },
+      author: { id: 3, nickname: '러너', profileImage: null },
+      title: '일지',
+      content: '<p>내용</p>',
+      imgUrl: ['https://cdn.example.com/a.jpg'],
+      thumbnailUrl: null,
+      likeInfo: { likedByMe: false, likeCnt: 0 },
+      diaryInfo: { feeling: 'NONE', achievementRate: 40 },
+    } as unknown as DiaryDetail;
+
+    const view = mapDiaryToViewData(diary);
+
+    expect(view.authorId).toBe(3);
+    expect(view.authorName).toBe('러너');
+    expect(view.connectedChallengeId).toBe(99);
+    expect(view.connectedChallengeTitle).toBe('아침 러닝');
+    expect(view.achievementPercent).toBe(40);
+    expect(view.contentImageUrls).toEqual(['https://cdn.example.com/a.jpg']);
   });
 });

--- a/src/app.feature/diary/detail/utils/diaryViewData.ts
+++ b/src/app.feature/diary/detail/utils/diaryViewData.ts
@@ -15,7 +15,7 @@ import type {
 import type {
   AuthorInfo,
   DiaryDetail,
-  DiaryGoalStatus,
+  DiaryInfo,
   Feeling,
 } from '../../board/type/diary';
 import {
@@ -27,31 +27,6 @@ import type { DiaryComment } from '../type/comment';
 export interface ChecklistItem {
   id: string;
   label: string;
-}
-
-export interface DiaryInfoWithAliases {
-  createdAt?: string;
-  challengedDate?: string;
-  feeling?: Feeling;
-  achievement?: number[] | null;
-  diaryGoal?: DiaryGoalStatus[] | null;
-  achievementRate?: number;
-}
-
-export type DiaryDetailWithAliases = DiaryDetail & {
-  diaryInfoDto?: DiaryInfoWithAliases | null;
-  diaryInfo?: DiaryInfoWithAliases | null;
-  authorInfoDto?: AuthorInfo | null;
-  author?: AuthorInfo | null;
-};
-
-interface DiaryImageFields {
-  imgUrl?: unknown;
-  img?: unknown;
-  imageUrl?: unknown;
-  thumbnailUrl?: unknown;
-  images?: unknown;
-  thumbnail?: unknown;
 }
 
 export const FEELING_LABEL_MAP: Record<Feeling, string> = {
@@ -154,14 +129,12 @@ function resolveImageList(...rawSources: unknown[]): string[] {
   return urls;
 }
 
-export function getDiaryInfo(diary: DiaryDetail): DiaryInfoWithAliases | null {
-  const diaryWithAliases = diary as DiaryDetailWithAliases;
-  return diaryWithAliases.diaryInfoDto ?? diaryWithAliases.diaryInfo ?? null;
+export function getDiaryInfo(diary: DiaryDetail): DiaryInfo | null {
+  return diary.diaryInfo;
 }
 
 export function getAuthorInfo(diary: DiaryDetail): AuthorInfo | null {
-  const diaryWithAliases = diary as DiaryDetailWithAliases;
-  return diaryWithAliases.authorInfoDto ?? diaryWithAliases.author ?? null;
+  return diary.author;
 }
 
 export function parsePositiveInteger(value: unknown): number | null {
@@ -184,8 +157,11 @@ export function resolveSidebarMemberId(sidebarData: unknown): number | null {
     return null;
   }
 
+  // SidebarData 타입에는 회원 id 필드가 선언돼 있지 않다(닉네임 폴백이 실제
+  // 소유자 판별을 담당). 서버가 확정 계약상 존재하지 않는 member_id·userId·
+  // user_id 는 제거하고, 실 응답에서 나타날 수 있는 memberId·id 만 확인한다.
   const sidebar = sidebarData as Record<string, unknown>;
-  const candidateKeys = ['memberId', 'member_id', 'userId', 'user_id', 'id'];
+  const candidateKeys = ['memberId', 'id'];
 
   for (const key of candidateKeys) {
     const parsedValue = parsePositiveInteger(sidebar[key]);
@@ -312,22 +288,11 @@ export function mapDiaryToViewData(
   // 연동 챌린지 필은 프리페치된 일지 상세(diary.challenge)로 첫 페인트부터
   // 그리고, challengeDetailData 는 체크리스트 goals 용으로 계속 사용한다.
   const summary =
-    challengeDetailData?.challengeSummary ??
-    (diary.challenge as ChallengeSummary | null) ??
-    undefined;
-  const diaryWithImageAliases = diary as DiaryDetail & DiaryImageFields;
-  const contentImageUrls = resolveImageList(
-    diaryWithImageAliases.imgUrl,
-    diaryWithImageAliases.img,
-    diaryWithImageAliases.imageUrl,
-    diaryWithImageAliases.thumbnailUrl,
-    diaryWithImageAliases.images,
-    diaryWithImageAliases.thumbnail
-  );
+    challengeDetailData?.challengeSummary ?? diary.challenge ?? undefined;
+  const contentImageUrls = resolveImageList(diary.imgUrl, diary.thumbnailUrl);
 
   const feeling: Feeling = diaryInfo?.feeling ?? 'NONE';
-  const rawAchievementRate =
-    diary.achievementRate ?? diaryInfo?.achievementRate ?? 0;
+  const rawAchievementRate = diaryInfo?.achievementRate ?? 0;
   const achievementPercent = Math.min(
     100,
     Math.max(0, Math.round(rawAchievementRate))

--- a/src/app.feature/diary/write/utils/diaryFormHelpers.ts
+++ b/src/app.feature/diary/write/utils/diaryFormHelpers.ts
@@ -184,16 +184,15 @@ export function mapSidebarChallengeToChallengeListItem(
   };
 }
 
+// DiaryDetail 에 없는 레거시/방어용 이미지 별칭 필드만 얹는다.
+// (imgUrl·thumbnailUrl·diaryInfo 는 이미 DiaryDetail 확정 타입에 있다.)
 export type DiaryDetailWithAliases = DiaryDetail & {
-  diaryInfo?: DiaryInfo | null;
   img?:
     | Array<{ url?: string | null; imageUrl?: string | null }>
     | string[]
     | string
     | null;
-  imgUrl?: string[] | string | null;
   imageUrl?: string | null;
-  thumbnailUrl?: string | null;
   thumbnail?: string | null;
   images?:
     | Array<{ url?: string | null; imageUrl?: string | null } | string>
@@ -211,8 +210,7 @@ export function revokeObjectUrlIfNeeded(url: string): void {
 export function getDiaryInfo(
   diary: DiaryDetail | null | undefined
 ): DiaryInfo | null {
-  const diaryWithAliases = diary as DiaryDetailWithAliases | null | undefined;
-  return diaryWithAliases?.diaryInfoDto ?? diaryWithAliases?.diaryInfo ?? null;
+  return diary?.diaryInfo ?? null;
 }
 
 // 폼에서 다루는 이미지 한 장.

--- a/src/app.feature/home/hooks/useHomeRandomDiaryLike.ts
+++ b/src/app.feature/home/hooks/useHomeRandomDiaryLike.ts
@@ -2,6 +2,7 @@ import { DIARY_QUERY_KEYS } from '@feature/diary/board/consts/queryKeys';
 import {
   type DiaryDetail,
   type DiaryItem,
+  type LikeInfo,
 } from '@feature/diary/board/type/diary';
 import { diaryDetailApi } from '@feature/diary/detail/api/diaryDetailApi';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
@@ -17,7 +18,7 @@ interface UseHomeRandomDiaryLikeResult {
 }
 
 function resolveNextLikeCount(
-  diary: DiaryItem,
+  likeInfo: LikeInfo,
   likedByMe: boolean,
   likeCountFromServer?: number
 ): number {
@@ -28,24 +29,30 @@ function resolveNextLikeCount(
     return Math.max(0, likeCountFromServer);
   }
 
-  if (diary.likeInfo.likedByMe === likedByMe) {
-    return diary.likeInfo.likeCnt;
+  if (likeInfo.likedByMe === likedByMe) {
+    return likeInfo.likeCnt;
   }
 
-  return Math.max(0, diary.likeInfo.likeCnt + (likedByMe ? 1 : -1));
+  return Math.max(0, likeInfo.likeCnt + (likedByMe ? 1 : -1));
 }
 
-function updateDiaryLikeInfo(
-  diary: DiaryItem,
+// 목록 아이템(DiaryItem)과 상세(DiaryDetail) 모두 likeInfo 만 갱신하므로
+// likeInfo 를 가진 어떤 형태든 받도록 제네릭으로 둔다.
+function updateDiaryLikeInfo<T extends { likeInfo: LikeInfo }>(
+  diary: T,
   likedByMe: boolean,
   likeCountFromServer?: number
-): DiaryItem {
+): T {
   return {
     ...diary,
     likeInfo: {
       ...diary.likeInfo,
       likedByMe,
-      likeCnt: resolveNextLikeCount(diary, likedByMe, likeCountFromServer),
+      likeCnt: resolveNextLikeCount(
+        diary.likeInfo,
+        likedByMe,
+        likeCountFromServer
+      ),
     },
   };
 }

--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -85,7 +85,6 @@ function StoryRing({
   const hasMyStory = groups.some((group) => group.isMyStory);
   const friendCount = hasMyStory ? groups.length - 1 : groups.length;
   const myImageUrl = resolveDiaryImageUrl(myProfileImage ?? null) ?? undefined;
-  const hasMyImage = isValidNextImageSrc(myImageUrl);
 
   return (
     <div
@@ -134,10 +133,10 @@ function StoryRing({
               )}
               aria-hidden
             >
-              {hasMyImage ? (
+              {isValidNextImageSrc(myImageUrl) ? (
                 <span className="relative h-full w-full">
                   <FadeInImage
-                    src={myImageUrl as string}
+                    src={myImageUrl}
                     alt=""
                     fill
                     sizes="36px"
@@ -159,7 +158,6 @@ function StoryRing({
         const [preview] = group.stories;
         const profileUrl =
           resolveDiaryImageUrl(group.profileImage) ?? undefined;
-        const hasProfile = isValidNextImageSrc(profileUrl);
         const name = group.userName?.trim() || `친구 ${group.userId}`;
         const title = preview?.diaryTitle ?? '';
         const time = preview ? formatStoryDate(preview.createdAt) : '';
@@ -234,9 +232,9 @@ function StoryRing({
                 )}
                 aria-hidden
               >
-                {hasProfile ? (
+                {isValidNextImageSrc(profileUrl) ? (
                   <FadeInImage
-                    src={profileUrl as string}
+                    src={profileUrl}
                     alt=""
                     fill
                     sizes="40px"


### PR DESCRIPTION
## 배경

클라 리팩토링 로드맵 마지막 항목(10). 진단 리포트 T1·T3·T4 대응.
서버 확정 계약(origin/dev 코드 근거)에 맞춰 응답 타입을 정정하고, 응답 shape을
잘못 가정하던 방어적 캐스팅·probe·`as string` 억제를 확정 타입 기반으로 정리한다.

**원칙: 런타임 동작 보존.** 타입/파싱만 정정하며 실제 렌더 결과는 동일하다.

## 변경 요약

### T1 — 일지 상세 타입 정정 (`diaryViewData.ts`, `diary.ts`)
- `DiaryDetail` 을 `DiaryItem` 별칭에서 분리해 실제 상세 응답 shape으로 정의
  - `author`(AuthorInfoDto), `diaryInfo`(DiaryInfoDto) — `*Dto` 접미사 필드 없음
  - `challenge` 를 `ChallengeSummaryResponse`(challengeId 키, enum 타입)로
- `DiaryInfoWithAliases` / `DiaryDetailWithAliases` / `DiaryImageFields` 제거
- `getDiaryInfo`/`getAuthorInfo` 를 확정 필드 직접 접근으로 단순화

### T3 — envelope 언랩 비대칭 통일
- 두 목록 모두 서버 envelope(`{message, data}`)를 내려받지만, diary 는 API
  레이어(`requestData`)에서 언랩해 `{items, pageInfo}` 를 반환하는 반면
  challenge 는 `requestBody` 로 envelope 를 그대로 노출(훅이 `.data.pageInfo`,
  화면이 `.data.items` 를 다시 벗김)해 비대칭이었다.
- **diary 쪽이 이미 서버 계약과 맞는 깔끔한 경계**이므로 challenge 를 여기에
  맞춘다: `getChallengeList` 를 `requestData` 로 언랩 → 훅 `lastPage.pageInfo`,
  화면 `page.items`. 렌더 결과 동일(항목·페이지네이션 불변).

### T4 — nullable 이미지 URL `as string` 억제 제거
- `DiaryCard` / `StoryRing` / `ChallengeListItem` 에서 `src={... as string}` 제거.
- 원인은 타입 가드 결과를 boolean 변수에 담아 narrowing 이 전파되지 않던 것.
  가드를 JSX 조건부에 인라인해 타입으로 해소(런타임 조건 동일).

## 제거한 캐스팅/probe 목록
- `diaryInfoDto ?? diaryInfo` → `diary.diaryInfo`
- `authorInfoDto ?? author` → `diary.author`
- `diary.challenge as ChallengeSummary` → `diary.challenge` (확정 타입)
- top-level `diary.achievementRate ??` 폴백 (상세 응답에 존재하지 않음)
- 이미지 별칭 probe(`img`/`imageUrl`/`images`/`thumbnail`) → `imgUrl`/`thumbnailUrl`
- `resolveSidebarMemberId` 의 `member_id`/`userId`/`user_id` probe (계약상 부재)
- challenge 목록 `lastPage.data.pageInfo` / `page.data.items` 의 이중 언랩
- `DiaryCard`/`StoryRing`/`ChallengeListItem` 의 `as string` 4곳

## 남긴 부분 (의도적, 보수적 판단)
- **`resolveSidebarMemberId`**: `SidebarData` 타입에는 회원 id 필드 자체가
  선언돼 있지 않아(닉네임 폴백이 실제 소유자 판별 담당) 현재 이 함수는 런타임
  에서 사실상 항상 `null` 을 반환한다. 서버가 확정적으로 없다고 확인된
  `member_id`/`userId`/`user_id` 만 제거하고, 실 응답에 나타날 수 있는
  `memberId`/`id` probe 는 보수적으로 유지했다(제거 시 소유자 판별 회귀 위험).
- **`diaryFormHelpers.getDiaryImageUrls`**: 수정 폼의 기존 이미지 raw 재전송
  경로(변형 시 400 위험)라 이미지 별칭 방어 로직을 그대로 두었다.
- **`DiaryListScreen` 의 로컬 `getDiaryInfo`/`getDiaryAuthorInfo`**: 목록 아이템
  (`DiaryItem`)은 API 에서 `authorInfoDto`/`diaryInfoDto` 로 정규화되므로 해당
  probe 는 목록 계약상 정상 — 범위 밖으로 유지.

## 검증
- `pnpm test` (vitest) — 80 passed
- `npx tsc --noEmit` — 통과
- `pnpm lint` — 통과
- `pnpm knip` — 통과(신규 미사용 export 없음)
- `pnpm build` — 통과

브라우저 확인은 수행하지 않았습니다(정적 검증까지만).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved challenge board list loading and pagination for more reliable results.
  * Updated diary detail handling to consistently display author, challenge, achievement, and image information.
  * Improved profile, story, and challenge image rendering with safer fallbacks when images are unavailable.
  * Made like-count updates more consistent across diary views.
* **Tests**
  * Added coverage for diary data mapping, member identification, achievement rates, and connected challenges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->