### PR TITLE
feat: 통계 화면 리디자인 및 마이페이지 통계 진입 개선

### DIFF
--- a/src/app.constants/consts/noticeData.ts
+++ b/src/app.constants/consts/noticeData.ts
@@ -11,6 +11,13 @@ export interface NoticeItem {
 
 export const NOTICE_ITEMS: NoticeItem[] = [
   {
+    id: 'notice-2026-07-11',
+    category: '업데이트',
+    title: '통계 기능이 추가됐어요! 나의 기록을 한눈에',
+    body: '마이페이지에 통계 기능이 새로 추가됐습니다. 주·월·연 단위 활동 요약부터 감정 분포, 일지 작성 추이, 친구들과 나의 활동까지 한눈에 확인할 수 있어요. 마이페이지 > 활동 통계의 더보기에서 만나보세요. 꾸준히 쌓아온 기록이 얼마나 성장했는지 지금 확인해 보세요!',
+    createdAt: '2026-07-11',
+  },
+  {
     id: 'notice-2026-05-23',
     category: '공지',
     title: '1D1S 정식 오픈! 오늘부터 함께 갓생 살아봐요',

--- a/src/app.feature/member/mypage/components/MyPageStatSection.tsx
+++ b/src/app.feature/member/mypage/components/MyPageStatSection.tsx
@@ -1,6 +1,7 @@
 import { CountUp } from '@component/CountUp';
 import type { MyPageStreak } from '@feature/member/type/member';
 import { cn } from '@module/utils/cn';
+import Link from 'next/link';
 import React from 'react';
 
 import { getLongestGoalStreakSummary } from '../utils/mypageUtils';
@@ -26,6 +27,17 @@ export function MyPageStatSection({
       <MyPageSectionHeader
         title="활동 통계"
         subtitle="나의 활동 기록과 성장 지표"
+        action={
+          <Link
+            href="/mypage/statistics"
+            className={cn(
+              'text-main-700 text-xs font-bold',
+              'transition-opacity hover:opacity-80'
+            )}
+          >
+            더보기 →
+          </Link>
+        }
       />
       <div className={cn('mt-4 grid grid-cols-2 gap-2.5', 'sm:grid-cols-4')}>
         <MyPageStatTile

--- a/src/app.feature/member/statistics/components/DiaryTrendSection.tsx
+++ b/src/app.feature/member/statistics/components/DiaryTrendSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SegmentedControl } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
 import React, { useState } from 'react';
 
 import { useDiaryTrend } from '../hooks/useStatisticsQueries';
@@ -20,9 +21,8 @@ const UNIT_OPTIONS = [
  */
 export function DiaryTrendSection(): React.ReactElement {
   const [unit, setUnit] = useState<DiaryTrendUnit>('DAY');
-  const { data, isPending, isSuccess, isError, error } = useDiaryTrend({
-    unit,
-  });
+  const { data, isPending, isPlaceholderData, isSuccess, isError, error } =
+    useDiaryTrend({ unit });
 
   const points = data?.points ?? [];
   const chartData: TrendDatum[] = points.map((p) => ({
@@ -52,10 +52,19 @@ export function DiaryTrendSection(): React.ReactElement {
       emptyText="이 기간에 작성한 일지가 없어요."
       skeletonHeight={160}
     >
-      <TrendBars
-        data={chartData}
-        ariaLabel={`작성 추이 막대 차트, 총 ${totalCount}건`}
-      />
+      {/* 단위 전환 중(placeholder)에는 dim, 새 데이터가 오면
+          opacity 만 부드럽게 복귀 — remount 없는 크로스페이드. */}
+      <div
+        className={cn(
+          'transition-opacity duration-300 ease-out',
+          isPlaceholderData && 'opacity-40'
+        )}
+      >
+        <TrendBars
+          data={chartData}
+          ariaLabel={`작성 추이 막대 차트, 총 ${totalCount}건`}
+        />
+      </div>
     </StatisticsCard>
   );
 }

--- a/src/app.feature/member/statistics/components/DonutChart.tsx
+++ b/src/app.feature/member/statistics/components/DonutChart.tsx
@@ -25,7 +25,24 @@ interface DonutChartProps {
 const VIEW = 100;
 const CENTER = VIEW / 2;
 const RADIUS = 40;
-const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+// 12시 방향 기준 각도(deg) → 원 위의 좌표.
+function pointAt(angleDeg: number): [number, number] {
+  const rad = ((angleDeg - 90) * Math.PI) / 180;
+  return [
+    CENTER + RADIUS * Math.cos(rad),
+    CENTER + RADIUS * Math.sin(rad),
+  ];
+}
+
+// 시계 방향 아크 패스. dasharray 원 트릭 대신 명시적 패스로 그려
+// 브라우저별 dash 렌더링 아티팩트를 피한다.
+function arcPath(startDeg: number, endDeg: number): string {
+  const [sx, sy] = pointAt(startDeg);
+  const [ex, ey] = pointAt(endDeg);
+  const largeArc = endDeg - startDeg > 180 ? 1 : 0;
+  return `M ${sx} ${sy} A ${RADIUS} ${RADIUS} 0 ${largeArc} 1 ${ex} ${ey}`;
+}
 
 /**
  * 순수 SVG 도넛 차트 (외부 의존성 없음).
@@ -43,14 +60,17 @@ export function DonutChart({
   // px 두께를 viewBox 단위로 환산 (scale = size/VIEW).
   const strokeWidth = (thickness / size) * VIEW;
 
-  let offset = 0;
+  const visible = segments.filter((seg) => seg.value > 0);
+  let accDeg = 0;
   const arcs =
     total > 0
-      ? segments
-          .filter((seg) => seg.value > 0)
-          .map((seg) => {
-            const dash = (seg.value / total) * CIRCUMFERENCE;
-            const arc = (
+      ? visible.map((seg) => {
+          const startDeg = accDeg;
+          const sweep = (seg.value / total) * 360;
+          accDeg += sweep;
+          // 단일 세그먼트 100% 는 아크로 못 그리므로 원으로 대체.
+          if (visible.length === 1) {
+            return (
               <circle
                 key={seg.key}
                 cx={CENTER}
@@ -59,13 +79,19 @@ export function DonutChart({
                 fill="none"
                 stroke={seg.color}
                 strokeWidth={strokeWidth}
-                strokeDasharray={`${dash} ${CIRCUMFERENCE - dash}`}
-                strokeDashoffset={-offset}
               />
             );
-            offset += dash;
-            return arc;
-          })
+          }
+          return (
+            <path
+              key={seg.key}
+              d={arcPath(startDeg, accDeg)}
+              fill="none"
+              stroke={seg.color}
+              strokeWidth={strokeWidth}
+            />
+          );
+        })
       : [];
 
   return (
@@ -88,8 +114,7 @@ export function DonutChart({
           stroke="var(--gray-100)"
           strokeWidth={strokeWidth}
         />
-        {/* -90deg 회전으로 12시 방향에서 시작 */}
-        <g transform={`rotate(-90 ${CENTER} ${CENTER})`}>{arcs}</g>
+        {arcs}
       </svg>
       {centerSlot ? (
         <div className="absolute inset-0 flex flex-col items-center justify-center">

--- a/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
+++ b/src/app.feature/member/statistics/components/FeelingDistributionSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Text } from '@1d1s/design-system';
+import { ProgressBar, Text } from '@1d1s/design-system';
 import type { Feeling } from '@feature/diary/board/type/diary';
 import { cn } from '@module/utils/cn';
 import Image from 'next/image';
@@ -9,9 +9,11 @@ import React from 'react';
 import { useFeelingStatistics } from '../hooks/useStatisticsQueries';
 import {
   FEELING_COLOR,
+  FEELING_FG,
   FEELING_LABEL,
   FEELING_MOOD_IMAGE,
   FEELING_ORDER,
+  FEELING_SOFT_BG,
   formatPercent,
 } from '../utils/statisticsView';
 import { DonutChart, type DonutSegment } from './DonutChart';
@@ -85,37 +87,46 @@ export function FeelingDistributionSection(): React.ReactElement {
               ratioByFeeling.get(feeling) ??
               (total > 0 ? count / total : 0);
             const mood = FEELING_MOOD_IMAGE[feeling];
+            const fg = FEELING_FG[feeling];
             return (
               <li
                 key={feeling}
-                className="flex items-center gap-2.5"
+                className="flex items-center gap-3 rounded-[12px] px-4 py-2.5"
+                style={{ backgroundColor: FEELING_SOFT_BG[feeling] }}
               >
                 <span
                   aria-hidden
-                  className="h-3 w-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: FEELING_COLOR[feeling] }}
-                />
-                {mood ? (
-                  <Image
-                    src={mood.src}
-                    alt=""
-                    width={18}
-                    height={18}
-                    aria-hidden
-                    unoptimized
-                  />
-                ) : null}
-                <Text size="caption1" className="flex-1 text-gray-700">
+                  className={cn(
+                    'flex h-[30px] w-[30px] shrink-0 items-center',
+                    'justify-center rounded-full bg-white'
+                  )}
+                >
+                  {mood ? (
+                    <Image
+                      src={mood.src}
+                      alt=""
+                      width={18}
+                      height={18}
+                      unoptimized
+                    />
+                  ) : null}
+                </span>
+                <Text size="caption1" weight="bold" style={{ color: fg }}>
                   {FEELING_LABEL[feeling]}
                 </Text>
-                <Text
-                  size="caption1"
-                  weight="bold"
-                  className="text-gray-900"
-                >
+                <ProgressBar
+                  value={Math.round(ratio * 100)}
+                  size="sm"
+                  showValueText={false}
+                  fillColor={fg}
+                  trackColor="var(--white)"
+                  className="flex-1"
+                  trackClassName="mt-0"
+                />
+                <Text size="caption1" weight="bold" style={{ color: fg }}>
                   {formatPercent(ratio)}
                 </Text>
-                <Text size="caption3" className="w-10 text-right text-gray-400">
+                <Text size="caption3" className="w-6 text-right text-gray-400">
                   {count}개
                 </Text>
               </li>

--- a/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
+++ b/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { SegmentedControl, Tag, Text } from '@1d1s/design-system';
+import {
+  Icon,
+  ProgressBar,
+  SegmentedControl,
+  Tag,
+  Text,
+} from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import React, { useState } from 'react';
 
@@ -31,12 +37,15 @@ function Bar({
       <Text size="caption4" className="w-14 shrink-0 text-gray-400">
         {caption}
       </Text>
-      <div className="h-3 flex-1 overflow-hidden rounded-full bg-gray-100">
-        <div
-          className="h-full rounded-full"
-          style={{ width: `${widthPct}%`, backgroundColor: color }}
-        />
-      </div>
+      <ProgressBar
+        value={widthPct}
+        size="lg"
+        showValueText={false}
+        fillColor={color}
+        trackColor="var(--white)"
+        className="flex-1"
+        trackClassName="mt-0"
+      />
       <Text size="caption3" weight="bold" className="w-8 text-right">
         {formatCount(value)}
       </Text>
@@ -57,21 +66,21 @@ function CompareRow({
 }: CompareRowProps): React.ReactElement {
   const max = Math.max(mine, average, 1);
   return (
-    <div>
+    <div className="rounded-[14px] bg-gray-50 p-4">
       <div className="flex items-center justify-between">
-        <Text size="caption1" weight="medium" className="text-gray-700">
+        <Text size="caption1" weight="bold" className="text-gray-900">
           {label}
         </Text>
         <Text size="caption3" className="text-gray-400">
           나 {formatCount(mine)} · 친구 평균 {formatCount(average)}
         </Text>
       </div>
-      <div className="mt-2 space-y-1.5">
-        <Bar value={mine} max={max} color="var(--main-500)" caption="나" />
+      <div className="mt-3 space-y-2">
+        <Bar value={mine} max={max} color="var(--main-700)" caption="나" />
         <Bar
           value={average}
           max={max}
-          color="var(--gray-300)"
+          color="var(--gray-200)"
           caption="친구 평균"
         />
       </div>
@@ -84,7 +93,7 @@ function CompareRow({
  */
 export function FriendComparisonSection(): React.ReactElement {
   const [period, setPeriod] = useState<FriendComparisonPeriod>('WEEK');
-  const { data, isPending, isSuccess, isError, error } =
+  const { data, isPending, isPlaceholderData, isSuccess, isError, error } =
     useFriendComparison(period);
 
   const friendCount = data?.friendCount ?? 0;
@@ -94,42 +103,52 @@ export function FriendComparisonSection(): React.ReactElement {
 
   return (
     <StatisticsCard
-      title="친구 비교"
-      subtitle="친구 평균과 나의 활동 비교"
+      title="친구들과 나"
+      subtitle="친구 평균과 나의 활동을 나란히"
       action={
         <SegmentedControl
           size="sm"
           options={PERIOD_OPTIONS}
           value={period}
           onValueChange={(v) => setPeriod(v as FriendComparisonPeriod)}
-          aria-label="친구 비교 기간"
+          aria-label="친구 통계 기간"
         />
       }
       isLoading={isPending}
       isError={isError}
       error={error}
       isEmpty={isSuccess && friendCount === 0}
-      emptyText="친구를 추가하면 평균과 순위를 비교할 수 있어요."
+      emptyText="친구를 추가하면 평균과 순위를 함께 볼 수 있어요."
       skeletonHeight={200}
     >
-      <div className="space-y-4">
+      {/* 기간 전환 중(placeholder)에는 dim, 새 데이터가 오면
+          opacity 만 부드럽게 복귀 — remount 없는 크로스페이드. */}
+      <div
+        className={cn(
+          'space-y-4 transition-opacity duration-300 ease-out',
+          isPlaceholderData && 'opacity-40'
+        )}
+      >
         <div className="flex flex-wrap items-center gap-2">
-          <Tag tone="gray" size="sm">
+          <Tag
+            tone="gray"
+            size="sm"
+            icon={<Icon name="People" size={12} aria-hidden />}
+          >
             친구 {friendCount}명
           </Tag>
           {rank && rank.outOf > 0 ? (
-            <Tag tone="brand" size="sm" icon="🏆">
+            <Tag
+              tone="brand"
+              size="sm"
+              icon={<Icon name="Trophy" size={12} aria-hidden />}
+            >
               일지 순위 {rank.byDiaryCount}/{rank.outOf}
             </Tag>
           ) : null}
         </div>
 
-        <div
-          className={cn(
-            'space-y-4 rounded-[12px] border border-gray-100',
-            'bg-gray-50 p-4'
-          )}
-        >
+        <div className="grid gap-3 lg:grid-cols-2">
           <CompareRow
             label="작성한 일지"
             mine={me?.diaryCount ?? 0}

--- a/src/app.feature/member/statistics/components/MyPageStatisticsEntry.tsx
+++ b/src/app.feature/member/statistics/components/MyPageStatisticsEntry.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Text } from '@1d1s/design-system';
+import { Icon, Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
-import { BarChart3, ChevronRight } from 'lucide-react';
+// BarChart3 는 DS Icon 에 대응 아이콘이 없어 lucide 유지.
+import { BarChart3 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -36,10 +37,15 @@ export function MyPageStatisticsEntry(): React.ReactElement {
           통계
         </Text>
         <Text as="div" size="caption2" className="text-gray-500">
-          감정 분포·작성 추이·친구 비교
+          감정 분포·작성 추이·친구들과 나
         </Text>
       </div>
-      <ChevronRight className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
+      <Icon
+        name="ChevronRight"
+        size={16}
+        className="shrink-0 text-gray-400"
+        aria-hidden
+      />
     </button>
   );
 }

--- a/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
+++ b/src/app.feature/member/statistics/components/PeriodSummarySection.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import {
+  Button,
+  Icon,
   SegmentedControl,
   Select,
   SelectContent,
@@ -8,11 +10,10 @@ import {
   SelectTrigger,
   SelectValue,
   StatCard,
-  Tag,
   Text,
 } from '@1d1s/design-system';
+import { Skeleton } from '@component/Skeleton';
 import { cn } from '@module/utils/cn';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
 import React, { useMemo, useState } from 'react';
 
@@ -22,9 +23,11 @@ import {
 } from '../hooks/useStatisticsQueries';
 import type { StatisticsPeriodUnit } from '../type/statistics';
 import {
+  FEELING_FG,
   FEELING_LABEL,
   FEELING_MOOD_IMAGE,
   FEELING_ORDER,
+  FEELING_SOFT_BG,
   formatBucketLabel,
   formatDelta,
   formatPercent,
@@ -54,22 +57,23 @@ function NavButton({
   disabled: boolean;
   onClick(): void;
 }): React.ReactElement {
-  const Icon = direction === 'prev' ? ChevronLeft : ChevronRight;
   return (
-    <button
+    <Button
       type="button"
+      variant="secondary"
+      size="icon"
+      pill
       onClick={onClick}
       disabled={disabled}
       aria-label={direction === 'prev' ? '이전 기간' : '다음 기간'}
-      className={cn(
-        'flex h-9 w-9 shrink-0 items-center justify-center',
-        'rounded-full border border-gray-200 bg-white text-gray-600',
-        'transition-colors hover:bg-gray-50',
-        'disabled:cursor-not-allowed disabled:opacity-40'
-      )}
+      className="shrink-0"
     >
-      <Icon className="h-4 w-4" aria-hidden />
-    </button>
+      <Icon
+        name={direction === 'prev' ? 'ChevronLeft' : 'ChevronRight'}
+        size={16}
+        aria-hidden
+      />
+    </Button>
   );
 }
 
@@ -110,6 +114,111 @@ function PeriodNav({
         </Select>
       </div>
       <NavButton direction="next" disabled={!hasNext} onClick={onNext} />
+    </div>
+  );
+}
+
+interface KpiTileProps {
+  icon: React.ReactNode;
+  /** soft 아이콘 타일 배경/글자색 유틸 클래스 */
+  iconClass: string;
+  label: string;
+  value: React.ReactNode;
+  unit?: string;
+  sub?: string;
+  /** 보조 텍스트 강조색 유틸 클래스 */
+  subClass?: string;
+}
+
+// DS StatCard 조합 — soft 아이콘 타일을 label 슬롯에 넣는다.
+function KpiTile({
+  icon,
+  iconClass,
+  label,
+  value,
+  unit,
+  sub,
+  subClass,
+}: KpiTileProps): React.ReactElement {
+  return (
+    <StatCard
+      tone="white"
+      size="sm"
+      className="min-w-0 shadow-none"
+      label={
+        <span className="flex items-center gap-1.5">
+          <span
+            aria-hidden
+            className={cn(
+              'flex h-7 w-7 items-center justify-center',
+              'rounded-[9px]',
+              iconClass
+            )}
+          >
+            {icon}
+          </span>
+          {label}
+        </span>
+      }
+      value={
+        <>
+          {value}
+          {unit ? (
+            <span className="ml-0.5 text-[13px] font-bold text-gray-400">
+              {unit}
+            </span>
+          ) : null}
+        </>
+      }
+      helper={
+        sub ? (
+          <span className={cn('font-bold', subClass)}>{sub}</span>
+        ) : undefined
+      }
+    />
+  );
+}
+
+// 실제 레이아웃(네비 + KPI 4종 + 하이라이트 + 칩 + 추이)과 동일한 구조의
+// 스켈레톤 — 로드 완료 시 레이아웃 쉬프트가 없도록 높이를 맞춘다.
+function SummarySkeleton(): React.ReactElement {
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-2">
+        <Skeleton shape="circle" className="h-[38px] w-[38px] shrink-0" />
+        <Skeleton className="h-[38px] flex-1 rounded-[10px]" />
+        <Skeleton shape="circle" className="h-[38px] w-[38px] shrink-0" />
+      </div>
+      <div className="grid grid-cols-2 gap-2.5 lg:grid-cols-4">
+        {Array.from({ length: 4 }, (_, index) => (
+          <div
+            key={index}
+            className={cn(
+              'space-y-2.5 rounded-[12px] border border-gray-200',
+              'p-3'
+            )}
+          >
+            <div className="flex items-center gap-1.5">
+              <Skeleton className="h-7 w-7 rounded-[9px]" />
+              <Skeleton className="h-3 w-14" />
+            </div>
+            <Skeleton className="h-6 w-12" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+        ))}
+      </div>
+      <Skeleton className="h-11 w-full rounded-[12px]" />
+      <div className="space-y-2">
+        <Skeleton className="h-3 w-14" />
+        <div className="flex gap-1.5">
+          <Skeleton shape="pill" className="h-6 w-20" />
+          <Skeleton shape="pill" className="h-6 w-20" />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-[90px] w-full" />
+      </div>
     </div>
   );
 }
@@ -200,7 +309,7 @@ export function PeriodSummarySection(): React.ReactElement {
       error={summaryQuery.error}
       isEmpty={summaryQuery.isSuccess && !summary}
       emptyText="아직 요약할 활동이 없어요."
-      skeletonHeight={320}
+      skeleton={<SummarySkeleton />}
     >
       {summary ? (
         <div className="space-y-5">
@@ -214,92 +323,136 @@ export function PeriodSummarySection(): React.ReactElement {
             onJump={setPeriodKey}
           />
 
-          <div className="grid grid-cols-2 gap-2.5 lg:grid-cols-4">
-            <StatCard
-              label="작성한 일지"
-              value={summary.diaryCount}
-              helper={`전기간 대비 ${formatDelta(summary.diaryCountDelta)}`}
-              tone="brand"
-            />
-            <StatCard label="활동일수" value={summary.activeDays} />
-            <StatCard
-              label="목표 달성률"
-              value={formatPercent(summary.goalCompletionRate)}
-              helper={`달성 ${summary.completedGoalCount}개`}
-              tone="mint"
-            />
-            <StatCard
-              label="기간 내 최장 스트릭"
-              value={summary.maxStreakInPeriod}
-              tone="blue"
-            />
-          </div>
-
+          {/* 기간 전환 중(placeholder)에는 dim, 새 데이터가 오면
+              opacity 만 부드럽게 복귀 — remount 없는 크로스페이드. */}
           <div
             className={cn(
-              'flex flex-wrap items-center gap-2 rounded-[12px]',
-              'bg-gray-50 px-4 py-3'
+              'space-y-5 transition-opacity duration-300 ease-out',
+              summaryQuery.isPlaceholderData && 'opacity-40'
             )}
           >
-            <Text size="caption2" className="text-gray-500">
-              {PEAK_LABEL[summary.unit]}
-            </Text>
-            <Text size="caption1" weight="bold" className="text-gray-900">
-              {summary.peakBucket && summary.peakBucket.count > 0
-                ? `${formatBucketLabel(summary.peakBucket.key)} · ` +
-                  `${summary.peakBucket.count}개`
-                : '없음'}
-            </Text>
-          </div>
+            <div className="grid grid-cols-2 gap-2.5 lg:grid-cols-4">
+              <KpiTile
+                icon={<Icon name="PencilLine" size={14} aria-hidden />}
+                iconClass="bg-main-200 text-main-700"
+                label="작성한 일지"
+                value={summary.diaryCount}
+                unit="개"
+                sub={`전기간 대비 ${formatDelta(summary.diaryCountDelta)}`}
+                subClass="text-main-700"
+              />
+              <KpiTile
+                icon={<Icon name="Calendar" size={14} aria-hidden />}
+                iconClass="bg-blue-200 text-blue-600"
+                label="활동일수"
+                value={summary.activeDays}
+                unit="일"
+              />
+              <KpiTile
+                icon={<Icon name="Target" size={14} aria-hidden />}
+                iconClass="bg-mint-100 text-mint-900"
+                label="목표 달성률"
+                value={formatPercent(summary.goalCompletionRate).replace(
+                  '%',
+                  ''
+                )}
+                unit="%"
+                sub={`달성 ${summary.completedGoalCount}개`}
+                subClass="text-mint-900"
+              />
+              <KpiTile
+                icon={<Icon name="Flame" size={14} aria-hidden />}
+                iconClass="bg-gray-100 text-gray-600"
+                label="최장 스트릭"
+                value={summary.maxStreakInPeriod}
+                unit="일"
+              />
+            </div>
 
-          <div>
-            <Text size="caption2" className="mb-2 block text-gray-500">
-              감정 구성
-            </Text>
-            <div className="flex flex-wrap gap-1.5">
-              {FEELING_ORDER.map((feeling) => {
-                const count =
-                  (summary.feelingBreakdown ?? []).find(
-                    (entry) => entry.feeling === feeling
-                  )?.count ?? 0;
-                // count 0 감정(특히 미선택 NONE)은 칩에서 제외.
-                if (count === 0) {
-                  return null;
-                }
-                const mood = FEELING_MOOD_IMAGE[feeling];
-                return (
-                  <Tag key={feeling} tone="gray" size="sm">
-                    <span className="inline-flex items-center gap-1">
+            <div
+              className={cn(
+                'flex items-center gap-2.5 rounded-[12px]',
+                'bg-main-200 px-4 py-3'
+              )}
+            >
+              <Icon
+                name="Trophy"
+                size={16}
+                className="text-main-700"
+                aria-hidden
+              />
+              <Text size="caption1" weight="bold" className="text-gray-700">
+                {PEAK_LABEL[summary.unit]}
+              </Text>
+              <Text
+                size="caption1"
+                weight="bold"
+                className="text-main-700 ml-auto"
+              >
+                {summary.peakBucket && summary.peakBucket.count > 0
+                  ? `${formatBucketLabel(summary.peakBucket.key)} · ` +
+                    `${summary.peakBucket.count}개`
+                  : '없음'}
+              </Text>
+            </div>
+
+            <div>
+              <Text size="caption2" className="mb-2 block text-gray-500">
+                감정 구성
+              </Text>
+              <div className="flex flex-wrap gap-1.5">
+                {FEELING_ORDER.map((feeling) => {
+                  const count =
+                    (summary.feelingBreakdown ?? []).find(
+                      (entry) => entry.feeling === feeling
+                    )?.count ?? 0;
+                  // count 0 감정(특히 미선택 NONE)은 칩에서 제외.
+                  if (count === 0) {
+                    return null;
+                  }
+                  const mood = FEELING_MOOD_IMAGE[feeling];
+                  return (
+                    <span
+                      key={feeling}
+                      className={cn(
+                        'inline-flex items-center gap-1 rounded-full',
+                        'px-2.5 py-1 text-xs font-bold'
+                      )}
+                      style={{
+                        backgroundColor: FEELING_SOFT_BG[feeling],
+                        color: FEELING_FG[feeling],
+                      }}
+                    >
                       {mood ? (
                         <Image
                           src={mood.src}
                           alt=""
-                          width={16}
-                          height={16}
+                          width={14}
+                          height={14}
                           aria-hidden
                           unoptimized
                         />
                       ) : null}
                       {FEELING_LABEL[feeling]} {count}
                     </span>
-                  </Tag>
-                );
-              })}
+                  );
+                })}
+              </div>
             </div>
-          </div>
 
-          {subTrend.length > 0 ? (
-            <div>
-              <Text size="caption2" className="mb-2 block text-gray-500">
-                기간 내 추이
-              </Text>
-              <TrendBars
-                data={subTrend}
-                compact
-                ariaLabel="기간 내 작성 추이 막대 차트"
-              />
-            </div>
-          ) : null}
+            {subTrend.length > 0 ? (
+              <div>
+                <Text size="caption2" className="mb-2 block text-gray-500">
+                  기간 내 추이
+                </Text>
+                <TrendBars
+                  data={subTrend}
+                  compact
+                  ariaLabel="기간 내 작성 추이 막대 차트"
+                />
+              </div>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </StatisticsCard>

--- a/src/app.feature/member/statistics/components/StatisticsCard.tsx
+++ b/src/app.feature/member/statistics/components/StatisticsCard.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@1d1s/design-system';
+import { Card, SectionHeader, Text } from '@1d1s/design-system';
 import { Skeleton } from '@component/Skeleton';
 import { normalizeApiError } from '@module/api/error';
 import { cn } from '@module/utils/cn';
@@ -17,6 +17,8 @@ interface StatisticsCardProps {
   emptyText?: string;
   /** 로딩 스켈레톤 높이(px) */
   skeletonHeight?: number;
+  /** 레이아웃과 동일한 형태의 커스텀 스켈레톤 (지정 시 기본 블록 대체) */
+  skeleton?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -57,36 +59,34 @@ export function StatisticsCard({
   isEmpty,
   emptyText = '데이터가 아직 없어요.',
   skeletonHeight = 160,
+  skeleton,
   children,
 }: StatisticsCardProps): React.ReactElement {
   return (
-    <section
-      className={cn(
-        'rounded-[16px] border border-gray-200 bg-white',
-        'p-5 lg:p-6'
-      )}
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <Text as="h2" size="body1" weight="bold" className="text-gray-900">
+    <Card radius="lg" className="p-5 lg:p-6">
+      {/* SectionHeader 자체 스케일(max text-lg)로는 마이페이지 헤더
+          (heading2)와 급이 안 맞아 title/subtitle 을 Text 로 직접 지정. */}
+      <SectionHeader
+        title={
+          <Text size="heading2" weight="bold" className="text-gray-900">
             {title}
           </Text>
-          {subtitle ? (
-            <Text
-              as="p"
-              size="caption2"
-              className="mt-0.5 block text-gray-500"
-            >
+        }
+        subtitle={
+          subtitle ? (
+            <Text size="caption1" weight="regular" className="text-gray-500">
               {subtitle}
             </Text>
-          ) : null}
-        </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
-      </div>
+          ) : undefined
+        }
+        action={action}
+      />
 
       <div className="mt-4">
         {isLoading ? (
-          <Skeleton style={{ height: skeletonHeight }} className="w-full" />
+          (skeleton ?? (
+            <Skeleton style={{ height: skeletonHeight }} className="w-full" />
+          ))
         ) : isError ? (
           <StatisticsMessage tone="error">
             {normalizeApiError(error).message}
@@ -94,9 +94,10 @@ export function StatisticsCard({
         ) : isEmpty ? (
           <StatisticsMessage tone="empty">{emptyText}</StatisticsMessage>
         ) : (
-          children
+          // 스켈레톤 → 실데이터 전환 시 mount 되며 페이드 인.
+          <div className="data-fade-in">{children}</div>
         )}
       </div>
-    </section>
+    </Card>
   );
 }

--- a/src/app.feature/member/statistics/components/TrendBars.tsx
+++ b/src/app.feature/member/statistics/components/TrendBars.tsx
@@ -12,9 +12,7 @@ export interface TrendDatum {
 
 interface TrendBarsProps {
   data: TrendDatum[];
-  /** 막대 색 (CSS color) */
-  color?: string;
-  /** 미니 모드: 라벨/값 숨김, 높이 축소 */
+  /** 미니 모드: 막대 영역 높이 축소 */
   compact?: boolean;
   /** 스크린리더용 차트 설명 */
   ariaLabel?: string;
@@ -23,74 +21,79 @@ interface TrendBarsProps {
 
 /**
  * CSS flex 기반 막대 차트 (외부 의존성 없음).
- * 각 bucket 을 최대값 기준 비율 높이 막대로 그린다.
+ * 최댓값 막대를 브랜드색으로 강조하고 나머지는 soft 피치색으로 그린다.
  */
 export function TrendBars({
   data,
-  color = 'var(--main-500)',
   compact = false,
   ariaLabel,
   className,
 }: TrendBarsProps): React.ReactElement {
   const max = data.reduce((m, d) => Math.max(m, d.count), 0);
-  const areaHeight = compact ? 56 : 128;
-  // 최댓값 막대 위 count 라벨이 고정 높이 영역을 넘지 않도록 여백 확보.
-  const labelReserve = compact ? 0 : 18;
+  const areaHeight = compact ? 72 : 128;
+  // 막대 위 count 라벨이 고정 높이 영역을 넘지 않도록 여백 확보.
+  const labelReserve = 18;
   const barArea = Math.max(0, areaHeight - labelReserve);
 
   return (
     <div className={cn('w-full', className)}>
       <div
-        className="flex items-end gap-1"
+        className="flex items-end gap-1.5"
         style={{ height: areaHeight }}
         role="img"
         aria-label={ariaLabel}
       >
         {data.map((d, i) => {
           const heightPx = computeBarHeightPx(d.count, max, barArea);
+          const isPeak = d.count === max && d.count > 0;
+          const barColor =
+            d.count === 0
+              ? 'var(--gray-100)'
+              : isPeak
+                ? 'var(--main-700)'
+                : 'var(--main-400)';
           return (
             <div
               key={`${d.bucket}-${i}`}
-              className="flex min-w-0 flex-1 flex-col items-center justify-end"
+              className={cn(
+                'flex min-w-0 flex-1 flex-col items-center',
+                'justify-end'
+              )}
               title={`${d.label}: ${d.count}`}
             >
-              {!compact && d.count > 0 ? (
+              {d.count > 0 ? (
                 <Text
                   size="caption5"
-                  className="mb-1 block text-gray-500"
+                  weight="bold"
+                  className={cn(
+                    'mb-1 block',
+                    isPeak ? 'text-main-700' : 'text-gray-400'
+                  )}
                 >
                   {d.count}
                 </Text>
               ) : null}
               <div
-                className="w-full rounded-[3px] transition-[height]"
-                style={{
-                  height: heightPx,
-                  backgroundColor: d.count > 0 ? color : 'var(--gray-200)',
-                }}
+                className="w-full rounded-[6px] transition-[height]"
+                style={{ height: heightPx, backgroundColor: barColor }}
               />
             </div>
           );
         })}
       </div>
 
-      {!compact ? (
-        <div className="mt-2 flex gap-1">
-          {data.map((d, i) => (
-            <div
-              key={`${d.bucket}-label-${i}`}
-              className="min-w-0 flex-1 text-center"
-            >
-              <Text
-                size="caption5"
-                className="block truncate text-gray-400"
-              >
-                {d.label}
-              </Text>
-            </div>
-          ))}
-        </div>
-      ) : null}
+      <div className="mt-2 flex gap-1.5">
+        {data.map((d, i) => (
+          <div
+            key={`${d.bucket}-label-${i}`}
+            className="min-w-0 flex-1 text-center"
+          >
+            <Text size="caption5" className="block truncate text-gray-400">
+              {d.label}
+            </Text>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app.feature/member/statistics/hooks/useStatisticsQueries.ts
+++ b/src/app.feature/member/statistics/hooks/useStatisticsQueries.ts
@@ -1,5 +1,9 @@
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useQuery,
+  type UseQueryResult,
+} from '@tanstack/react-query';
 
 import { statisticsApi } from '../api/statisticsApi';
 import { STATISTICS_QUERY_KEYS } from '../consts/queryKeys';
@@ -40,6 +44,8 @@ export function useDiaryTrend(
     queryFn: () => statisticsApi.getDiaryTrend(params),
     enabled: isLoggedIn,
     staleTime: STATISTICS_STALE_TIME,
+    // 단위 전환 시 이전 데이터 유지 — 스켈레톤 레이아웃 쉬프트 방지.
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -66,6 +72,8 @@ export function useStatisticsSummary(
     // 않아 "필수 파라미터 누락" 400 을 방지한다.
     enabled: isLoggedIn && Boolean(params.periodKey),
     staleTime: STATISTICS_STALE_TIME,
+    // 기간 이동 시 이전 데이터 유지 — 스켈레톤 레이아웃 쉬프트 방지.
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -78,5 +86,7 @@ export function useFriendComparison(
     queryFn: () => statisticsApi.getFriendComparison(period),
     enabled: isLoggedIn,
     staleTime: STATISTICS_STALE_TIME,
+    // 기간 전환 시 이전 데이터 유지 — 스켈레톤 레이아웃 쉬프트 방지.
+    placeholderData: keepPreviousData,
   });
 }

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -23,11 +23,29 @@ export const FEELING_MOOD_IMAGE: Record<
 };
 
 // SVG/inline 스타일용 색상 (colors.css 토큰 참조).
+// 무드 SVG 아이콘의 실제 색과 맞춘다 —
+// 좋음=피치(main), 보통=민트(mint), 아쉬움=블루(blue).
 export const FEELING_COLOR: Record<Feeling, string> = {
   HAPPY: 'var(--main-500)',
-  NORMAL: 'var(--blue-400)',
-  SAD: 'var(--red-400)',
+  NORMAL: 'var(--mint-500)',
+  SAD: 'var(--blue-400)',
   NONE: 'var(--gray-300)',
+};
+
+// 감정별 soft 배경 / 강조 텍스트색 — 레전드·칩 무드 컬러 시스템.
+// 팔레트에 파스텔 단계가 없어 color-mix 로 흰색과 섞어 연하게 만든다.
+export const FEELING_SOFT_BG: Record<Feeling, string> = {
+  HAPPY: 'color-mix(in srgb, var(--main-500) 22%, white)',
+  NORMAL: 'color-mix(in srgb, var(--mint-500) 20%, white)',
+  SAD: 'color-mix(in srgb, var(--blue-400) 14%, white)',
+  NONE: 'var(--gray-50)',
+};
+
+export const FEELING_FG: Record<Feeling, string> = {
+  HAPPY: 'var(--main-700)',
+  NORMAL: 'var(--mint-900)',
+  SAD: 'var(--blue-500)',
+  NONE: 'var(--gray-500)',
 };
 
 export function formatPercent(ratio: number): string {


### PR DESCRIPTION
## 변경 사항

### 통계 화면 리디자인 (디자인 시안: 1D1S 통계 개선)
- **무드 컬러 시스템** — 무드 SVG 아이콘 실제 색 기준으로 통일 (좋음=피치, 보통=민트, 아쉬움=블루). 파스텔 soft 배경은 `color-mix`로 생성
- **DS 컴포넌트 교체** — Card/SectionHeader/StatCard/Button/Icon/ProgressBar 적용, lucide 이모지·수제 요소 제거
- **도넛 차트 재구현** — stroke-dasharray 트릭 → 명시적 SVG 패스 아크 (렌더링 아티팩트 제거)
- **막대 차트** — 라운드 바 + 피크 브랜드색 강조, 컬럼 폭 채움

### UX 개선
- 기간/단위 전환 시 `keepPreviousData` + 크로스페이드 → 레이아웃 쉬프트 제거
- 실제 레이아웃과 동일한 구조의 상세 스켈레톤 + 스켈레톤→데이터 페이드 인
- 섹션 타이틀을 마이페이지와 동일한 heading2 급으로 통일
- '친구 비교' → '친구들과 나' 워딩 변경

### 기타
- 마이페이지 활동 통계 헤더에 '더보기 →' 링크 (→ /mypage/statistics)
- 통계 기능 출시 공지 등록 (2026-07-11)

## 검증
- `pnpm lint` 0 errors / `tsc --noEmit` 통과 / 기존 테스트 통과
- 브라우저 수동 확인 완료 (스크린샷 피드백 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new notice announcing the statistics feature update.
  - Added a “더보기” link from My Page to detailed statistics.
  - Enhanced statistics with progress bars, trend charts, friend comparisons, period summaries, and improved feeling indicators.

- **UI Improvements**
  - Refreshed statistics cards, navigation controls, colors, icons, and loading transitions.
  - Improved chart readability and reduced layout shifts when changing periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->