### PR TITLE
feat: 친구 비교를 특정 친구 1:1 비교로 전환

### DIFF
--- a/src/app.feature/member/statistics/api/statisticsApi.ts
+++ b/src/app.feature/member/statistics/api/statisticsApi.ts
@@ -7,7 +7,7 @@ import type {
   FeelingStatistics,
   FeelingStatisticsParams,
   FriendComparison,
-  FriendComparisonPeriod,
+  FriendComparisonParams,
   StatisticsPeriods,
   StatisticsPeriodUnit,
   StatisticsSummary,
@@ -74,12 +74,15 @@ export const statisticsApi = {
     }),
 
   getFriendComparison: async (
-    period: FriendComparisonPeriod
+    params: FriendComparisonParams
   ): Promise<FriendComparison> =>
     requestData<FriendComparison>(apiClient, {
       url: withQuery(
         '/member/statistics/friend-comparison',
-        buildQueryString({ period })
+        buildQueryString({
+          period: params.period,
+          friendId: params.friendId,
+        })
       ),
       method: 'GET',
     }),

--- a/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
+++ b/src/app.feature/member/statistics/components/FriendComparisonSection.tsx
@@ -1,14 +1,20 @@
 'use client';
 
 import {
-  Icon,
+  CircleAvatar,
   ProgressBar,
   SegmentedControl,
-  Tag,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Text,
 } from '@1d1s/design-system';
+import { useFriendList } from '@feature/friend/hooks/useFriendQueries';
+import { normalizeApiError } from '@module/api/error';
 import { cn } from '@module/utils/cn';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { useFriendComparison } from '../hooks/useStatisticsQueries';
 import type { FriendComparisonPeriod } from '../type/statistics';
