### PR TITLE
fix: 로그인 힌트 변화를 반응형으로 구독해 로그아웃 오표시 해결

### DIFF
--- a/src/app.component/layout/useAuthLayoutState.ts
+++ b/src/app.component/layout/useAuthLayoutState.ts
@@ -3,8 +3,8 @@
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { useUnreadCount } from '@feature/notification/hooks/useNotificationQueries';
 import { NOOP_SUBSCRIBE } from '@module/hooks/useHasMounted';
-import { authStorage } from '@module/utils/auth';
-import { useEffect, useMemo, useReducer, useSyncExternalStore } from 'react';
+import { useHasSessionHint } from '@module/hooks/useHasSessionHint';
+import { useMemo, useSyncExternalStore } from 'react';
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 const ENDLESS_MIN_YEAR = 2090;
@@ -108,61 +108,12 @@ export function useAuthLayoutState(): AuthLayoutState {
   );
   const now = useSyncExternalStore(NOOP_SUBSCRIBE, getMountTimestamp, () => 0);
 
-  // 콜드 PWA(사파리 홈화면 앱) 런치에서 cookie/localStorage 복원이 한 박자
-  // 늦으면 첫 렌더의 authStorage.hasTokens() 가 false 로 굳어 useSidebar 쿼리가
-  // 비활성 상태로 멈춘다 → 로그인 사용자가 게스트로 보이고, 앱을 재실행하면
-  // 정상화된다. mount 직후 짧게(최대 ~0.9s) 재확인해 토큰이 보이면 re-render 를
-  // 유발, 아래 useSidebar 의 enabled(=hasTokens()) 를 다시 평가시킨다.
-  // (데이터 페칭은 그대로 TanStack Query 가 담당한다.)
-  const [, revalidateAuth] = useReducer((count: number) => count + 1, 0);
-  useEffect(() => {
-    let attempts = 0;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const recheck = (): void => {
-      attempts += 1;
-      if (authStorage.hasTokens()) {
-        revalidateAuth();
-        return;
-      }
-      if (attempts < 6) {
-        timer = setTimeout(recheck, 150);
-      }
-    };
-    if (!authStorage.hasTokens()) {
-      timer = setTimeout(recheck, 150);
-    }
-
-    // 재접속(PWA 백그라운드 복귀 / BFCache 복원 / 탭 재포커스) 시 토큰 힌트를
-    // 다시 평가한다. 레이아웃은 soft navigation 으로 재마운트되지 않으므로 이
-    // 이벤트가 없으면, 최초 폴링이 끝난 뒤 게스트 오인이 새로고침 전까지
-    // 고착된다(= "다시 접속하면 로그아웃처럼 보이는" 문제). hasTokens() 가
-    // 다시 true 로 보이면 re-render 를 유발해 useSidebar 의 enabled(=hasTokens)
-    // 를 재평가시켜 비활성 상태의 쿼리를 되살린다.
-    const revalidateIfAuthed = (): void => {
-      if (authStorage.hasTokens()) {
-        revalidateAuth();
-      }
-    };
-    const onVisibilityChange = (): void => {
-      if (document.visibilityState === 'visible') {
-        revalidateIfAuthed();
-      }
-    };
-    window.addEventListener('focus', revalidateIfAuthed);
-    window.addEventListener('pageshow', revalidateIfAuthed);
-    document.addEventListener('visibilitychange', onVisibilityChange);
-
-    return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      window.removeEventListener('focus', revalidateIfAuthed);
-      window.removeEventListener('pageshow', revalidateIfAuthed);
-      document.removeEventListener('visibilitychange', onVisibilityChange);
-    };
-  }, []);
-
-  const hasTokenHint = hasMounted && authStorage.hasTokens();
+  // 로그인 힌트 변화를 구독한다. 재발급/미들웨어가 세션을 복구해 힌트가
+  // 나타나면(콜드 PWA 런치의 지연 복원, BFCache 복귀, 탭 재포커스, SPA 이동 중
+  // 재발급 성공 포함) 즉시 재렌더돼 useSidebar 의 enabled(=hasTokens) 가
+  // 재평가된다. 예전엔 폴링 reducer 로 흉내냈으나, 이벤트 기반 구독으로 대체해
+  // 전체 새로고침(=미들웨어 재실행) 없이도 로그인 상태를 스스로 복구한다.
+  const hasTokenHint = useHasSessionHint();
 
   const {
     data: sidebarData,

--- a/src/app.feature/member/hooks/useIsLoggedIn.ts
+++ b/src/app.feature/member/hooks/useIsLoggedIn.ts
@@ -1,6 +1,4 @@
-import { NOOP_SUBSCRIBE } from '@module/hooks/useHasMounted';
-import { authStorage } from '@module/utils/auth';
-import { useSyncExternalStore } from 'react';
+import { useHasSessionHint } from '@module/hooks/useHasSessionHint';
 
 import { useSidebar } from './useMemberQueries';
 
@@ -17,15 +15,11 @@ import { useSidebar } from './useMemberQueries';
  * 반드시 이 훅을 사용할 것.
  */
 export function useIsLoggedIn(): boolean {
-  const hasMounted = useSyncExternalStore(
-    NOOP_SUBSCRIBE,
-    () => true,
-    () => false
-  );
+  // 힌트 변화를 구독한다. 재발급/미들웨어가 세션을 복구해 힌트가 나타나면
+  // 즉시 재렌더돼 useSidebar 가 활성화되고, 서버 라운드트립으로 로그인이
+  // 확정된다. (하이드레이션 중에는 false → 서버 결과와 일치)
+  const hasSessionHint = useHasSessionHint();
   const { data, isLoading, isFetching } = useSidebar();
-  const hasTokenHint = hasMounted && authStorage.hasTokens();
 
-  return (
-    hasMounted && hasTokenHint && (Boolean(data) || isLoading || isFetching)
-  );
+  return hasSessionHint && (Boolean(data) || isLoading || isFetching);
 }

--- a/src/app.module/hooks/useHasSessionHint.ts
+++ b/src/app.module/hooks/useHasSessionHint.ts
@@ -1,0 +1,70 @@
+import { authStorage } from '@module/utils/auth';
+import { useSyncExternalStore } from 'react';
+
+// 콜드 PWA(사파리 홈화면 앱) 런치에서 cookie/localStorage 복원이 한 박자 늦으면
+// 첫 스냅샷이 false 로 굳는다. mount 직후 짧게 재확인해 뒤늦게 나타난 힌트를
+// 반영한다. (markAuthenticated 를 거치지 않고 OS/미들웨어가 심은 쿠키 대비)
+const COLD_START_RECHECK_MS = 150;
+const COLD_START_MAX_ATTEMPTS = 6;
+
+/**
+ * 로그인 힌트(hasTokens) 변화를 구독한다.
+ *
+ * 힌트는 JS 에서 반응형이 아니라, 미들웨어/재발급이 세션을 복구해도(=힌트 set)
+ * 이를 읽는 컴포넌트가 저절로 re-render 되지 않았다. 그 결과 useSidebar 의
+ * enabled(=hasTokens) 가 재평가되지 않아 전체 새로고침(=미들웨어 재실행) 전까지
+ * 로그아웃처럼 보였다. SPA 이동은 미들웨어를 타지 않아 고착됐다.
+ *
+ * 이 hook 은 authStorage 변경 이벤트 + focus/pageshow/visibility + 콜드스타트
+ * 폴링을 구독원으로 삼아, 힌트가 나타나는 즉시 재렌더 → useSidebar 재활성화 →
+ * 서버 라운드트립(사이드바)으로 로그인 확정되게 한다.
+ *
+ * SSR/하이드레이션 중에는 getServerSnapshot 이 false 를 돌려주어 서버 결과와
+ * 어긋나지 않는다(기존 hasMounted 게이팅과 동일).
+ */
+function subscribe(onChange: () => void): () => void {
+  const unsubscribeStore = authStorage.subscribe(onChange);
+
+  const onVisibility = (): void => {
+    if (document.visibilityState === 'visible') {
+      onChange();
+    }
+  };
+  window.addEventListener('focus', onChange);
+  window.addEventListener('pageshow', onChange);
+  document.addEventListener('visibilitychange', onVisibility);
+
+  let attempts = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const recheck = (): void => {
+    attempts += 1;
+    if (authStorage.hasTokens()) {
+      onChange();
+      return;
+    }
+    if (attempts < COLD_START_MAX_ATTEMPTS) {
+      timer = setTimeout(recheck, COLD_START_RECHECK_MS);
+    }
+  };
+  if (!authStorage.hasTokens()) {
+    timer = setTimeout(recheck, COLD_START_RECHECK_MS);
+  }
+
+  return () => {
+    unsubscribeStore();
+    window.removeEventListener('focus', onChange);
+    window.removeEventListener('pageshow', onChange);
+    document.removeEventListener('visibilitychange', onVisibility);
+    if (timer) {
+      clearTimeout(timer);
+    }
+  };
+}
+
+export function useHasSessionHint(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => authStorage.hasTokens(),
+    () => false
+  );
+}

