### PR TITLE
feat: 챌린지 통계·날짜별 히트맵 캘린더·날짜 필터 일지 목록

### DIFF
--- a/src/app.feature/challenge/board/consts/queryKeys.ts
+++ b/src/app.feature/challenge/board/consts/queryKeys.ts
@@ -21,15 +21,27 @@ export const CHALLENGE_QUERY_KEYS = {
   checkWrite: (challengeId: number) =>
     [...CHALLENGE_QUERY_KEYS.all, 'check-write', challengeId] as const,
   challengeDiaries: () => [...CHALLENGE_QUERY_KEYS.all, 'diaries'] as const,
-  diaries: (challengeId: number, params?: { page?: number; size?: number }) =>
-    [...CHALLENGE_QUERY_KEYS.challengeDiaries(), challengeId, params] as const,
-  diariesInfinite: (challengeId: number, params?: { size?: number }) =>
+  diaries: (
+    challengeId: number,
+    params?: { page?: number; size?: number; date?: string }
+  ) =>
+    [
+      ...CHALLENGE_QUERY_KEYS.challengeDiaries(),
+      challengeId,
+      params,
+    ] as const,
+  diariesInfinite: (
+    challengeId: number,
+    params?: { size?: number; date?: string }
+  ) =>
     [
       ...CHALLENGE_QUERY_KEYS.challengeDiaries(),
       challengeId,
       'infinite',
       params,
     ] as const,
+  statistics: (challengeId: number) =>
+    [...CHALLENGE_QUERY_KEYS.all, 'statistics', challengeId] as const,
   participants: () => [...CHALLENGE_QUERY_KEYS.all, 'participants'] as const,
   participantList: (challengeId: number, params?: ParticipantListParams) =>
     [...CHALLENGE_QUERY_KEYS.participants(), challengeId, params] as const,

--- a/src/app.feature/challenge/detail/api/challengeDetailApi.ts
+++ b/src/app.feature/challenge/detail/api/challengeDetailApi.ts
@@ -17,6 +17,7 @@ import {
   VerifyChallengePasswordResponse,
 } from '../../board/type/challenge';
 import { ChallengeDiaryListResponse } from '../type/challengeDiary';
+import { ChallengeStatistics } from '../type/challengeStatistics';
 
 export const challengeDetailApi = {
   // 챌린지 상세 조회
@@ -138,17 +139,20 @@ export const challengeDetailApi = {
     });
   },
 
-  // 챌린지 일지 목록 조회
+  // 챌린지 일지 목록 조회 (date 지정 시 그 날짜 completedDate 일지만)
   getChallengeDiaries: async (
     challengeId: number,
-    params: { page?: number; size?: number } = {}
+    params: { page?: number; size?: number; date?: string } = {}
   ): Promise<ChallengeDiaryListResponse> => {
-    const requestParams: Record<string, number> = {};
+    const requestParams: Record<string, number | string> = {};
     if (params.page !== undefined) {
       requestParams.page = params.page;
     }
     if (params.size !== undefined) {
       requestParams.size = params.size;
+    }
+    if (params.date) {
+      requestParams.date = params.date;
     }
 
     return requestData<ChallengeDiaryListResponse>(apiClient, {
@@ -157,4 +161,13 @@ export const challengeDetailApi = {
       params: Object.keys(requestParams).length > 0 ? requestParams : undefined,
     });
   },
+
+  // 챌린지 통계 조회 (참여율/완료 목표수/일자별 일지 추이)
+  getChallengeStatistics: async (
+    challengeId: number
+  ): Promise<ChallengeStatistics> =>
+    requestData<ChallengeStatistics>(apiClient, {
+      url: `/challenges/${challengeId}/statistics`,
+      method: 'GET',
+    }),
 };

