### PR TITLE
fix: refresh 재사용 감지(AUTH-012) 시 서버 세션 정리

### DIFF
--- a/src/app.module/api/error.test.ts
+++ b/src/app.module/api/error.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { isInvalidRefreshTokenError } from './error';
+
+const axiosErrorWithCode = (code: string): unknown => ({
+  isAxiosError: true,
+  response: { status: 401, data: { code } },
+});
+
+describe('isInvalidRefreshTokenError', () => {
+  // 서버가 쿠키를 만료시키지 않는 재사용 감지(AUTH-012)도 복구 불가로 보고
+  // /auth/logout 정리를 트리거해야 한다.
+  it.each(['AUTH-006', 'AUTH-012'])('treats %s as unrecoverable', (code) => {
+    expect(isInvalidRefreshTokenError(axiosErrorWithCode(code))).toBe(true);
+  });
+
+  it('ignores recoverable/other codes', () => {
+    expect(isInvalidRefreshTokenError(axiosErrorWithCode('AUTH-007'))).toBe(
+      false
+    );
+    expect(isInvalidRefreshTokenError(new Error('boom'))).toBe(false);
+  });
+});

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -79,9 +79,13 @@ const getResponseCode = (payload: unknown): string | null => {
     : null;
 };
 
-// 백엔드가 내려주는 refresh token 무효/형식 오류 코드. 상태 코드와 무관하게
-// 세션을 복구할 수 없으므로 로컬 토큰을 정리해야 한다(예: AUTH-006).
-const INVALID_REFRESH_TOKEN_CODES = new Set(['AUTH-006']);
+// 복구 불가능한 refresh token 상태 코드. 상태 코드와 무관하게 세션을 복구할
+// 수 없으므로 로컬 토큰 정리 + 서버 쿠키 만료(/auth/logout)까지 해야 한다.
+//   - AUTH-006: refresh token 무효/형식 오류
+//   - AUTH-012: 회전형 refresh 재사용 감지. 서버가 쿠키를 만료시키지 않으므로
+//     클라가 /auth/logout 으로 HttpOnly 쿠키를 정리하지 않으면, 미들웨어가
+//     남은 access 쿠키를 보고 힌트를 재발급해 강제 로그아웃이 되돌려진다.
+const INVALID_REFRESH_TOKEN_CODES = new Set(['AUTH-006', 'AUTH-012']);
 
 // 백엔드 도메인 에러 코드(예: CHALLENGE_022)를 응답 본문에서 추출한다.
 // 상태 코드만으로 구분할 수 없는 분기 처리에 사용한다.


### PR DESCRIPTION
## 배경
서버 RTR 계약상 refresh **재사용 감지(AUTH-012)** 는 `401` 로 응답하지만 **서버가 토큰 쿠키를 만료시키지 않는다**. 클라가 세션 무효로 보고 강제 로그아웃 + `/auth/logout` 으로 HttpOnly 쿠키를 정리해야 한다.

## 문제
- `handleAuthError` 는 `invalidRefresh`(= `INVALID_REFRESH_TOKEN_CODES`)일 때만 `clearServerSession()`(`/auth/logout`)을 호출했고, 이 집합에는 `AUTH-006` 만 있었다.
- `AUTH-012` 는 401 이라 **로컬 힌트/플래그만** 정리되고 서버 HttpOnly 쿠키(`accessToken`/`refreshToken`)는 그대로 남았다.
- 이후 `middleware/auth.ts::restoreSessionHintCookies` 가 남아있는 `accessToken` 쿠키를 보고 세션 힌트를 **재발급** → 강제 로그아웃이 되돌려지고, 재사용 감지된(잠재적 탈취) 세션이 access TTL 만료까지 유지됨. 재사용된 refresh 쿠키도 계속 잔존.

> 사이드바 경로(`forceLogout` → `/auth/logout`)는 자체 401 을 이미 커버하지만, 일반 `apiClient` 인터셉터 경로는 커버하지 못했다.

## 변경
- `INVALID_REFRESH_TOKEN_CODES` 에 `AUTH-012` 추가 → `AUTH-006` 과 동일하게 로컬 정리 + `/auth/logout` 서버 쿠키 만료 수행.
- `error.test.ts` 추가(AUTH-006/012 → unrecoverable, 그 외 → false).

## 검증
tsc / lint / vitest(109 pass) / knip / build 통과. 브라우저 실측은 미수행(정적 검증까지만).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh-token error handling to recognize an additional invalid-token scenario.
  * Ensures affected sessions can be properly signed out and local authentication data cleared.

* **Tests**
  * Added coverage for recognized and unrecognized authentication errors, including non-network errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->