### PR TITLE
fix: 통계 감정 표시 아이콘 통일 및 미선택(0 버킷) 제외

### DIFF
--- a/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
+++ b/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
@@ -3,13 +3,14 @@
 import { Text } from '@1d1s/design-system';
 import type { Feeling } from '@feature/diary/board/type/diary';
 import { cn } from '@module/utils/cn';
+import Image from 'next/image';
 import React from 'react';
 
 import { useFeelingStatistics } from '../hooks/useStatisticsQueries';
 import {
   FEELING_COLOR,
-  FEELING_EMOJI,
   FEELING_LABEL,
+  FEELING_MOOD_IMAGE,
   FEELING_ORDER,
   formatPercent,
 } from '../utils/statisticsView';
@@ -31,7 +32,13 @@ export function FeelingDistributionSection(): React.ReactElement {
     ratioByFeeling.set(item.feeling, item.ratio);
   });
 
-  const segments: DonutSegment[] = FEELING_ORDER.map((feeling) => ({
+  // count 0 버킷(특히 미선택 NONE)은 범례·도넛에서 제외 — 실제 기록된
+  // 감정만 노출. 총합/비율은 0 버킷이 어차피 0 기여라 그대로 정합.
+  const visibleFeelings = FEELING_ORDER.filter(
+    (feeling) => (countByFeeling.get(feeling) ?? 0) > 0
+  );
+
+  const segments: DonutSegment[] = visibleFeelings.map((feeling) => ({
     key: feeling,
     value: countByFeeling.get(feeling) ?? 0,
     color: FEELING_COLOR[feeling],
@@ -72,11 +79,12 @@ export function FeelingDistributionSection(): React.ReactElement {
         />
 
         <ul className="w-full flex-1 space-y-2.5">
-          {FEELING_ORDER.map((feeling) => {
+          {visibleFeelings.map((feeling) => {
             const count = countByFeeling.get(feeling) ?? 0;
             const ratio =
               ratioByFeeling.get(feeling) ??
               (total > 0 ? count / total : 0);
+            const mood = FEELING_MOOD_IMAGE[feeling];
             return (
               <li
                 key={feeling}
@@ -87,7 +95,16 @@ export function FeelingDistributionSection(): React.ReactElement {
                   className="h-3 w-3 shrink-0 rounded-full"
                   style={{ backgroundColor: FEELING_COLOR[feeling] }}
                 />
-                <span aria-hidden>{FEELING_EMOJI[feeling]}</span>
+                {mood ? (
+                  <Image
+                    src={mood.src}
+                    alt=""
+                    width={18}
+                    height={18}
+                    aria-hidden
+                    unoptimized
+                  />
+                ) : null}
                 <Text size="caption1" className="flex-1 text-gray-700">
                   {FEELING_LABEL[feeling]}
                 </Text>

--- a/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
+++ b/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
@@ -13,6 +13,7 @@ import {
 } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import Image from 'next/image';
 import React, { useMemo, useState } from 'react';
 
 import {
@@ -21,8 +22,8 @@ import {
 } from '../hooks/useStatisticsQueries';
 import type { StatisticsPeriodUnit } from '../type/statistics';
 import {
-  FEELING_EMOJI,
   FEELING_LABEL,
+  FEELING_MOOD_IMAGE,
   FEELING_ORDER,
   formatBucketLabel,
   formatDelta,
@@ -248,13 +249,30 @@ export function PeriodSummarySection(): React.ReactElement {
             </Text>
             <div className="flex flex-wrap gap-1.5">
               {FEELING_ORDER.map((feeling) => {
-                const item = (summary.feelingBreakdown ?? []).find(
-                  (entry) => entry.feeling === feeling
-                );
+                const count =
+                  (summary.feelingBreakdown ?? []).find(
+                    (entry) => entry.feeling === feeling
+                  )?.count ?? 0;
+                // count 0 감정(특히 미선택 NONE)은 칩에서 제외.
+                if (count === 0) {
+                  return null;
+                }
+                const mood = FEELING_MOOD_IMAGE[feeling];
                 return (
                   <Tag key={feeling} tone="gray" size="sm">
-                    {FEELING_EMOJI[feeling]} {FEELING_LABEL[feeling]}{' '}
-                    {item?.count ?? 0}
+                    <span className="inline-flex items-center gap-1">
+                      {mood ? (
+                        <Image
+                          src={mood.src}
+                          alt=""
+                          width={16}
+                          height={16}
+                          aria-hidden
+                          unoptimized
+                        />
+                      ) : null}
+                      {FEELING_LABEL[feeling]} {count}
+                    </span>
                   </Tag>
                 );
               })}

--- a/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
+++ b/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
@@ -122,9 +122,6 @@ export function PeriodSummarySection(): React.ReactElement {
   const [periodKey, setPeriodKey] = useState<string | undefined>(undefined);
 
   const periodsQuery = useStatisticsPeriods(unit);
-  const summaryQuery = useStatisticsSummary({ unit, periodKey });
-
-  const summary = summaryQuery.data;
 
   // start 기준 오름차순 정렬 → 서버 배열 순서와 무관하게 이전/다음 결정.
   const sortedPeriods = useMemo(() => {
@@ -134,8 +131,20 @@ export function PeriodSummarySection(): React.ReactElement {
     );
   }, [periodsQuery.data]);
 
-  // 실제 로드된 기간 키를 우선 사용 (초기 undefined → 서버가 최신 반환).
-  const activeKey = summary?.periodKey ?? periodKey;
+  // periodKey 는 서버 필수 파라미터. 사용자가 특정 기간을 고르기 전에는
+  // 가장 최근 기간(정렬 마지막)을 기본값으로 사용해 요청에 반드시 담는다.
+  const resolvedPeriodKey =
+    periodKey ?? sortedPeriods[sortedPeriods.length - 1]?.key;
+
+  const summaryQuery = useStatisticsSummary({
+    unit,
+    periodKey: resolvedPeriodKey,
+  });
+
+  const summary = summaryQuery.data;
+
+  // 실제 로드된 기간 키를 우선 사용 (없으면 기본 최근 기간).
+  const activeKey = summary?.periodKey ?? resolvedPeriodKey;
   const activeIndex = sortedPeriods.findIndex((item) => item.key === activeKey);
 
   // 버튼 활성은 서버 신호(hasPrev/hasNext)와 실제 목록 내 이동 가능 여부를

--- a/src/app.feature/member/statistics/hooks/useStatisticsQueries.ts
+++ b/src/app.feature/member/statistics/hooks/useStatisticsQueries.ts
@@ -62,7 +62,9 @@ export function useStatisticsSummary(
   return useQuery({
     queryKey: STATISTICS_QUERY_KEYS.summary(params),
     queryFn: () => statisticsApi.getSummary(params),
-    enabled: isLoggedIn,
+    // periodKey 는 서버 필수 파라미터 — 확정 전(초기 렌더)에는 요청하지
+    // 않아 "필수 파라미터 누락" 400 을 방지한다.
+    enabled: isLoggedIn && Boolean(params.periodKey),
     staleTime: STATISTICS_STALE_TIME,
   });
 }

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -1,6 +1,6 @@
 import type { Feeling } from '@feature/diary/board/type/diary';
 
-// 감정 표시 메타 — 라벨/이모지/차트 색(colors.css 변수).
+// 감정 표시 메타 — 라벨/아이콘/차트 색(colors.css 변수).
 export const FEELING_ORDER: Feeling[] = ['HAPPY', 'NORMAL', 'SAD', 'NONE'];
 
 export const FEELING_LABEL: Record<Feeling, string> = {
@@ -10,11 +10,16 @@ export const FEELING_LABEL: Record<Feeling, string> = {
   NONE: '미선택',
 };
 
-export const FEELING_EMOJI: Record<Feeling, string> = {
-  HAPPY: '😊',
-  NORMAL: '😌',
-  SAD: '🥲',
-  NONE: '⚪',
+// 감정 아이콘 — 일지 화면과 동일한 무드 SVG(/images/mood-*.svg).
+// NONE(미선택)은 대응 아이콘이 없어 null.
+export const FEELING_MOOD_IMAGE: Record<
+  Feeling,
+  { src: string; alt: string } | null
+> = {
+  HAPPY: { src: '/images/mood-happy.svg', alt: '좋음' },
+  NORMAL: { src: '/images/mood-soso.svg', alt: '보통' },
+  SAD: { src: '/images/mood-sad.svg', alt: '아쉬움' },
+  NONE: null,
 };
 
 // SVG/inline 스타일용 색상 (colors.css 토큰 참조).


### PR DESCRIPTION
## 배경
통계 화면(`/mypage/statistics`)의 감정 표시·필수 파라미터 버그 수정. 동작 보존 원칙(버그 수정 외 변경 없음).

## 이슈 1 — 감정 이모지 → 프로젝트 감정 아이콘
- 감정 분포 범례·기간 요약 "감정 구성" 칩의 이모지(😊😌🥲⚪)를 일지 화면과 동일한 무드 SVG(`/images/mood-*.svg`)로 교체
- `statisticsView.ts`에 `FEELING_MOOD_IMAGE` 매핑 추가(일지의 `mood-happy/soso/sad.svg`와 동일 에셋), 미사용이 된 `FEELING_EMOJI` 제거

## 이슈 2 — 미선택(NONE) 0 버킷 표시 제거
- `count === 0`인 감정 버킷(특히 미선택 NONE)을 범례·칩·도넛에서 제외
- 백엔드는 NONE을 count>0일 때만 응답에 포함하므로, 프론트도 응답에 실제 존재하는 count>0 항목만 렌더 → "미선택"은 실제 미선택 일지가 있을 때만 노출(하드코딩 NONE 없음)
- 0 버킷은 총합/비율 기여가 0이라 도넛 각도·비율과 정합 유지

## 이슈 3 — 필수 요청 파라미터 누락 (실제 원인: `/summary`의 `periodKey`)
서버 조사 결과, `/friend-comparison`의 `period`는 백엔드 `@RequestParam(defaultValue="MONTH")`라 "누락" 에러를 낼 수 없음. 사용자가 "period 누락"이라 부른 것은 실제로 **`/summary`의 `periodKey` 누락**이었음.

- `/summary`는 `unit`+`periodKey`가 서버 필수인데, 초기 렌더에서 `periodKey`가 `undefined`로 나가 `/summary?unit=WEEK`로 요청 → "필수 파라미터 누락" 400
- 가장 최근 기간을 기본 `periodKey`로 사용하고, `periodKey` 확정 전에는 `useStatisticsSummary`를 `enabled: false`로 두어 빈 요청 차단

### 나머지 필수 파라미터 점검 (모두 정상 전송 확인)
- `/periods` → `unit`: ✅ (`unit` state 기본 `WEEK`)
- `/diary-trend` → `unit`: ✅ (기본 `DAY`)
- `/friend-comparison` → `period`: ✅ (기본 `WEEK`, 이미 전송 중)

## 검증
- `tsc --noEmit` / `pnpm lint`(0 errors) / `pnpm test`(97 passed) / `pnpm knip` / `pnpm build` 통과, CI 전체 pass
- 브라우저 확인은 사용자에게 위임(프로젝트 정책상 preview 미사용)