--- a/src/app.feature/challenge/detail/components/ChallengeStatisticsSection.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeStatisticsSection.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { Heatmap, Text } from '@1d1s/design-system';
+import { Skeleton } from '@component/Skeleton';
+import { LineTrend, type TrendDatum } from '@feature/member/statistics/components/LineTrend';
+import { formatBucketLabel } from '@feature/member/statistics/utils/statisticsView';
+import { normalizeApiError } from '@module/api/error';
+import { cn } from '@module/utils/cn';
+import { formatMonthDayKR } from '@module/utils/date';
+import { useRouter } from 'next/navigation';
+import React, { useMemo } from 'react';
+
+import { useChallengeStatistics } from '../hooks/useChallengeDiaryQueries';
+import { toHeatmapLevel } from '../utils/challengeStatisticsView';
+
+interface ChallengeStatisticsSectionProps {
+  challengeId: number;
+}
+
+function StatTile({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1 rounded-[12px] bg-gray-50 px-4 py-3">
+      <Text size="caption1" weight="regular" className="text-gray-500">
+        {label}
+      </Text>
+      <Text size="heading2" weight="bold" className="text-gray-900">
+        {value}
+      </Text>
+    </div>
+  );
+}
+
+/**
+ * 챌린지 통계 — 참여율/완료 목표수 KPI + 일자별 일지 추이(꺾은선) +
+ * 날짜별 일지 개수 히트맵 캘린더. 셀 클릭 시 그 날짜로 필터된 일지 목록으로
+ * 이동한다.
+ */
+export function ChallengeStatisticsSection({
+  challengeId,
+}: ChallengeStatisticsSectionProps): React.ReactElement {
+  const router = useRouter();
+  const { data, isPending, isError, error } =
+    useChallengeStatistics(challengeId);
+
+  const trend = useMemo(() => data?.diaryTrend ?? [], [data]);
+  const maxCount = useMemo(
+    () => trend.reduce((max, point) => Math.max(max, point.count), 0),
+    [trend]
+  );
+  const barData: TrendDatum[] = useMemo(
+    () =>
+      trend.map((point) => ({
+        bucket: point.date,
+        count: point.count ?? 0,
+        label: formatBucketLabel(point.date),
+      })),
+    [trend]
+  );
+  const cells = useMemo(
+    () => trend.map((point) => toHeatmapLevel(point.count, maxCount)),
+    [trend, maxCount]
+  );
+  // Heatmap 은 컬럼 우선(7행) — 한 컬럼이 연속 7일. 컬럼 수만 계산해 전달.
+  const cols = Math.max(1, Math.ceil(trend.length / 7));
+  const totalDiaries = useMemo(
+    () => trend.reduce((sum, point) => sum + (point.count ?? 0), 0),
+    [trend]
+  );
+
+  const participationLabel = !data
+    ? '-'
+    : data.participationRate < 0
+      ? '시작 전'
+      : `${Math.round(data.participationRate * 10) / 10}%`;
+
+  return (
+    <section
+      className={cn(
+        'rounded-[14px] border border-gray-200 bg-white',
+        'p-4 sm:p-5 lg:p-6'
+      )}
+    >
+      <Text
+        as="h2"
+        size="heading2"
+        weight="extrabold"
+        className="mb-3 block tracking-[-0.3px] text-gray-900"
+      >
+        챌린지 통계
+      </Text>
+
+      {isPending ? (
+        <Skeleton style={{ height: 220 }} className="w-full" />
+      ) : isError ? (
+        <div
+          className={cn(
+            'flex min-h-[120px] items-center justify-center rounded-[12px]',
+            'bg-gray-50 px-4 py-8 text-center'
+          )}
+        >
+          <Text size="caption1" className="text-red-500">
+            {normalizeApiError(error).message}
+          </Text>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-5">
+          <div className="grid grid-cols-2 gap-3">
+            <StatTile label="참여율" value={participationLabel} />
+            <StatTile
+              label="완료 목표수"
+              value={`${data.completedGoalCount}개`}
+            />
+          </div>
+
+          <div>
+            <Text
+              size="caption1"
+              weight="bold"
+              className="mb-2 block text-gray-500"
+            >
+              일자별 일지 추이
+            </Text>
+            {barData.length > 0 && totalDiaries > 0 ? (
+              <LineTrend
+                data={barData}
+                ariaLabel={`일자별 일지 추이 꺾은선 차트, 총 ${totalDiaries}건`}
+              />
+            ) : (
+              <Text size="caption1" className="block text-gray-400">
+                아직 작성된 일지가 없어요.
+              </Text>
+            )}
+          </div>
+
+          <div>
+            <Text
+              size="caption1"
+              weight="bold"
+              className="mb-2 block text-gray-500"
+            >
+              날짜별 일지 (날짜를 눌러 그 날 일지만 보기)
+            </Text>
+            {cells.length > 0 ? (
+              <div className="overflow-x-auto">
+                <Heatmap
+                  cells={cells}
+                  cols={cols}
+                  tone="main"
+                  ariaLabel={(index) => {
+                    const point = trend[index];
+                    if (!point) {
+                      return '';
+                    }
+                    const label = formatMonthDayKR(point.date) || point.date;
+                    return point.count > 0
+                      ? `${label} · 일지 ${point.count}개`
+                      : `${label} · 일지 없음`;
+                  }}
+                  renderCellTooltip={({ index }) => {
+                    const point = trend[index];
+                    if (!point) {
+                      return null;
+                    }
+                    const label = formatMonthDayKR(point.date) || point.date;
+                    return (
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-semibold">{label}</span>
+                        <span className="text-gray-200">
+                          {point.count > 0
+                            ? `일지 ${point.count}개`
+                            : '일지 없음'}
+                        </span>
+                      </div>
+                    );
+                  }}
+                  onCellClick={({ index }) => {
+                    const point = trend[index];
+                    if (point) {
+                      router.push(
+                        `/challenge/${challengeId}/diary?date=${point.date}`
+                      );
+                    }
+                  }}
+                />
+              </div>
+            ) : (
+              <Text size="caption1" className="block text-gray-400">
+                표시할 기간이 없어요.
+              </Text>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app.feature/challenge/detail/hooks/useChallengeDiaryQueries.ts
+++ b/src/app.feature/challenge/detail/hooks/useChallengeDiaryQueries.ts
@@ -9,6 +9,10 @@ import {
 import { CHALLENGE_QUERY_KEYS } from '../../board/consts/queryKeys';
 import { challengeDetailApi } from '../api/challengeDetailApi';
 import { ChallengeDiaryListResponse } from '../type/challengeDiary';
+import { ChallengeStatistics } from '../type/challengeStatistics';
+
+// 통계는 자주 바뀌지 않으므로 5분간 stale 유지.
+const CHALLENGE_STATISTICS_STALE_TIME = 5 * 60 * 1000;
 
 export function useChallengeDiaryList(
   challengeId: number,
@@ -22,21 +26,35 @@ export function useChallengeDiaryList(
   });
 }
 
-// 챌린지 일지 목록 조회 (무한 스크롤)
+// 챌린지 일지 목록 조회 (무한 스크롤). date 지정 시 그 날짜 일지만.
 export function useChallengeDiaryListInfinite(
   challengeId: number,
-  size?: number
+  size?: number,
+  date?: string
 ): UseInfiniteQueryResult<InfiniteData<ChallengeDiaryListResponse>, Error> {
   return useInfiniteQuery({
-    queryKey: CHALLENGE_QUERY_KEYS.diariesInfinite(challengeId, { size }),
+    queryKey: CHALLENGE_QUERY_KEYS.diariesInfinite(challengeId, { size, date }),
     queryFn: ({ pageParam }) =>
       challengeDetailApi.getChallengeDiaries(challengeId, {
         page: pageParam,
         size,
+        date,
       }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>
       lastPage.pageInfo.hasNextPage ? lastPage.pageInfo.page + 1 : undefined,
     enabled: Boolean(challengeId),
+  });
+}
+
+// 챌린지 통계 조회 (참여율/완료 목표수/일자별 일지 추이)
+export function useChallengeStatistics(
+  challengeId: number
+): UseQueryResult<ChallengeStatistics, Error> {
+  return useQuery({
+    queryKey: CHALLENGE_QUERY_KEYS.statistics(challengeId),
+    queryFn: () => challengeDetailApi.getChallengeStatistics(challengeId),
+    enabled: Boolean(challengeId),
+    staleTime: CHALLENGE_STATISTICS_STALE_TIME,
   });
 }

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -46,6 +46,7 @@ import { ChallengeLeaderboardCard } from '../components/ChallengeLeaderboardCard
 import { ChallengePasswordDialog } from '../components/ChallengePasswordDialog';
 import { ChallengeProgressCard } from '../components/ChallengeProgressCard';
 import { ChallengeRulesCard } from '../components/ChallengeRulesCard';
+import { ChallengeStatisticsSection } from '../components/ChallengeStatisticsSection';
 import { ExpandableText } from '../components/ExpandableText';
 import { PendingMemberItem } from '../components/PendingMemberItem';
 import { useChallengeDiaryList } from '../hooks/useChallengeDiaryQueries';
@@ -747,6 +748,8 @@ export function ChallengeDetailScreen({
                   itemClassName="w-[240px] shrink-0 sm:w-[260px]"
                 />
               </section>
+
+              <ChallengeStatisticsSection challengeId={challengeId} />
             </div>
 
             {/* 우측 sticky rail: 진행률 + 리더보드 */}

--- a/src/app.feature/challenge/detail/screen/ChallengeDiaryListScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDiaryListScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MobileHeader, Text } from '@1d1s/design-system';
+import { MobileHeader, Tag, Text } from '@1d1s/design-system';
 import DiaryCard from '@component/cards/DiaryCard';
 import EmptyState from '@component/EmptyState';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
@@ -23,6 +23,7 @@ import {
   resolveDiaryImageUrl,
 } from '@module/utils/diaryImageUrl';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
+import Link from 'next/link';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { useChallengeDiaryListInfinite } from '../hooks/useChallengeDiaryQueries';
@@ -32,6 +33,8 @@ const CHALLENGE_DIARY_PAGE_SIZE = 12;
 
 interface ChallengeDiaryListScreenProps {
   id: string;
+  // 캘린더에서 넘어온 날짜 필터 (YYYY-MM-DD). 없으면 전체 목록.
+  date?: string;
 }
 
 interface ChallengeDiaryListItemProps {
@@ -87,9 +90,17 @@ ChallengeDiaryListItem.displayName = 'ChallengeDiaryListItem';
 
 export function ChallengeDiaryListScreen({
   id,
+  date,
 }: ChallengeDiaryListScreenProps): React.ReactElement {
   const challengeId = Number(id);
-  const handleBack = useSafeBack(`/challenge/${id}`);
+  // 잘못된 형식은 무시해 쿼리키/요청에 오염이 들어가지 않게 한다.
+  const activeDate =
+    date && /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined;
+  const filterLabel = activeDate ? formatMonthDayKR(activeDate) : '';
+  // 필터 중엔 뒤로가기를 전체 목록으로 보내 해제 동선을 자연스럽게 한다.
+  const handleBack = useSafeBack(
+    activeDate ? `/challenge/${id}/diary` : `/challenge/${id}`
+  );
   const isLoggedIn = useIsLoggedIn();
   const [showLoginDialog, setShowLoginDialog] = useState(false);
   const likeDiary = useLikeDiary();
@@ -102,7 +113,11 @@ export function ChallengeDiaryListScreen({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useChallengeDiaryListInfinite(challengeId, CHALLENGE_DIARY_PAGE_SIZE);
+  } = useChallengeDiaryListInfinite(
+    challengeId,
+    CHALLENGE_DIARY_PAGE_SIZE,
+    activeDate
+  );
   const showSkeleton = useMinimumLoading(isLoading);
   const { ref } = useInfiniteScroll({
     hasNextPage: hasNextPage ?? false,
@@ -178,6 +193,23 @@ export function ChallengeDiaryListScreen({
           </div>
         </header>
 
+        {activeDate ? (
+          <div className="mt-5 flex items-center gap-2 lg:mt-6">
+            <Tag tone="brand" size="sm">
+              {filterLabel} 일지만 보기
+            </Tag>
+            <Link
+              href={`/challenge/${id}/diary`}
+              className={cn(
+                'text-[12px] text-gray-500 underline-offset-2',
+                'hover:text-gray-700 hover:underline'
+              )}
+            >
+              필터 해제
+            </Link>
+          </div>
+        ) : null}
+
         {showSkeleton ? (
           <DiaryCardSkeletonGrid
             count={CHALLENGE_DIARY_PAGE_SIZE}
@@ -210,8 +242,16 @@ export function ChallengeDiaryListScreen({
         {!showSkeleton && !isError && !hasDiaries ? (
           <EmptyState
             variant="diary"
-            title="아직 등록된 일지가 없어요"
-            description="이 챌린지의 첫 일지를 남겨 보세요"
+            title={
+              activeDate
+                ? `${filterLabel}에 작성된 일지가 없어요`
+                : '아직 등록된 일지가 없어요'
+            }
+            description={
+              activeDate
+                ? '다른 날짜를 선택하거나 필터를 해제해 보세요'
+                : '이 챌린지의 첫 일지를 남겨 보세요'
+            }
             className="mt-10"
           />
         ) : null}

--- a/src/app.feature/challenge/detail/type/challengeStatistics.ts
+++ b/src/app.feature/challenge/detail/type/challengeStatistics.ts
@@ -1,0 +1,15 @@
+// 서버 계약 (1D1S-server-v2 #322).
+// GET /challenges/{challengeId}/statistics
+
+export interface ChallengeDiaryTrendPoint {
+  date: string; // yyyy-MM-dd
+  count: number; // 해당 날짜(completedDate) 일지 수, 빈 날짜는 0
+}
+
+export interface ChallengeStatistics {
+  // 참여율(%). 챌린지 시작 전이면 -1.
+  participationRate: number;
+  completedGoalCount: number;
+  // 챌린지 기간(startDate~endDate, 무기한이면 ~오늘) 날짜별 일지 수.
+  diaryTrend: ChallengeDiaryTrendPoint[];
+}

--- a/src/app.feature/challenge/detail/utils/challengeStatisticsView.test.ts
+++ b/src/app.feature/challenge/detail/utils/challengeStatisticsView.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { toHeatmapLevel } from './challengeStatisticsView';
+
+describe('toHeatmapLevel', () => {
+  it('0건이거나 max 가 0이면 level 0', () => {
+    expect(toHeatmapLevel(0, 10)).toBe(0);
+    expect(toHeatmapLevel(-3, 10)).toBe(0);
+    expect(toHeatmapLevel(5, 0)).toBe(0);
+  });
+
+  it('작성이 있으면 최소 level 1 로 보이게 한다', () => {
+    expect(toHeatmapLevel(1, 100)).toBe(1);
+  });
+
+  it('최댓값 대비 비율로 1~4 를 매긴다 (포화 방지)', () => {
+    expect(toHeatmapLevel(10, 10)).toBe(4);
+    expect(toHeatmapLevel(5, 10)).toBe(2);
+    expect(toHeatmapLevel(6, 10)).toBe(3);
+  });
+});

--- a/src/app.feature/challenge/detail/utils/challengeStatisticsView.ts
+++ b/src/app.feature/challenge/detail/utils/challengeStatisticsView.ts
@@ -1,0 +1,8 @@
+// 참여자 수가 많은 챌린지는 하루 count 가 커서 raw count 를 그대로 level 에
+// 매핑하면 대부분 4로 포화된다. 기간 내 최댓값 대비 비율로 0~4 를 매긴다.
+export function toHeatmapLevel(count: number, max: number): number {
+  if (count <= 0 || max <= 0) {
+    return 0;
+  }
+  return Math.max(1, Math.min(4, Math.ceil((count / max) * 4)));
+}

--- a/src/app/challenge/[id]/diary/page.tsx
+++ b/src/app/challenge/[id]/diary/page.tsx
@@ -3,12 +3,15 @@ import React from 'react';
 
 interface ChallengeDiaryListPageProps {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ date?: string }>;
 }
 
 export default async function ChallengeDiaryListPage({
   params,
+  searchParams,
 }: ChallengeDiaryListPageProps): Promise<React.ReactElement> {
   const { id } = await params;
+  const { date } = await searchParams;
 
-  return <ChallengeDiaryListScreen id={id} />;
+  return <ChallengeDiaryListScreen id={id} date={date} />;
 }


### PR DESCRIPTION
## 개요
서버 PR #322(챌린지 통계 API) 프론트 연동. 챌린지 상세에 통계 섹션을 추가하고, 날짜별 일지 개수 캘린더에서 날짜를 클릭하면 그 날짜로 필터된 챌린지 일지 목록으로 이동한다.

> 이 PR은 서버 #322 배포 후 실동작한다(배포는 서버 먼저).

## 서버 계약
- `GET /challenges/{challengeId}/statistics` → `{ participationRate, completedGoalCount, diaryTrend: [{date, count}] }` (participationRate 는 시작 전 `-1`, diaryTrend 는 기간 전체 날짜별 일지 수)
- `GET /diaries/challenges/{challengeId}?date=YYYY-MM-DD&page&size` → `date` 지정 시 그 날짜(completedDate) 일지만

## 변경 사항
### 1. 챌린지 통계 UI (`ChallengeStatisticsSection`)
- 챌린지 상세 `참여자 일지` 아래 통계 섹션으로 배치
- KPI: **참여율**(`-1` → "시작 전"), **완료 목표수**
- **일자별 일지 추이**: 개인 통계의 `TrendBars`(막대/추이 차트) 재사용

### 2. 날짜별 히트맵 캘린더
- `diaryTrend` 를 DS `Heatmap`(마이페이지 활동 잔디와 동일 컴포넌트)으로 렌더
- 하루 count 포화 방지를 위해 **기간 내 최댓값 대비 비율**로 level(0~4) 스케일
- 셀 hover 툴팁(날짜·일지 수), **셀 클릭 → `/challenge/{id}/diary?date=...`**

### 3. 날짜 필터 일지 목록
- 기존 `ChallengeDiaryListScreen`/조회에 `date` 파라미터 지원(API·훅·쿼리키)
- 필터 칩 `N월 D일 일지만 보기` + `필터 해제` 링크, 필터 중 뒤로가기는 전체 목록으로
- 잘못된 date 형식은 무시, 필터 상태 전용 빈 상태 문구

### 4. 방어
- 통계 로딩/에러/빈 상태 처리, `enabled: Boolean(challengeId)`, `staleTime` 5분
- period·date 상태와 쿼리키 정합

## 검증
- `tsc --noEmit` ✅ / `pnpm lint` ✅(0 errors) / `pnpm test` ✅(115) / `knip` ✅ / `build` ✅
- 브라우저 실동작은 서버 #322 배포 후 확인 필요(로컬 preview 미실행)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added challenge statistics with participation rates, completed goals, trend charts, and activity heatmaps.
  * Added date-based diary filtering from the heatmap, including filter indicators and navigation.
  * Added tailored empty states for filtered and unfiltered diary views.

* **Bug Fixes**
  * Improved diary navigation when viewing entries for a specific date.

* **Tests**
  * Added coverage for activity heatmap level calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->