--- a/src/app.module/utils/auth.test.ts
+++ b/src/app.module/utils/auth.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { authStorage } from './auth';
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('authStorage subscribe', () => {
+  it('notifies subscribers on markAuthenticated and clearTokens', () => {
+    const listener = vi.fn();
+    const unsubscribe = authStorage.subscribe(listener);
+
+    authStorage.markAuthenticated();
+    authStorage.clearTokens();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    authStorage.markAuthenticated();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app.module/utils/auth.ts
+++ b/src/app.module/utils/auth.ts
@@ -22,7 +22,26 @@ function hasReadableAccessTokenCookie(): boolean {
   );
 }
 
+// 로그인 힌트(쿠키/localStorage) 변화를 구독자에게 알린다. 힌트 값은 JS 에서
+// 반응형이 아니라, markAuthenticated/clearTokens 로 바뀌어도 이를 읽는
+// 컴포넌트가 저절로 re-render 되지 않는다. 그 결과 미들웨어/재발급이 세션을
+// 복구해도(=힌트 set) useSidebar 의 enabled(=hasTokens) 가 재평가되지 않아
+// 전체 새로고침 전까지 로그아웃처럼 보였다. useSyncExternalStore 구독으로
+// 힌트 변화를 즉시 UI 에 반영한다. (useHasSessionHint 참조)
+type AuthListener = () => void;
+const authListeners = new Set<AuthListener>();
+const notifyAuthChange = (): void => {
+  authListeners.forEach((listener) => listener());
+};
+
 export const authStorage = {
+  subscribe: (listener: AuthListener): (() => void) => {
+    authListeners.add(listener);
+    return () => {
+      authListeners.delete(listener);
+    };
+  },
+
   markAuthenticated: (): void => {
     if (typeof window === 'undefined') {
       return;
@@ -37,6 +56,7 @@ export const authStorage = {
       sameSite: 'lax',
       secure: window.location.protocol === 'https:',
     });
+    notifyAuthChange();
   },
 
   // 인증 상태 플래그 제거 (실제 토큰은 백엔드 Set-Cookie/HTTP-only로 관리)
@@ -48,6 +68,7 @@ export const authStorage = {
     // 저장되지 않은 잔존 쿠키를 완전히 정리하기 위함)
     Cookies.remove(AUTH_HINT_COOKIE);
     Cookies.remove(AUTH_HINT_COOKIE, { domain: AUTH_HINT_COOKIE_DOMAIN });
+    notifyAuthChange();
   },
 
   /**


### PR DESCRIPTION
## 증상
- 웹앱 접속 시 **두 번에 한 번꼴로 로그아웃처럼** 보임.
- **전체 새로고침(껐다 켜기)** 하면 로그인으로 보이고, **SPA 내 이동**에선 계속 로그아웃처럼 보임.
- 실제 세션(HttpOnly 쿠키)은 유효한데 UI 만 로그아웃 상태.

## 근본 원인
로그인 판정(`useIsLoggedIn`, `useAuthLayoutState`)이 JS 읽기용 힌트 `authStorage.hasTokens()` 에 의존하고, `useSidebar` 도 `enabled: !isServer && authStorage.hasTokens()` 로 게이팅됨.
- `hasTokens()` 는 **반응형이 아님** — 미들웨어(`middleware/auth.ts::restoreSessionHintCookies`)나 재발급(`markAuthenticated`)이 세션을 복구해 힌트를 set 해도, 이를 읽는 컴포넌트가 재렌더되지 않아 `useSidebar.enabled` 가 재평가되지 않음 → **서버 라운드트립(사이드바)이 일어나지 않아** 로그인 확정이 안 됨.
- **전체 새로고침** 은 미들웨어가 SSR 단계에서 힌트를 Set-Cookie 로 심어 하이드레이션 시점에 이미 `hasTokens()=true` → 로그인. **SPA 이동은 미들웨어를 안 타서** 힌트가 없거나(세션 중 일시적 401 → `handleAuthError` 로 clear) 뒤늦게 복원돼도 UI 가 굳음.
- **두 번에 한 번**: access 토큰 만료 여부에 따라 힌트 복원 타이밍(미들웨어 restore 는 access 쿠키가 있어야 동작)이 갈려 로드마다 로그인/로그아웃이 교대로 나타남. `useIsLoggedIn`(약 30개 컴포넌트 사용)에는 `useAuthLayoutState` 가 갖고 있던 폴링/재평가 워크어라운드조차 없어 더 잘 드러남.

## 수정 (동작 보존, 이벤트 기반 반응형)
- `authStorage` 에 `subscribe`/`notify` 추가 — `markAuthenticated`/`clearTokens` 시 구독자에게 통지.
- `useHasSessionHint` 훅 신설 — `useSyncExternalStore` 로 힌트 변화(스토어 이벤트 + `focus`/`pageshow`/`visibilitychange` + 콜드 PWA 스타트 폴링)를 구독. 힌트가 나타나는 **즉시 재렌더 → `useSidebar` 재활성화 → 사이드바 200 으로 로그인 확정.**
- `useIsLoggedIn` / `useAuthLayoutState` 가 이 훅을 사용. `useAuthLayoutState` 의 폴링 reducer + 중복 리스너는 이벤트 기반 구독으로 대체(순삭·중복 제거).

**권위는 서버 라운드트립(사이드바):** 성공=로그인 확정(`markAuthenticated`), **실제 401 일 때만** 로그아웃(`forceLogout`) — 기존 흐름 유지. 힌트 소실(미복원) ≠ 로그아웃.

## 회귀 고려
- **SSR/하이드레이션**: `getServerSnapshot=false` 로 기존 `hasMounted` 게이팅과 동일 → mismatch 없음.
- **게스트**: `hasTokens()=false` → `useSidebar` 비활성 유지, 불필요한 사이드바 probe 없음(게스트 스팸 없음).
- **로그아웃/만료**: `clearTokens` → notify → 즉시 로그아웃 반영. 실제 401 정리 경로 불변.
- **콜드 PWA 런치**: 지연 복원 대비 짧은 폴링(≤~0.9s)을 훅 내부에 보존.
- #125/#152 와 정합(힌트 기반 판정 + 서버 권위).

## 검증
tsc / lint(0 error) / vitest(109 pass, 신규 emitter 테스트 포함) / knip(exit 0) / build 통과. 브라우저 실측은 미수행(정적 검증까지).