### PR TITLE
release: 인증 쿠키 흐름 안정화 (AUTH-012 로그아웃 + 로그인 상태 반응형)

### DIFF
--- a/src/app.component/layout/useAuthLayoutState.ts
+++ b/src/app.component/layout/useAuthLayoutState.ts
@@ -3,8 +3,8 @@
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { useUnreadCount } from '@feature/notification/hooks/useNotificationQueries';
 import { NOOP_SUBSCRIBE } from '@module/hooks/useHasMounted';
-import { authStorage } from '@module/utils/auth';
-import { useEffect, useMemo, useReducer, useSyncExternalStore } from 'react';
+import { useHasSessionHint } from '@module/hooks/useHasSessionHint';
+import { useMemo, useSyncExternalStore } from 'react';
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 const ENDLESS_MIN_YEAR = 2090;
@@ -108,61 +108,12 @@ export function useAuthLayoutState(): AuthLayoutState {
   );
   const now = useSyncExternalStore(NOOP_SUBSCRIBE, getMountTimestamp, () => 0);
 
-  // 콜드 PWA(사파리 홈화면 앱) 런치에서 cookie/localStorage 복원이 한 박자
-  // 늦으면 첫 렌더의 authStorage.hasTokens() 가 false 로 굳어 useSidebar 쿼리가
-  // 비활성 상태로 멈춘다 → 로그인 사용자가 게스트로 보이고, 앱을 재실행하면
-  // 정상화된다. mount 직후 짧게(최대 ~0.9s) 재확인해 토큰이 보이면 re-render 를
-  // 유발, 아래 useSidebar 의 enabled(=hasTokens()) 를 다시 평가시킨다.
-  // (데이터 페칭은 그대로 TanStack Query 가 담당한다.)
-  const [, revalidateAuth] = useReducer((count: number) => count + 1, 0);
-  useEffect(() => {
-    let attempts = 0;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const recheck = (): void => {
-      attempts += 1;
-      if (authStorage.hasTokens()) {
-        revalidateAuth();
-        return;
-      }
-      if (attempts < 6) {
-        timer = setTimeout(recheck, 150);
-      }
-    };
-    if (!authStorage.hasTokens()) {
-      timer = setTimeout(recheck, 150);
-    }
-
-    // 재접속(PWA 백그라운드 복귀 / BFCache 복원 / 탭 재포커스) 시 토큰 힌트를
-    // 다시 평가한다. 레이아웃은 soft navigation 으로 재마운트되지 않으므로 이
-    // 이벤트가 없으면, 최초 폴링이 끝난 뒤 게스트 오인이 새로고침 전까지
-    // 고착된다(= "다시 접속하면 로그아웃처럼 보이는" 문제). hasTokens() 가
-    // 다시 true 로 보이면 re-render 를 유발해 useSidebar 의 enabled(=hasTokens)
-    // 를 재평가시켜 비활성 상태의 쿼리를 되살린다.
-    const revalidateIfAuthed = (): void => {
-      if (authStorage.hasTokens()) {
-        revalidateAuth();
-      }
-    };
-    const onVisibilityChange = (): void => {
-      if (document.visibilityState === 'visible') {
-        revalidateIfAuthed();
-      }
-    };
-    window.addEventListener('focus', revalidateIfAuthed);
-    window.addEventListener('pageshow', revalidateIfAuthed);
-    document.addEventListener('visibilitychange', onVisibilityChange);
-
-    return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      window.removeEventListener('focus', revalidateIfAuthed);
-      window.removeEventListener('pageshow', revalidateIfAuthed);
-      document.removeEventListener('visibilitychange', onVisibilityChange);
-    };
-  }, []);
-
-  const hasTokenHint = hasMounted && authStorage.hasTokens();
+  // 로그인 힌트 변화를 구독한다. 재발급/미들웨어가 세션을 복구해 힌트가
+  // 나타나면(콜드 PWA 런치의 지연 복원, BFCache 복귀, 탭 재포커스, SPA 이동 중
+  // 재발급 성공 포함) 즉시 재렌더돼 useSidebar 의 enabled(=hasTokens) 가
+  // 재평가된다. 예전엔 폴링 reducer 로 흉내냈으나, 이벤트 기반 구독으로 대체해
+  // 전체 새로고침(=미들웨어 재실행) 없이도 로그인 상태를 스스로 복구한다.
+  const hasTokenHint = useHasSessionHint();
 
   const {
     data: sidebarData,

--- a/src/app.feature/member/hooks/useIsLoggedIn.ts
+++ b/src/app.feature/member/hooks/useIsLoggedIn.ts
@@ -1,6 +1,4 @@
-import { NOOP_SUBSCRIBE } from '@module/hooks/useHasMounted';
-import { authStorage } from '@module/utils/auth';
-import { useSyncExternalStore } from 'react';
+import { useHasSessionHint } from '@module/hooks/useHasSessionHint';
 
 import { useSidebar } from './useMemberQueries';
 
@@ -17,15 +15,11 @@ import { useSidebar } from './useMemberQueries';
  * 반드시 이 훅을 사용할 것.
  */
 export function useIsLoggedIn(): boolean {
-  const hasMounted = useSyncExternalStore(
-    NOOP_SUBSCRIBE,
-    () => true,
-    () => false
-  );
+  // 힌트 변화를 구독한다. 재발급/미들웨어가 세션을 복구해 힌트가 나타나면
+  // 즉시 재렌더돼 useSidebar 가 활성화되고, 서버 라운드트립으로 로그인이
+  // 확정된다. (하이드레이션 중에는 false → 서버 결과와 일치)
+  const hasSessionHint = useHasSessionHint();
   const { data, isLoading, isFetching } = useSidebar();
-  const hasTokenHint = hasMounted && authStorage.hasTokens();
 
-  return (
-    hasMounted && hasTokenHint && (Boolean(data) || isLoading || isFetching)
-  );
+  return hasSessionHint && (Boolean(data) || isLoading || isFetching);
 }

--- a/src/app.module/api/error.test.ts
+++ b/src/app.module/api/error.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { isInvalidRefreshTokenError } from './error';
+
+const axiosErrorWithCode = (code: string): unknown => ({
+  isAxiosError: true,
+  response: { status: 401, data: { code } },
+});
+
+describe('isInvalidRefreshTokenError', () => {
+  // 서버가 쿠키를 만료시키지 않는 재사용 감지(AUTH-012)도 복구 불가로 보고
+  // /auth/logout 정리를 트리거해야 한다.
+  it.each(['AUTH-006', 'AUTH-012'])('treats %s as unrecoverable', (code) => {
+    expect(isInvalidRefreshTokenError(axiosErrorWithCode(code))).toBe(true);
+  });
+
+  it('ignores recoverable/other codes', () => {
+    expect(isInvalidRefreshTokenError(axiosErrorWithCode('AUTH-007'))).toBe(
+      false
+    );
+    expect(isInvalidRefreshTokenError(new Error('boom'))).toBe(false);
+  });
+});

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -79,9 +79,13 @@ const getResponseCode = (payload: unknown): string | null => {
     : null;
 };
 
-// 백엔드가 내려주는 refresh token 무효/형식 오류 코드. 상태 코드와 무관하게
-// 세션을 복구할 수 없으므로 로컬 토큰을 정리해야 한다(예: AUTH-006).
-const INVALID_REFRESH_TOKEN_CODES = new Set(['AUTH-006']);
+// 복구 불가능한 refresh token 상태 코드. 상태 코드와 무관하게 세션을 복구할
+// 수 없으므로 로컬 토큰 정리 + 서버 쿠키 만료(/auth/logout)까지 해야 한다.
+//   - AUTH-006: refresh token 무효/형식 오류
+//   - AUTH-012: 회전형 refresh 재사용 감지. 서버가 쿠키를 만료시키지 않으므로
+//     클라가 /auth/logout 으로 HttpOnly 쿠키를 정리하지 않으면, 미들웨어가
+//     남은 access 쿠키를 보고 힌트를 재발급해 강제 로그아웃이 되돌려진다.
+const INVALID_REFRESH_TOKEN_CODES = new Set(['AUTH-006', 'AUTH-012']);
 
 // 백엔드 도메인 에러 코드(예: CHALLENGE_022)를 응답 본문에서 추출한다.
 // 상태 코드만으로 구분할 수 없는 분기 처리에 사용한다.

--- a/src/app.module/hooks/useHasSessionHint.ts
+++ b/src/app.module/hooks/useHasSessionHint.ts
@@ -1,0 +1,70 @@
+import { authStorage } from '@module/utils/auth';
+import { useSyncExternalStore } from 'react';
+
+// 콜드 PWA(사파리 홈화면 앱) 런치에서 cookie/localStorage 복원이 한 박자 늦으면
+// 첫 스냅샷이 false 로 굳는다. mount 직후 짧게 재확인해 뒤늦게 나타난 힌트를
+// 반영한다. (markAuthenticated 를 거치지 않고 OS/미들웨어가 심은 쿠키 대비)
+const COLD_START_RECHECK_MS = 150;
+const COLD_START_MAX_ATTEMPTS = 6;
+
+/**
+ * 로그인 힌트(hasTokens) 변화를 구독한다.
+ *
+ * 힌트는 JS 에서 반응형이 아니라, 미들웨어/재발급이 세션을 복구해도(=힌트 set)
+ * 이를 읽는 컴포넌트가 저절로 re-render 되지 않았다. 그 결과 useSidebar 의
+ * enabled(=hasTokens) 가 재평가되지 않아 전체 새로고침(=미들웨어 재실행) 전까지
+ * 로그아웃처럼 보였다. SPA 이동은 미들웨어를 타지 않아 고착됐다.
+ *
+ * 이 hook 은 authStorage 변경 이벤트 + focus/pageshow/visibility + 콜드스타트
+ * 폴링을 구독원으로 삼아, 힌트가 나타나는 즉시 재렌더 → useSidebar 재활성화 →
+ * 서버 라운드트립(사이드바)으로 로그인 확정되게 한다.
+ *
+ * SSR/하이드레이션 중에는 getServerSnapshot 이 false 를 돌려주어 서버 결과와
+ * 어긋나지 않는다(기존 hasMounted 게이팅과 동일).
+ */
+function subscribe(onChange: () => void): () => void {
+  const unsubscribeStore = authStorage.subscribe(onChange);
+
+  const onVisibility = (): void => {
+    if (document.visibilityState === 'visible') {
+      onChange();
+    }
+  };
+  window.addEventListener('focus', onChange);
+  window.addEventListener('pageshow', onChange);
+  document.addEventListener('visibilitychange', onVisibility);
+
+  let attempts = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const recheck = (): void => {
+    attempts += 1;
+    if (authStorage.hasTokens()) {
+      onChange();
+      return;
+    }
+    if (attempts < COLD_START_MAX_ATTEMPTS) {
+      timer = setTimeout(recheck, COLD_START_RECHECK_MS);
+    }
+  };
+  if (!authStorage.hasTokens()) {
+    timer = setTimeout(recheck, COLD_START_RECHECK_MS);
+  }
+
+  return () => {
+    unsubscribeStore();
+    window.removeEventListener('focus', onChange);
+    window.removeEventListener('pageshow', onChange);
+    document.removeEventListener('visibilitychange', onVisibility);
+    if (timer) {
+      clearTimeout(timer);
+    }
+  };
+}
+
+export function useHasSessionHint(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => authStorage.hasTokens(),
+    () => false
+  );
+}

