### PR TITLE
fix: 홈 인사 영역의 손 흔드는 요소 제거

### DIFF
--- a/src/app.feature/home/components/HomeWarmGreeting.tsx
+++ b/src/app.feature/home/components/HomeWarmGreeting.tsx
@@ -24,36 +24,9 @@ export default function HomeWarmGreeting(): React.ReactElement {
     <div className="min-h-[64px] w-full">
       <div className="flex items-end justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <Text size="heading2" weight="extrabold" className="text-gray-900">
-              {greetingTitle}
-            </Text>
-            <span aria-hidden className="animate-wave inline-block">
-              <svg
-                width="26"
-                height="26"
-                viewBox="0 0 40 40"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g fill="#F2A65C">
-                  <rect x="10.5" y="15" width="21" height="21" rx="9.5" />
-                  <rect x="12.2" y="6" width="4.4" height="19" rx="2.2" />
-                  <rect x="17.3" y="3" width="4.4" height="22" rx="2.2" />
-                  <rect x="22.4" y="4" width="4.4" height="21" rx="2.2" />
-                  <rect x="27.3" y="7" width="4.4" height="18" rx="2.2" />
-                  <rect
-                    x="5.5"
-                    y="18.5"
-                    width="4.4"
-                    height="13"
-                    rx="2.2"
-                    transform="rotate(-34 7.7 25)"
-                  />
-                </g>
-              </svg>
-            </span>
-          </div>
+          <Text size="heading2" weight="extrabold" className="text-gray-900">
+            {greetingTitle}
+          </Text>
           <Text size="caption2" weight="medium" className="mt-1 text-gray-600">
             오늘도 작은 한 걸음을 응원해요.
           </Text>

--- a/src/app.styles/animation.css
+++ b/src/app.styles/animation.css
@@ -194,39 +194,6 @@
   }
 }
 
-/* 홈 인사 손 흔들기 — 손목(아래쪽)을 축으로 좌우로 까딱이며 흔든다.
-   기존 animate-float(상하 이동) 대신 사용한다. transform(rotate) 만 쓰므로
-   GPU 합성으로 처리된다. */
-@keyframes wave {
-  0%,
-  100% {
-    transform: rotate(0deg);
-  }
-  20% {
-    transform: rotate(-14deg);
-  }
-  40% {
-    transform: rotate(10deg);
-  }
-  60% {
-    transform: rotate(-8deg);
-  }
-  80% {
-    transform: rotate(5deg);
-  }
-}
-
-.animate-wave {
-  transform-origin: 70% 80%;
-  animation: wave 1.8s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .animate-wave {
-    animation: none;
-  }
-}
-
 /* 스토리 진행 바 — 현재 스토리 세그먼트를 좌→우로 채운다. 채우는 시간은
    StoryViewer 의 STORY_DURATION_MS(자동 전환 간격)과 동일하게 inline
    animation-duration 으로 맞춘다. transform(scaleX) 만 써서 GPU 합성으로


### PR DESCRIPTION
## 배경
홈 화면 인사말 옆의 손 흔드는(waving hand) 아이콘이 어색해 제거한다.
인사 문구 자체는 유지한다.

## 변경
- `HomeWarmGreeting.tsx` — `.animate-wave` 손 흔들기 SVG `<span>` 제거.
  손 아이콘만 감싸려고 있던 `flex items-center gap-2` 래퍼도 정리하고
  인사 제목 `Text` 를 직접 배치.
- `animation.css` — 위 SVG 에서만 쓰던 `@keyframes wave`, `.animate-wave`,
  reduced-motion 블록을 삭제(다른 사용처 없음, knip 통과).

인사 문구와 StreakChip 은 그대로 유지. 데스크톱/모바일 공통 컴포넌트라
양쪽 모두 반영된다.

## 검증
- `tsc --noEmit` ✅
- `eslint src` ✅ (0 errors)
- `vitest run` ✅ (97 passed)
- `knip` ✅
- `next build` ✅
- 브라우저 실확인은 수행하지 않음(정적 검증까지).