@@ -34,7 +40,10 @@ function Bar({
   const widthPct = max > 0 ? Math.max(4, (value / max) * 100) : 4;
   return (
     <div className="flex items-center gap-2">
-      <Text size="caption4" className="w-14 shrink-0 text-gray-400">
+      <Text
+        size="caption4"
+        className="w-16 shrink-0 truncate text-gray-400"
+      >
         {caption}
       </Text>
       <ProgressBar
@@ -56,15 +65,17 @@ function Bar({
 interface CompareRowProps {
   label: string;
   mine: number;
-  average: number;
+  friendValue: number;
+  friendName: string;
 }
 
 function CompareRow({
   label,
   mine,
-  average,
+  friendValue,
+  friendName,
 }: CompareRowProps): React.ReactElement {
-  const max = Math.max(mine, average, 1);
+  const max = Math.max(mine, friendValue, 1);
   return (
     <div className="rounded-[14px] bg-gray-50 p-4">
       <div className="flex items-center justify-between">
@@ -72,16 +83,16 @@ function CompareRow({
           {label}
         </Text>
         <Text size="caption3" className="text-gray-400">
-          나 {formatCount(mine)} · 친구 평균 {formatCount(average)}
+          나 {formatCount(mine)} · {friendName} {formatCount(friendValue)}
         </Text>
       </div>
       <div className="mt-3 space-y-2">
         <Bar value={mine} max={max} color="var(--main-700)" caption="나" />
         <Bar
-          value={average}
+          value={friendValue}
           max={max}
-          color="var(--gray-200)"
-          caption="친구 평균"
+          color="var(--gray-300)"
+          caption={friendName}
         />
       </div>
     </div>
@@ -89,77 +100,124 @@ function CompareRow({
 }
 
 /**
- * 친구 비교 — 나 vs 친구 평균 + 순위. 개별 친구는 노출하지 않는다.
+ * 친구 비교 — 나 vs 선택한 친구 1:1 (서버 #321).
+ * 친구 목록(GET /friends)에서 한 명을 골라 지표를 나란히 비교한다.
  */
 export function FriendComparisonSection(): React.ReactElement {
   const [period, setPeriod] = useState<FriendComparisonPeriod>('WEEK');
-  const { data, isPending, isPlaceholderData, isSuccess, isError, error } =
-    useFriendComparison(period);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
 
-  const friendCount = data?.friendCount ?? 0;
-  const me = data?.me;
-  const average = data?.friendsAverage;
-  const rank = data?.myRank;
+  const {
+    data: friends,
+    isPending: friendsPending,
+    isError: friendsError,
+    error: friendsErrorObj,
+  } = useFriendList();
+
+  // 선택 전에는 첫 친구를 기본으로 — 별도 effect 없이 파생.
+  const effectiveId = selectedId ?? friends?.[0]?.memberId ?? null;
+  const selectedFriend = useMemo(
+    () => friends?.find((f) => f.memberId === effectiveId),
+    [friends, effectiveId]
+  );
+
+  const {
+    data,
+    isPending: comparePending,
+    isPlaceholderData,
+    isError: compareError,
+    error: compareErrorObj,
+  } = useFriendComparison(effectiveId, period);
+
+  const hasFriends = (friends?.length ?? 0) > 0;
+  const friendName = selectedFriend?.nickname ?? '친구';
 
   return (
     <StatisticsCard
-      title="친구들과 나"
-      subtitle="친구 평균과 나의 활동을 나란히"
+      title="친구와 나"
+      subtitle="친구 한 명을 골라 나와 나란히"
       action={
-        <SegmentedControl
-          size="sm"
-          options={PERIOD_OPTIONS}
-          value={period}
-          onValueChange={(v) => setPeriod(v as FriendComparisonPeriod)}
-          aria-label="친구 통계 기간"
-        />
-      }
-      isLoading={isPending}
-      isError={isError}
-      error={error}
-      isEmpty={isSuccess && friendCount === 0}
-      emptyText="친구를 추가하면 평균과 순위를 함께 볼 수 있어요."
-      skeletonHeight={200}
-    >
-      {/* 기간 전환 중(placeholder)에는 dim, 새 데이터가 오면
-          opacity 만 부드럽게 복귀 — remount 없는 크로스페이드. */}
-      <div
-        className={cn(
-          'space-y-4 transition-opacity duration-300 ease-out',
-          isPlaceholderData && 'opacity-40'
-        )}
-      >
-        <div className="flex flex-wrap items-center gap-2">
-          <Tag
-            tone="gray"
+        hasFriends ? (
+          <SegmentedControl
             size="sm"
-            icon={<Icon name="People" size={12} aria-hidden />}
-          >
-            친구 {friendCount}명
-          </Tag>
-          {rank && rank.outOf > 0 ? (
-            <Tag
-              tone="brand"
-              size="sm"
-              icon={<Icon name="Trophy" size={12} aria-hidden />}
+            options={PERIOD_OPTIONS}
+            value={period}
+            onValueChange={(v) => setPeriod(v as FriendComparisonPeriod)}
+            aria-label="친구 통계 기간"
+          />
+        ) : undefined
+      }
+      isLoading={friendsPending}
+      isError={friendsError}
+      error={friendsErrorObj}
+      isEmpty={!friendsPending && !friendsError && !hasFriends}
+      emptyText="비교할 친구가 없어요. 친구를 추가해보세요."
+      skeletonHeight={220}
+    >
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
+          <CircleAvatar
+            size="sm"
+            imageUrl={selectedFriend?.profileUrl}
+            alt={friendName}
+          />
+          <div className="min-w-0 flex-1">
+            <Select
+              value={effectiveId != null ? String(effectiveId) : undefined}
+              onValueChange={(v) => setSelectedId(Number(v))}
             >
-              일지 순위 {rank.byDiaryCount}/{rank.outOf}
-            </Tag>
-          ) : null}
+              <SelectTrigger size="sm" className="w-full">
+                <SelectValue placeholder="친구 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {friends?.map((friend) => (
+                  <SelectItem
+                    key={friend.memberId}
+                    value={String(friend.memberId)}
+                  >
+                    {friend.nickname}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
 
-        <div className="grid gap-3 lg:grid-cols-2">
-          <CompareRow
-            label="작성한 일지"
-            mine={me?.diaryCount ?? 0}
-            average={average?.diaryCount ?? 0}
-          />
-          <CompareRow
-            label="달성한 목표"
-            mine={me?.completedGoalCount ?? 0}
-            average={average?.completedGoalCount ?? 0}
-          />
-        </div>
+        {compareError ? (
+          <div
+            className={cn(
+              'flex min-h-[120px] items-center justify-center',
+              'rounded-[12px] bg-gray-50 px-4 py-8 text-center'
+            )}
+          >
+            <Text size="caption1" className="text-red-500">
+              {normalizeApiError(compareErrorObj).message}
+            </Text>
+          </div>
+        ) : (
+          // 기간/친구 전환 중(placeholder·로딩)에는 dim, 데이터가 오면
+          // opacity 만 부드럽게 복귀 — remount 없는 크로스페이드.
+          <div
+            className={cn(
+              'grid gap-3 transition-opacity duration-300 ease-out',
+              'lg:grid-cols-2',
+              (isPlaceholderData || (comparePending && !data)) && 'opacity-40'
+            )}
+          >
+            <CompareRow
+              label="작성한 일지"
+              mine={data?.me.diaryCount ?? 0}
+              friendValue={data?.friend.diaryCount ?? 0}
+              friendName={friendName}
+            />
+            <CompareRow
+              label="달성한 목표"
+              mine={data?.me.completedGoalCount ?? 0}
+              friendValue={data?.friend.completedGoalCount ?? 0}
+              friendName={friendName}
+            />
+          </div>
+        )}
       </div>
     </StatisticsCard>
   );

--- a/src/app.feature/member/statistics/consts/queryKeys.ts
+++ b/src/app.feature/member/statistics/consts/queryKeys.ts
@@ -1,7 +1,7 @@
 import type {
   DiaryTrendParams,
   FeelingStatisticsParams,
-  FriendComparisonPeriod,
+  FriendComparisonParams,
   StatisticsPeriodUnit,
   StatisticsSummaryParams,
 } from '../type/statistics';
@@ -16,6 +16,6 @@ export const STATISTICS_QUERY_KEYS = {
     [...STATISTICS_QUERY_KEYS.all, 'periods', unit] as const,
   summary: (params: StatisticsSummaryParams) =>
     [...STATISTICS_QUERY_KEYS.all, 'summary', params] as const,
-  friendComparison: (period: FriendComparisonPeriod) =>
-    [...STATISTICS_QUERY_KEYS.all, 'friend-comparison', period] as const,
+  friendComparison: (params: FriendComparisonParams) =>
+    [...STATISTICS_QUERY_KEYS.all, 'friend-comparison', params] as const,
 };

--- a/src/app.feature/member/statistics/hooks/useStatisticsQueries.ts
+++ b/src/app.feature/member/statistics/hooks/useStatisticsQueries.ts
@@ -78,15 +78,25 @@ export function useStatisticsSummary(
 }
 
 export function useFriendComparison(
+  friendId: number | null,
   period: FriendComparisonPeriod
 ): UseQueryResult<FriendComparison, Error> {
   const isLoggedIn = useIsLoggedIn();
   return useQuery({
-    queryKey: STATISTICS_QUERY_KEYS.friendComparison(period),
-    queryFn: () => statisticsApi.getFriendComparison(period),
-    enabled: isLoggedIn,
+    queryKey: STATISTICS_QUERY_KEYS.friendComparison({
+      period,
+      friendId: friendId ?? 0,
+    }),
+    queryFn: () =>
+      statisticsApi.getFriendComparison({
+        period,
+        // enabled 가드로 friendId 확정 후에만 호출된다.
+        friendId: friendId as number,
+      }),
+    // 친구가 선택돼야(그리고 로그인돼야) 조회 — friendId 미지정 400 방지.
+    enabled: isLoggedIn && friendId != null && friendId > 0,
     staleTime: STATISTICS_STALE_TIME,
-    // 기간 전환 시 이전 데이터 유지 — 스켈레톤 레이아웃 쉬프트 방지.
+    // 기간/친구 전환 시 이전 데이터 유지 — 스켈레톤 레이아웃 쉬프트 방지.
     placeholderData: keepPreviousData,
   });
 }

--- a/src/app.feature/member/statistics/type/statistics.ts
+++ b/src/app.feature/member/statistics/type/statistics.ts
@@ -91,21 +91,25 @@ export interface StatisticsSummaryParams {
   periodKey?: string;
 }
 
-// 5. 친구 비교
+// 5. 친구 비교 — 특정 친구 1:1 비교 (서버 #321).
 export interface FriendComparisonMetrics {
   diaryCount: number;
   completedGoalCount: number;
 }
 
-export interface FriendComparisonRank {
-  byDiaryCount: number;
-  outOf: number;
+export interface FriendComparisonFriend extends FriendComparisonMetrics {
+  memberId: number;
+  nickname: string;
+  profileUrl: string;
 }
 
 export interface FriendComparison {
   period: FriendComparisonPeriod;
-  friendCount: number;
   me: FriendComparisonMetrics;
-  friendsAverage: FriendComparisonMetrics;
-  myRank: FriendComparisonRank;
+  friend: FriendComparisonFriend;
+}
+
+export interface FriendComparisonParams {
+  period: FriendComparisonPeriod;
+  friendId: number;
 }

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -55,8 +55,8 @@ export function formatPercent(ratio: number): string {
   return `${Math.round(ratio * 100)}%`;
 }
 
-// 평균 등 소수가 섞일 수 있는 값 표시 — 최대 1자리, 정수는 소수점 제거.
-// friendsAverage 처럼 서버가 실수를 내려줄 수 있는 값에 사용한다.
+// 소수가 섞일 수 있는 값 표시 — 최대 1자리, 정수는 소수점 제거.
+// (NaN 방어 포함) 통계 카운트 표시에 사용한다.
 export function formatCount(value: number): string {
   if (!Number.isFinite(value)) {
     return '0';


### PR DESCRIPTION
## 개요
통계 "친구 비교"를 **친구 평균/순위 → 특정 친구 1:1 비교**로 전환합니다.
서버 PR #321(dev)의 계약 변경에 맞춘 프론트 작업입니다.

> ⚠️ **배포 순서**: 서버 #321이 먼저 배포돼야 실동작합니다.

## 서버 계약 (#321)
- `GET /member/statistics/friend-comparison?period=MONTH|WEEK&friendId=<memberId>` — **friendId 필수**
- 응답: `{ period, me:{ diaryCount, completedGoalCount }, friend:{ memberId, nickname, profileUrl, diaryCount, completedGoalCount } }`
- 기존 `friendsAverage`/`myRank`/`friendCount` 제거(breaking)
- friendId가 내 친구 아니면 404(FRIEND-007), 미지정 400
- 친구 목록: 기존 `GET /friends` 재사용

## 변경 사항
- `type/statistics.ts`: `FriendComparison`을 `me + friend`(1:1)로 재정의, `FriendComparisonParams` 추가, 구 `FriendComparisonRank` 제거
- `api/statisticsApi.ts`: `getFriendComparison`에 `friendId` 파라미터 반영
- `consts/queryKeys.ts` · `hooks/useStatisticsQueries.ts`: 쿼리 키에 `period`+`friendId` 반영, `enabled`는 로그인 && 친구 선택됨
- `components/FriendComparisonSection.tsx`:
  - `useFriendList`(`GET /friends`) **재사용**해 친구 선택 드롭다운(`Select` + `CircleAvatar`) 구성, 기본 선택은 첫 친구
  - 나 vs 선택 친구 1:1 막대 비교(닉네임·프로필 표시), period(주/월) 토글 유지
  - 친구 0명 빈 상태 / friendId 미선택·로딩·에러(404 등) 방어

## 엣지 케이스
- 친구 0명 → "비교할 친구가 없어요" 빈 상태(토글·드롭다운 숨김)
- friendId 미확정 → 쿼리 `enabled=false`로 400 방지
- 비교 조회 에러(404 등) → 카드 내부 에러 메시지, 친구 목록은 유지

## 검증
- `tsc --noEmit` ✅ / `pnpm lint`(0 errors) ✅ / `pnpm test`(112 passed) ✅ / `pnpm knip` ✅ / `pnpm build` ✅
- 브라우저 실동작 확인은 하지 않았습니다(정적 검증까지).