--- a/src/app.module/utils/auth.test.ts
+++ b/src/app.module/utils/auth.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { authStorage } from './auth';
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('authStorage subscribe', () => {
+  it('notifies subscribers on markAuthenticated and clearTokens', () => {
+    const listener = vi.fn();
+    const unsubscribe = authStorage.subscribe(listener);
+
+    authStorage.markAuthenticated();
+    authStorage.clearTokens();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    authStorage.markAuthenticated();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app.module/utils/auth.ts
+++ b/src/app.module/utils/auth.ts
@@ -22,7 +22,26 @@ function hasReadableAccessTokenCookie(): boolean {
   );
 }
 
+// 로그인 힌트(쿠키/localStorage) 변화를 구독자에게 알린다. 힌트 값은 JS 에서
+// 반응형이 아니라, markAuthenticated/clearTokens 로 바뀌어도 이를 읽는
+// 컴포넌트가 저절로 re-render 되지 않는다. 그 결과 미들웨어/재발급이 세션을
+// 복구해도(=힌트 set) useSidebar 의 enabled(=hasTokens) 가 재평가되지 않아
+// 전체 새로고침 전까지 로그아웃처럼 보였다. useSyncExternalStore 구독으로
+// 힌트 변화를 즉시 UI 에 반영한다. (useHasSessionHint 참조)
+type AuthListener = () => void;
+const authListeners = new Set<AuthListener>();
+const notifyAuthChange = (): void => {
+  authListeners.forEach((listener) => listener());
+};
+
 export const authStorage = {
+  subscribe: (listener: AuthListener): (() => void) => {
+    authListeners.add(listener);
+    return () => {
+      authListeners.delete(listener);
+    };
+  },
+
   markAuthenticated: (): void => {
     if (typeof window === 'undefined') {
       return;
@@ -37,6 +56,7 @@ export const authStorage = {
       sameSite: 'lax',
       secure: window.location.protocol === 'https:',
     });
+    notifyAuthChange();
   },
 
   // 인증 상태 플래그 제거 (실제 토큰은 백엔드 Set-Cookie/HTTP-only로 관리)
@@ -48,6 +68,7 @@ export const authStorage = {
     // 저장되지 않은 잔존 쿠키를 완전히 정리하기 위함)
     Cookies.remove(AUTH_HINT_COOKIE);
     Cookies.remove(AUTH_HINT_COOKIE, { domain: AUTH_HINT_COOKIE_DOMAIN });
+    notifyAuthChange();
   },
 
   /**


### PR DESCRIPTION
## 운영 승격 (develop → main)

직전 클라 승격 #151 이후 develop 에 쌓인 변경 = 아래 2건뿐(확인 완료, 예상외/역행 없음).

### 포함 PR
- **#152** `fix: refresh 재사용 감지(AUTH-012) 시 서버 세션 정리` — AUTH-012(회전 refresh 재사용, 401·서버 쿠키 미만료)를 복구 불가로 분류해 `/auth/logout` 으로 HttpOnly 쿠키까지 정리. 미들웨어가 남은 access 쿠키로 힌트를 재발급해 강제 로그아웃이 되돌려지던 결함 차단.
- **#153** `fix: 로그인 힌트 변화를 반응형으로 구독해 로그아웃 오표시 해결` — 로그인 힌트(hasTokens)를 `useSyncExternalStore` 로 구독해 재발급/미들웨어의 세션 복구가 즉시 UI 에 반영되게. '두 번에 한 번 로그아웃' · 'SPA 이동 시 로그아웃 고착'(전체 새로고침 전까지) 해소.

### 변경 파일 (7)
error.ts, auth.ts, useIsLoggedIn.ts, useAuthLayoutState.ts, useHasSessionHint.ts(신규) + 테스트 2종.

### 검증
- 두 PR 모두 develop 에서 CI green(tsc·lint·vitest·knip·build) 후 squash 머지.
- main..develop delta = #152·#153 정확히 일치, 그 외 변경 없음.

머지 시 main 반영 → Vercel Production 자동 배포.