### PR TITLE
fix: 마이페이지 하위 이동 시 스켈레톤 번쩍임 제거

### DIFF
--- a/src/app/mypage/loading.tsx
+++ b/src/app/mypage/loading.tsx
@@ -1,6 +1,0 @@
-import { MyPageSkeleton } from '@component/skeletons/MyPageSkeleton';
-import React from 'react';
-
-export default function MyPageLoading(): React.ReactElement {
-  return <MyPageSkeleton />;
-}


### PR DESCRIPTION
## 증상
데스크톱에서 `/mypage/*` 하위 페이지(설정, 내 일지 리스트, 통계 등)로 이동할 때마다 **마이페이지 홈 스켈레톤이 잠깐 번쩍임**.

## 근본 원인
`src/app/mypage/loading.tsx`(= `MyPageSkeleton`)는 Next.js App Router 규약상 `/mypage` **세그먼트와 그 하위 전체**(statistics·settings·diary·challenge·friend)를 감싸는 로딩 경계다. 하위 페이지에는 자체 `loading.tsx`가 없어, 형제 라우트로 이동하면 이 상위 경계가 Suspense fallback으로 잡힌다.

- 하위 이동은 전부 prefetch 없는 `router.push`(예: `AppRightRail.tsx:226`, `MyPageProfileCard.tsx`, `MyPageStatisticsEntry.tsx`, `MyPageFriendsEntry.tsx`)라, 목적지 RSC가 캐시에 없어 이동할 때마다 경계가 트리거된다.
- 결과적으로 **Settings로 가는데 마이페이지 홈 스켈레톤**이 뜨는, 명백히 잘못된 fallback이 노출됐다.

### 왜 데스크톱에서만
- `MyPageSkeleton`의 특징적 요소(풀블리드 히어로 배너 `h-[180px]`, 배너에 겹치는 프로필 카드 `-mt-25`, 통계 4-col·Streak 2-col 그리드)가 전부 `lg:` 전용이다. 데스크톱에선 이 풍부한 **마이페이지 홈 레이아웃**이 그대로 떴다 사라져 이질감이 크다.
- 데스크톱은 `AppLayoutShell`의 TopNav가 `hidden lg:flex`로 **상단 크롬이 고정**된 채 `<main>`만 스켈레톤으로 교체돼 번쩍임이 눈에 띈다. 모바일(<lg)은 하위 화면이 자체 sticky 헤더로 풀스크린 전환되고 스켈레톤도 최소 스택이라 일반 로딩처럼 보인다.

## 수정
`src/app/mypage/loading.tsx` **삭제**.

- `/mypage/*`는 모두 **정적(○) 페이지**라 서버 RSC가 즉시 렌더되어 이 경계가 실질적 스트리밍 이득을 주지 않는다.
- 콜드 로드 스켈레톤은 **그대로 유지**된다: 각 화면이 클라이언트 컴포넌트로서 자체 스켈레톤을 SSR/CSR로 그린다. `MyPageScreen`은 `useMyPage()` 로딩 중 `MyPageSkeleton`을, 나머지 화면은 컴포넌트별 `Skeleton`을 렌더한다.
- 캐시가 확정된(로그인+데이터 있음) 사용자가 하위 이동할 때만 번쩍임이 사라진다. 비로그인/콜드 최초 진입 스켈레톤은 그대로 남는다.

## 검증
정적 검증까지만 수행(브라우저 실동작은 미확인).

- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors, 기존 8 warnings 무관)
- `pnpm test` ✅ (97 passed)
- `pnpm knip` ✅
- `pnpm build` ✅ (모든 `/mypage/*` 라우트 ○ Static 확인)