### PR TITLE
fix: 작성 추이 막대 그래프가 보이지 않던 문제 수정

### DIFF
--- a/src/app.feature/member/statistics/components/TrendBars.tsx
+++ b/src/app.feature/member/statistics/components/TrendBars.tsx
@@ -2,6 +2,8 @@ import { Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import React from 'react';
 
+import { computeBarHeightPx } from '../utils/statisticsView';
+
 export interface TrendDatum {
   bucket: string;
   count: number;
@@ -32,6 +34,9 @@ export function TrendBars({
 }: TrendBarsProps): React.ReactElement {
   const max = data.reduce((m, d) => Math.max(m, d.count), 0);
   const areaHeight = compact ? 56 : 128;
+  // 최댓값 막대 위 count 라벨이 고정 높이 영역을 넘지 않도록 여백 확보.
+  const labelReserve = compact ? 0 : 18;
+  const barArea = Math.max(0, areaHeight - labelReserve);
 
   return (
     <div className={cn('w-full', className)}>
@@ -42,10 +47,7 @@ export function TrendBars({
         aria-label={ariaLabel}
       >
         {data.map((d, i) => {
-          const ratio = max > 0 ? d.count / max : 0;
-          // 값이 있으면 최소 6% 높이로 보이게, 0이면 얇은 흔적만.
-          const heightPct =
-            d.count > 0 ? Math.max(6, ratio * 100) : 2;
+          const heightPx = computeBarHeightPx(d.count, max, barArea);
           return (
             <div
               key={`${d.bucket}-${i}`}
@@ -63,7 +65,7 @@ export function TrendBars({
               <div
                 className="w-full rounded-[3px] transition-[height]"
                 style={{
-                  height: `${heightPct}%`,
+                  height: heightPx,
                   backgroundColor: d.count > 0 ? color : 'var(--gray-200)',
                 }}
               />

--- a/src/app.feature/member/statistics/utils/statisticsView.test.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeBarHeightPx } from './statisticsView';
+
+describe('computeBarHeightPx', () => {
+  it('scales to the max bucket in pixels', () => {
+    // 최댓값 막대는 전체 영역 높이를 채운다.
+    expect(computeBarHeightPx(10, 10, 100)).toBe(100);
+    // 절반 값은 절반 높이.
+    expect(computeBarHeightPx(5, 10, 100)).toBe(50);
+  });
+
+  it('keeps positive counts visible with a 6px floor', () => {
+    // 비율이 아주 작아도 최소 6px 로 보장해 막대가 사라지지 않는다.
+    expect(computeBarHeightPx(1, 1000, 100)).toBe(6);
+  });
+
+  it('renders zero counts as a thin trace', () => {
+    expect(computeBarHeightPx(0, 10, 100)).toBe(2);
+  });
+
+  it('handles all-zero data without dividing by zero', () => {
+    expect(computeBarHeightPx(0, 0, 100)).toBe(2);
+  });
+
+  it('returns 0 when there is no area to draw in', () => {
+    expect(computeBarHeightPx(5, 10, 0)).toBe(0);
+  });
+});

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -52,6 +52,27 @@ export function formatDelta(delta: number): string {
   return '±0';
 }
 
+// 막대 픽셀 높이 계산.
+// 퍼센트 높이는 부모(flex 컬럼)의 높이가 확정돼 있어야 해석되는데, 컬럼이
+// content 높이라 % 가 0 으로 무너져 막대가 안 보였다. px 로 직접 계산해
+// 부모 높이와 무관하게 항상 그려지도록 한다.
+// - count <= 0: 얇은 흔적(2px)만.
+// - count > 0: 최대값 대비 비율, 최소 6px 로 보장.
+export function computeBarHeightPx(
+  count: number,
+  max: number,
+  areaHeight: number,
+): number {
+  if (areaHeight <= 0) {
+    return 0;
+  }
+  if (count <= 0) {
+    return 2;
+  }
+  const ratio = max > 0 ? count / max : 0;
+  return Math.max(6, Math.round(ratio * areaHeight));
+}
+
 // bucket 문자열을 사람이 읽는 짧은 라벨로. 서버 포맷을 방어적으로 처리한다.
 export function formatBucketLabel(bucket: string): string {
   if (!bucket) {


### PR DESCRIPTION
## 문제
통계 화면 "작성 추이"의 막대 그래프가 렌더되지 않았다.

## 원인
`TrendBars` 가 막대 높이를 퍼센트(`height: X%`)로 지정하는데, 부모 flex
컬럼이 `items-end` 라 stretch 되지 않고 content 높이(auto)로 무너진다.
퍼센트 높이는 부모 높이가 확정돼 있어야 해석되므로, `auto` 부모에서는
`0` 으로 계산돼 막대가 높이 0 으로 렌더됐다.

- `TrendBars.tsx` — 막대 `<div style={{ height: 'X%' }}>` (수정 전)

## 수정
- `computeBarHeightPx(count, max, areaHeight)` 순수 함수로 **픽셀 높이**를
  직접 계산 → 부모 높이와 무관하게 항상 그려짐.
- 최댓값 막대 위 count 라벨이 고정 높이 영역을 넘지 않도록 `labelReserve`
  여백 확보.
- `count <= 0` 은 2px 흔적, `count > 0` 은 최소 6px 보장, `max === 0`
  안전 처리.
- 순수 계산 로직 단위 테스트 추가 (`statisticsView.test.ts`).

## 검증
- `tsc --noEmit` ✅
- `eslint src` ✅ (0 errors)
- `vitest run` ✅ (5 passed)
- `knip` ✅
- `next build` ✅
- 브라우저 실확인은 수행하지 않음(정적 검증까지).