### PR TITLE
fix: 바텀 네비를 최상위 4개 탭에서만 노출

### DIFF
--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -38,23 +38,9 @@ const RIGHT_RAIL_HIDDEN_ROUTES = [
   '/install',
 ];
 
-const BOTTOM_NAV_HIDDEN_ROUTES = [
-  '/auth/login',
-  '/login',
-  '/auth/signup',
-  '/signup',
-  '/diary/create',
-  '/challenge/create',
-  '/onboarding',
-  '/notification',
-  '/notice',
-  '/inquiry',
-  '/mypage/settings',
-  '/mypage/friend',
-  '/terms',
-  '/privacy',
-  '/install',
-];
+// 바텀 네비는 최상위 4개 탭에서만 노출한다. 그 외 서브/상세 화면은
+// 각자 모바일 sticky 헤더(뒤로가기)를 사용하므로 바텀 네비를 숨긴다.
+const BOTTOM_NAV_VISIBLE_ROUTES = ['/', '/challenge', '/diary', '/mypage'];
 
 function matchesRoute(pathname: string, routes: readonly string[]): boolean {
   return routes.some(
@@ -62,22 +48,13 @@ function matchesRoute(pathname: string, routes: readonly string[]): boolean {
   );
 }
 
-function isBottomNavHidden(pathname: string): boolean {
-  if (matchesRoute(pathname, BOTTOM_NAV_HIDDEN_ROUTES)) {
-    return true;
-  }
-  // 챌린지/일지 상세는 자체 sticky CTA를 사용하므로 바텀 네비를 숨긴다.
-  if (/^\/challenge\/\d+/.test(pathname)) {
-    return true;
-  }
-  if (/^\/diary\/\d+/.test(pathname)) {
-    return true;
-  }
-  // 다른 회원 프로필 페이지는 자체 sticky 백 헤더를 사용한다.
-  if (/^\/member\/\d+\/?$/.test(pathname)) {
-    return true;
-  }
-  return false;
+function isBottomNavVisible(pathname: string): boolean {
+  // 정확히 최상위 탭 경로일 때만 노출(하위 경로는 서브 화면으로 간주).
+  const normalized =
+    pathname.length > 1 && pathname.endsWith('/')
+      ? pathname.slice(0, -1)
+      : pathname;
+  return BOTTOM_NAV_VISIBLE_ROUTES.includes(normalized);
 }
 
 function resolveActiveNavId(pathname: string): string {
@@ -183,7 +160,7 @@ export default function AppLayoutShell({
     RIGHT_RAIL_HIDDEN_ROUTES
   );
   const showRightRail = isContentRouteForRail;
-  const showBottomNav = !isBottomNavHidden(pathname) && !isNativeApp;
+  const showBottomNav = isBottomNavVisible(pathname) && !isNativeApp;
   const bottomNavRespClass = 'lg:hidden';
   const activeNavId = resolveActiveNavId(pathname);
 


### PR DESCRIPTION
## 근본 원인
바텀 네비 노출을 `BOTTOM_NAV_HIDDEN_ROUTES`(숨김 목록) + 상세 경로 정규식으로
판별했다. 목록에 빠진 서브 화면(통계 `/mypage/statistics`, 내 챌린지 전체보기
`/mypage/challenge`, 내 일지 리스트 `/mypage/diary`, 다른 회원의 챌린지/일지
리스트 등)에서는 바텀 네비가 그대로 노출됐고, 해당 화면들은 이미 자체 모바일
sticky 헤더를 갖고 있어 **바텀 네비 + 뒤로가기 헤더가 동시에** 보이는 상태였다.

## 변경 요약
- 노출 규칙을 **허용 목록**으로 반전: 정확히 최상위 4개 탭 경로에서만 노출.
  - 홈 `/`, 챌린지 `/challenge`, 일지 `/diary`, 마이 `/mypage`
  - 하위 경로(`/mypage/statistics`, `/challenge/[id]`, `/diary/create` 등)는
    모두 서브 화면으로 간주해 바텀 네비를 숨긴다.
- `isBottomNavHidden` → `isBottomNavVisible` 로 교체(허용 목록 + 트레일링
  슬래시 정규화). 제거된 상세 경로 정규식은 허용 목록 반전으로 자연히 커버된다.

## 영향 / 회귀
- 새로 바텀 네비가 숨겨지는 화면(`/mypage/statistics`, `/mypage/challenge`,
  `/mypage/diary`, `/member/[id]/challenge`, `/member/[id]/diary`)은 **모두 이미
  자체 모바일 헤더**(`SubPageShell` / `MobileStickyHeader`)를 렌더한다. 헤더
  없이 바텀 네비만 뜨던 화면은 없어, 헤더 누락 사각지대는 없다.
- 바텀 네비 컴포넌트는 `lg:hidden` 이라 **데스크톱 동작에는 영향 없음**.

## 검증
`tsc --noEmit`, `pnpm lint`(0 errors), `pnpm test`(97 passed), `pnpm knip`,
`pnpm build` 모두 통과. 브라우저 확인은 하지 않음(프로젝트 정책상 사용자 확인).