### PR TITLE
feat: 챌린지 종료 후 일지 작성 유예 옵션 반영

### DIFF
--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -46,6 +46,8 @@ export interface ChallengeSummary {
   likeInfo: LikeInfo;
   thumbnailImage?: string | null;
   deleted?: boolean;
+  // 종료 후 2일 유예 동안 일지 작성 허용 여부(생성 시 지정).
+  postEndWriteAllowed?: boolean;
   randomParticipants?: RandomParticipant[];
 }
 
@@ -61,6 +63,8 @@ export interface ChallengeListItem {
   participantCnt: number;
   // 인증샷(사진) 필수 여부(서버 JSON 키: photoRequired).
   photoRequired?: boolean;
+  // 종료 후 2일 유예 동안 일지 작성 허용 여부.
+  postEndWriteAllowed?: boolean;
   liked: boolean;
   likeCnt: number;
   // 공개 범위 — OFFICIAL 일 때 카드를 공식 챌린지로 강조한다.
@@ -74,6 +78,8 @@ export interface ChallengeDetail {
   allowMidJoin?: boolean;
   // 인증샷(사진) 필수 여부(서버 JSON 키: photoRequired).
   photoRequired?: boolean;
+  // 종료 후 2일 유예 동안 일지 작성 허용 여부.
+  postEndWriteAllowed?: boolean;
   myStatus: ParticipantStatus;
   participationRate: number;
   goalCompletionRate: number;
@@ -145,6 +151,8 @@ export interface CreateChallengeRequest {
   allowMidJoin: boolean;
   // 인증샷(사진) 필수 여부(서버 JSON 키: photoRequired, 기본 false).
   photoRequired: boolean;
+  // 종료 후 2일 유예 동안 일지 작성 허용 여부(기본 false).
+  postEndWriteAllowed: boolean;
   thumbnailImage?: string;
   // 공개 범위. 생성 시 PUBLIC 또는 PRIVATE 를 보낸다.
   challengeType: ChallengeType;

--- a/src/app.feature/challenge/board/utils/challengePeriod.test.ts
+++ b/src/app.feature/challenge/board/utils/challengePeriod.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { canWriteDiaryForChallenge } from './challengePeriod';
+
+describe('canWriteDiaryForChallenge', () => {
+  const start = '2026-07-01';
+  const end = '2026-07-10';
+
+  it('진행 중이면 옵션과 무관하게 작성 가능', () => {
+    const now = new Date('2026-07-05T09:00:00+09:00');
+    expect(canWriteDiaryForChallenge(start, end, false, now)).toBe(true);
+  });
+
+  it('무기한 챌린지는 시작 후 항상 작성 가능', () => {
+    const now = new Date('2027-01-01T09:00:00+09:00');
+    expect(canWriteDiaryForChallenge(start, '9999-12-31', false, now)).toBe(
+      true
+    );
+  });
+
+  it('종료 + 옵션 OFF: 작성 불가', () => {
+    const now = new Date('2026-07-11T09:00:00+09:00');
+    expect(canWriteDiaryForChallenge(start, end, false, now)).toBe(false);
+  });
+
+  it('종료 + 옵션 ON + 유예(+2일) 이내: 작성 가능', () => {
+    const now = new Date('2026-07-12T09:00:00+09:00');
+    expect(canWriteDiaryForChallenge(start, end, true, now)).toBe(true);
+  });
+
+  it('종료 + 옵션 ON + 유예 경과(+3일): 작성 불가', () => {
+    const now = new Date('2026-07-13T09:00:00+09:00');
+    expect(canWriteDiaryForChallenge(start, end, true, now)).toBe(false);
+  });
+});

--- a/src/app.feature/challenge/board/utils/challengePeriod.ts
+++ b/src/app.feature/challenge/board/utils/challengePeriod.ts
@@ -1,6 +1,10 @@
 import { toStartOfDay } from '@module/utils/date';
+import { add } from 'date-fns';
 
 const ENDLESS_MIN_YEAR = 2090;
+
+// 종료 후 일지 작성 유예 기간(일). 서버 규칙과 동일하게 종료일 +2일까지 허용.
+const POST_END_WRITE_GRACE_DAYS = 2;
 
 export function isInfiniteChallengeEndDate(endDate?: string | null): boolean {
   const normalizedEndDate = endDate?.trim();
@@ -58,6 +62,32 @@ export function isChallengeEnded(
   }
 
   return toStartOfDay(referenceDate) > end;
+}
+
+/**
+ * 일지 작성 가능 여부. 서버 규칙과 동일하게 판정한다:
+ *   진행 중(무기한 포함) OR (postEndWriteAllowed 이고 종료일 +2일 유예 이내).
+ * 챌린지 상세/카드 등 작성 진입 동선 여러 곳에서 재사용한다.
+ */
+export function canWriteDiaryForChallenge(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+  postEndWriteAllowed?: boolean | null,
+  referenceDate: Date = new Date()
+): boolean {
+  if (isChallengeOngoing(startDate, endDate, referenceDate)) {
+    return true;
+  }
+  if (!postEndWriteAllowed || !endDate || isInfiniteChallengeEndDate(endDate)) {
+    return false;
+  }
+  const end = toStartOfDay(new Date(endDate));
+  if (Number.isNaN(end.getTime())) {
+    return false;
+  }
+  const target = toStartOfDay(referenceDate);
+  const graceEnd = add(end, { days: POST_END_WRITE_GRACE_DAYS });
+  return target > end && target <= graceEnd;
 }
 
 // 참여자가 0명이면 아카이브된 챌린지로 간주해 종료 처리한다.

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -33,6 +33,7 @@ import {
   useChallengeDetail,
 } from '../../board/hooks/useChallengeQueries';
 import {
+  canWriteDiaryForChallenge,
   isChallengeEndedOrArchived,
   isChallengeOngoing,
   isInfiniteChallengeEndDate,
@@ -178,6 +179,12 @@ export function ChallengeDetailScreen({
     summaryEndDate,
     summaryParticipantCnt
   );
+  // 종료됐어도 종료 후 작성 허용 옵션 + 2일 유예 이내면 일지 작성을 살린다.
+  const canWriteDiary = canWriteDiaryForChallenge(
+    summaryStartDate,
+    summaryEndDate,
+    summary?.postEndWriteAllowed
+  );
   const isEndless = isInfiniteChallengeEndDate(summaryEndDate);
   // 챌린지 시작 여부 (시작일이 오늘 이전이면 시작된 것으로 간주)
   const isChallengeStarted =
@@ -188,7 +195,7 @@ export function ChallengeDetailScreen({
     isLoading: isCheckWriteDatesLoading,
   } = useChallengeCheckWriteDates(
     challengeId,
-    isParticipating && isChallengeCurrentlyOngoing
+    isParticipating && canWriteDiary
   );
   const hasWritableRecentDiaryDate = useMemo(
     () => hasSelectableDiaryDate(challengeCheckWriteDateKeys),
@@ -290,7 +297,7 @@ export function ChallengeDetailScreen({
   };
 
   const handleDiaryCreateClick = (): void => {
-    if (!isChallengeCurrentlyOngoing || isCheckWriteDatesLoading) {
+    if (!canWriteDiary || isCheckWriteDatesLoading) {
       return;
     }
 
@@ -425,7 +432,7 @@ export function ChallengeDetailScreen({
     isHost,
     isParticipating,
     isJoinRequestPending,
-    isChallengeCurrentlyOngoing,
+    canWriteDiary,
     isCheckWriteDatesLoading,
     canJoinByStatus,
     isChallengeAlreadyEnded,

--- a/src/app.feature/challenge/detail/utils/challengeCta.test.ts
+++ b/src/app.feature/challenge/detail/utils/challengeCta.test.ts
@@ -9,7 +9,7 @@ function makeParams(
     isHost: false,
     isParticipating: false,
     isJoinRequestPending: false,
-    isChallengeCurrentlyOngoing: false,
+    canWriteDiary: false,
     isCheckWriteDatesLoading: false,
     canJoinByStatus: false,
     isChallengeAlreadyEnded: false,
@@ -26,7 +26,7 @@ function makeParams(
 describe('buildChallengeCta', () => {
   it('호스트 + 진행 중: 일지 작성 primary + 수정 secondary', () => {
     const cta = buildChallengeCta(
-      makeParams({ isHost: true, isChallengeCurrentlyOngoing: true })
+      makeParams({ isHost: true, canWriteDiary: true })
     );
     expect(cta.label).toBe('일지 작성하기');
     expect(cta.variant).toBe('primary');
@@ -35,7 +35,7 @@ describe('buildChallengeCta', () => {
 
   it('호스트 + 종료: 챌린지 수정 단독 노출', () => {
     const cta = buildChallengeCta(
-      makeParams({ isHost: true, isChallengeCurrentlyOngoing: false })
+      makeParams({ isHost: true, canWriteDiary: false })
     );
     expect(cta.label).toBe('챌린지 수정');
     expect(cta.disabled).toBe(false);
@@ -44,7 +44,7 @@ describe('buildChallengeCta', () => {
 
   it('참여 중 + 진행 아님: 비활성 "진행 중이 아닙니다"', () => {
     const cta = buildChallengeCta(
-      makeParams({ isParticipating: true, isChallengeCurrentlyOngoing: false })
+      makeParams({ isParticipating: true, canWriteDiary: false })
     );
     expect(cta.label).toBe('진행 중이 아닙니다');
     expect(cta.disabled).toBe(true);
@@ -54,7 +54,7 @@ describe('buildChallengeCta', () => {
     const cta = buildChallengeCta(
       makeParams({
         isParticipating: true,
-        isChallengeCurrentlyOngoing: true,
+        canWriteDiary: true,
         isCheckWriteDatesLoading: true,
       })
     );

--- a/src/app.feature/challenge/detail/utils/challengeCta.ts
+++ b/src/app.feature/challenge/detail/utils/challengeCta.ts
@@ -21,7 +21,8 @@ export interface BuildChallengeCtaParams {
   // 참여 신청 후 호스트 승인 대기 상태 (myStatus === 'PENDING').
   // 뮤테이션의 isPending 과 혼동되지 않도록 명시적으로 명명한다.
   isJoinRequestPending: boolean;
-  isChallengeCurrentlyOngoing: boolean;
+  // 일지 작성 가능 여부(진행 중 또는 종료 후 유예 이내). 작성 CTA 노출 기준.
+  canWriteDiary: boolean;
   isCheckWriteDatesLoading: boolean;
   canJoinByStatus: boolean;
   isChallengeAlreadyEnded: boolean;
@@ -59,7 +60,7 @@ export function buildChallengeCta(
     isHost,
     isParticipating,
     isJoinRequestPending,
-    isChallengeCurrentlyOngoing,
+    canWriteDiary,
     isCheckWriteDatesLoading,
     canJoinByStatus,
     isChallengeAlreadyEnded,
@@ -77,9 +78,9 @@ export function buildChallengeCta(
       onClick: onEditChallenge,
       variant: 'secondary' as const,
     };
-    // 호스트도 참여자이므로 진행 중에는 일지 작성을 우선 CTA 로 노출하고
+    // 호스트도 참여자이므로 작성 가능 기간에는 일지 작성을 우선 CTA 로 노출하고
     // 챌린지 수정은 보조 버튼으로 함께 제공한다.
-    if (isChallengeCurrentlyOngoing) {
+    if (canWriteDiary) {
       return {
         label: '일지 작성하기',
         onClick: onDiaryCreate,
@@ -97,11 +98,9 @@ export function buildChallengeCta(
   }
   if (isParticipating) {
     return {
-      label: isChallengeCurrentlyOngoing
-        ? '일지 작성하기'
-        : '진행 중이 아닙니다',
+      label: canWriteDiary ? '일지 작성하기' : '진행 중이 아닙니다',
       onClick: onDiaryCreate,
-      disabled: !isChallengeCurrentlyOngoing || isCheckWriteDatesLoading,
+      disabled: !canWriteDiary || isCheckWriteDatesLoading,
       variant: 'primary',
       show: true,
     };

--- a/src/app.feature/challenge/write/components/ChallengeCreatePostEndWriteSection.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeCreatePostEndWriteSection.tsx
@@ -1,0 +1,51 @@
+import { SegmentedControl, Text } from '@1d1s/design-system';
+import { useFormContext } from 'react-hook-form';
+
+import { FormControl, FormField, FormItem } from '@/app.component/ui/Form';
+
+import { ChallengeCreateFormValues } from '../hooks/useChallengeCreateForm';
+import { ChallengeCreateSectionCard } from './ChallengeCreateSectionCard';
+
+type SectionElement = React.ReactElement | null;
+
+export function ChallengeCreatePostEndWriteSection(): SectionElement {
+  const { control, watch } = useFormContext<ChallengeCreateFormValues>();
+
+  // 무제한 챌린지는 종료일이 없어 유예 개념이 성립하지 않는다.
+  if (watch('periodType') === 'ENDLESS') {
+    return null;
+  }
+
+  return (
+    <ChallengeCreateSectionCard step={7} title="종료 후 작성">
+      <FormField
+        control={control}
+        name="postEndWriteAllowed"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <SegmentedControl
+                value={field.value ? 'ALLOWED' : 'BLOCKED'}
+                onValueChange={(value) => field.onChange(value === 'ALLOWED')}
+                aria-label="종료 후 일지 작성 허용 여부"
+                options={[
+                  { value: 'BLOCKED', label: '불가' },
+                  { value: 'ALLOWED', label: '허용' },
+                ]}
+              />
+            </FormControl>
+            <Text
+              size="caption1"
+              weight="regular"
+              className="mt-1 block text-gray-500"
+            >
+              {field.value
+                ? '챌린지 종료 후 2일간 일지를 작성할 수 있어요.'
+                : '챌린지가 종료되면 더 이상 일지를 작성할 수 없어요.'}
+            </Text>
+          </FormItem>
+        )}
+      />
+    </ChallengeCreateSectionCard>
+  );
+}

--- a/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
+++ b/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
@@ -35,6 +35,8 @@ export const challengeCreateFormSchema = z
     goalType: z.enum(['FIXED', 'FLEXIBLE']),
     allowMidJoin: z.boolean(),
     isPhotoRequired: z.boolean(),
+    // 종료 후 2일 유예 동안 일지 작성 허용 여부.
+    postEndWriteAllowed: z.boolean(),
     // 공개 범위 — 생성 시에는 공개/비공개만 선택할 수 있다.
     challengeType: z.enum(['PUBLIC', 'PRIVATE']),
     password: z.string().optional(),
@@ -159,6 +161,7 @@ export function useChallengeCreateForm(): ReturnType<
       // 허용으로 둔다. 작성자는 필요 시 토글로 비허용으로 바꿀 수 있다.
       allowMidJoin: true,
       isPhotoRequired: false,
+      postEndWriteAllowed: false,
       challengeType: 'PUBLIC',
       password: '',
       goals: [],

--- a/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
@@ -20,6 +20,7 @@ import { ChallengeCreateGoalSection } from '@feature/challenge/write/components/
 import { ChallengeCreateParticipationSection } from '@feature/challenge/write/components/ChallengeCreateParticipationSection';
 import { ChallengeCreatePeriodSection } from '@feature/challenge/write/components/ChallengeCreatePeriodSection';
 import { ChallengeCreatePhotoSection } from '@feature/challenge/write/components/ChallengeCreatePhotoSection';
+import { ChallengeCreatePostEndWriteSection } from '@feature/challenge/write/components/ChallengeCreatePostEndWriteSection';
 import { ChallengeCreatePreviewCard } from '@feature/challenge/write/components/ChallengeCreatePreviewCard';
 import { ChallengeCreateSuccessDialog } from '@feature/challenge/write/components/ChallengeCreateSuccessDialog';
 import { ChallengeCreateVisibilitySection } from '@feature/challenge/write/components/ChallengeCreateVisibilitySection';
@@ -99,6 +100,7 @@ export default function ChallengeCreateScreen(): React.ReactElement {
               <ChallengeCreatePeriodSection />
               <ChallengeCreateVisibilitySection />
               <ChallengeCreatePhotoSection />
+              <ChallengeCreatePostEndWriteSection />
             </div>
 
             <aside className="hidden lg:block">

--- a/src/app.feature/challenge/write/utils/challengeCreatePayload.test.ts
+++ b/src/app.feature/challenge/write/utils/challengeCreatePayload.test.ts
@@ -19,6 +19,7 @@ function makeValues(
     goalType: 'FIXED',
     allowMidJoin: true,
     isPhotoRequired: false,
+    postEndWriteAllowed: false,
     challengeType: 'PUBLIC',
     startDate: new Date(2026, 6, 10),
     goals: [{ value: '매일 커밋' }],
@@ -114,8 +115,16 @@ describe('formatFormValues', () => {
       participationType: 'INDIVIDUAL',
       goals: ['매일 커밋'],
       photoRequired: false,
+      postEndWriteAllowed: false,
       challengeType: 'PUBLIC',
     });
+  });
+
+  it('passes postEndWriteAllowed through to the payload', () => {
+    const payload = formatFormValues(
+      makeValues({ postEndWriteAllowed: true })
+    );
+    expect(payload.postEndWriteAllowed).toBe(true);
   });
 
   it('forces allowMidJoin to false for an individual challenge', () => {

--- a/src/app.feature/challenge/write/utils/challengeCreatePayload.ts
+++ b/src/app.feature/challenge/write/utils/challengeCreatePayload.ts
@@ -65,6 +65,7 @@ export function formatFormValues(
       values.participationType === 'INDIVIDUAL' ? false : values.allowMidJoin,
     // 와이어(서버) 키는 photoRequired, 폼 내부 필드명은 isPhotoRequired.
     photoRequired: values.isPhotoRequired,
+    postEndWriteAllowed: values.postEndWriteAllowed,
     thumbnailImage: values.thumbnailImageKey,
     challengeType: values.challengeType,
     // 비공개일 때만 비밀번호를 동봉한다.

--- a/src/app.feature/diary/write/consts/postEndWrite.ts
+++ b/src/app.feature/diary/write/consts/postEndWrite.ts
@@ -1,0 +1,6 @@
+// 종료 후 일지 작성 유예가 지났을 때 백엔드가 내려주는 도메인 에러 코드.
+export const POST_END_WRITE_EXPIRED_ERROR_CODE = 'DIARY-011';
+
+// 프론트는 버튼으로 이미 막지만, 위반 응답을 받았을 때 공통으로 쓰는 안내 문구.
+export const POST_END_WRITE_EXPIRED_MESSAGE =
+  '챌린지 종료 후 일지 작성 가능 기간이 지났습니다.';

--- a/src/app.feature/diary/write/hooks/useDiaryCreateForm.ts
+++ b/src/app.feature/diary/write/hooks/useDiaryCreateForm.ts
@@ -1,4 +1,4 @@
-import { isChallengeOngoing } from '@feature/challenge/board/utils/challengePeriod';
+import { canWriteDiaryForChallenge } from '@feature/challenge/board/utils/challengePeriod';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { formatDateISO } from '@module/utils/date';
 import { useSearchParams } from 'next/navigation';
@@ -138,10 +138,15 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
       ),
     [sidebarData]
   );
+  // 진행 중 + 종료 후 작성 유예 이내 챌린지를 작성 대상으로 노출한다.
   const ongoingMemberChallenges = useMemo(
     () =>
       memberChallenges.filter((challenge) =>
-        isChallengeOngoing(challenge.startDate, challenge.endDate)
+        canWriteDiaryForChallenge(
+          challenge.startDate,
+          challenge.endDate,
+          challenge.postEndWriteAllowed
+        )
       ),
     [memberChallenges]
   );
@@ -254,9 +259,10 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
     ? selectedChallenge.participantCnt === 0
     : false;
   const isSelectedChallengeOngoing = selectedChallenge
-    ? isChallengeOngoing(
+    ? canWriteDiaryForChallenge(
         selectedChallenge.startDate,
-        selectedChallenge.endDate
+        selectedChallenge.endDate,
+        selectedChallenge.postEndWriteAllowed
       ) && !isSelectedChallengeArchived
     : false;
 

--- a/src/app.feature/diary/write/hooks/useDiarySubmit.ts
+++ b/src/app.feature/diary/write/hooks/useDiarySubmit.ts
@@ -16,6 +16,10 @@ import {
   PHOTO_REQUIRED_ERROR_CODE,
   PHOTO_REQUIRED_MESSAGE,
 } from '../consts/photoRequired';
+import {
+  POST_END_WRITE_EXPIRED_ERROR_CODE,
+  POST_END_WRITE_EXPIRED_MESSAGE,
+} from '../consts/postEndWrite';
 import type { DiaryImageItem } from '../utils/diaryFormHelpers';
 import {
   getSubmitButtonLabel,
@@ -173,11 +177,14 @@ export function useDiarySubmit({
       router.push('/diary');
     } catch (error) {
       submitSuccessRef.current = false;
-      // 프론트에서 이미 막지만, 백엔드 사진 필수 위반 응답도 방어적으로 처리.
+      // 프론트에서 이미 막지만, 백엔드 도메인 위반 응답도 방어적으로 처리한다.
+      const errorCode = getApiErrorCode(error);
       toast.error(
-        getApiErrorCode(error) === PHOTO_REQUIRED_ERROR_CODE
+        errorCode === PHOTO_REQUIRED_ERROR_CODE
           ? PHOTO_REQUIRED_MESSAGE
-          : '일지 저장 또는 이미지 업로드에 실패했습니다.'
+          : errorCode === POST_END_WRITE_EXPIRED_ERROR_CODE
+            ? POST_END_WRITE_EXPIRED_MESSAGE
+            : '일지 저장 또는 이미지 업로드에 실패했습니다.'
       );
     }
   }, [

--- a/src/app.feature/diary/write/utils/diaryFormHelpers.ts
+++ b/src/app.feature/diary/write/utils/diaryFormHelpers.ts
@@ -181,6 +181,7 @@ export function mapSidebarChallengeToChallengeListItem(
     liked: challenge.likeInfo.likedByMe,
     likeCnt: challenge.likeInfo.likeCnt,
     thumbnailImage: challenge.thumbnailImage ?? undefined,
+    postEndWriteAllowed: challenge.postEndWriteAllowed,
   };
 }
 

--- a/src/app.feature/member/type/member.ts
+++ b/src/app.feature/member/type/member.ts
@@ -14,6 +14,8 @@ export interface SidebarChallenge {
   participationType: string;
   participantCnt: number;
   thumbnailImage?: string | null;
+  // 종료 후 2일 유예 동안 일지 작성 허용 여부.
+  postEndWriteAllowed?: boolean;
   likeInfo: {
     likedByMe: boolean;
     likeCnt: number;


### PR DESCRIPTION
## 배경
서버(#319)에 챌린지 boolean 옵션 `postEndWriteAllowed`가 추가됨(생성 시 지정). 종료된 챌린지라도 옵션 ON이면 종료일 +2일까지 일지 작성을 허용한다. 서버 규칙과 동일하게 프론트에 반영.

## 변경 사항
- **생성 폼**: `ChallengeCreatePostEndWriteSection`(step 7, "종료 후 작성" 토글) 추가. 생성 요청에 `postEndWriteAllowed` 전송(기본 false). 무기한 챌린지는 종료일이 없어 미노출.
- **타입**: `CreateChallengeRequest`(필수)·`ChallengeSummary`/`ChallengeDetail`/`ChallengeListItem`/`SidebarChallenge`(옵셔널)에 `postEndWriteAllowed` 추가. 수정 폼은 서버가 생성 시에만 받으므로 범위 밖.
- **작성 가능 판정**: 공용 헬퍼 `canWriteDiaryForChallenge(startDate, endDate, postEndWriteAllowed, now)` 추가 — `진행 중(무기한 포함) || (옵션 ON && 종료일 +2일 유예 이내)`. 기존 KST 날짜 유틸 재사용.
  - 적용 지점: 챌린지 상세 CTA(`buildChallengeCta`의 `canWriteDiary`), `useChallengeCheckWriteDates` enable, `handleDiaryCreateClick`, 일지 작성 폼의 선택 가능 챌린지 필터(`useDiaryCreateForm`).
  - → 종료된 챌린지라도 옵션 ON + 유예 이내면 "일지 작성하기" 버튼이 살아난다.
- **에러 처리(방어)**: 제출 시 서버 `DIARY-011`(400) 응답을 전용 안내 토스트로 처리.

## 검증
- `tsc --noEmit` ✅ / `pnpm lint` ✅(신규 에러 0) / `pnpm test` ✅(108 pass, 헬퍼·페이로드 테스트 추가) / `pnpm knip` ✅ / `pnpm build` ✅
- 브라우저 동작 확인은 하지 않음(리뷰어가 직접 확인).