### PR TITLE
fix: 꺾은선 차트 날짜 라벨을 점과 같은 x에 정렬

### DIFF
--- a/src/app.feature/member/statistics/components/LineTrend.tsx
+++ b/src/app.feature/member/statistics/components/LineTrend.tsx
@@ -53,7 +53,9 @@ export function LineTrend({
   const polyline = points.map((p) => `${p.xPct},${p.yPct}`).join(' ');
 
   return (
-    <div className={cn('w-full', className)}>
+    // 좌우 px 인셋 — 끝점(0%/100%) 점·라벨의 절반이 밖으로 잘리지 않게
+    // 선 영역과 라벨 영역에 동일하게 적용한다.
+    <div className={cn('w-full px-3', className)}>
       <div
         className="relative w-full"
         style={{ height: areaHeight }}
@@ -120,16 +122,20 @@ export function LineTrend({
         })}
       </div>
 
-      <div className="mt-2 flex gap-1.5">
-        {data.map((d, i) => (
-          <div
-            key={`${d.bucket}-label-${i}`}
-            className="min-w-0 flex-1 text-center"
+      {/* 날짜 라벨 — 점과 동일한 xPct 에 중앙 정렬로 배치해 정렬을 맞춘다. */}
+      <div className="relative mt-2 h-4">
+        {points.map((p, i) => (
+          <Text
+            key={`${data[i].bucket}-label-${i}`}
+            size="caption5"
+            className={cn(
+              'absolute -translate-x-1/2 whitespace-nowrap',
+              'text-center text-gray-400'
+            )}
+            style={{ left: `${p.xPct}%` }}
           >
-            <Text size="caption5" className="block truncate text-gray-400">
-              {d.label}
-            </Text>
-          </div>
+            {data[i].label}
+          </Text>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## 문제
통계 꺾은선 차트("기간 요약 > 기간 내 추이", "작성 추이")에서 선 위의
점과 x축 날짜 라벨(7/6·7/7…)의 정렬이 어긋났다. 점은 왼쪽으로 몰려
보이고 라벨은 전체 폭에 균등 배치돼 점이 해당 라벨 위에 오지 않았다.

## 근본 원인
`LineTrend`에서 점·값 라벨은 `computeTrendPoints`의 `xPct`(끝에서 끝,
`i/(n-1)*100%`)로 절대배치되는 반면, 날짜 라벨 행은 `flex` 균등 셀
(`flex-1`, 라벨 중심 ≈ `(i+0.5)/n*100%`)로 배치돼 **서로 다른 x 분포**를
사용했다. 두 좌표계가 달라 정렬이 깨졌다.

## 수정
- 날짜 라벨을 점과 **동일한 `points[i].xPct`** 로 절대배치·중앙정렬해
  하나의 좌표 계산을 공유하게 함.
- 끝점(0%/100%) 점·라벨의 절반이 밖으로 잘리지 않도록 선 영역과 라벨
  영역에 **동일한 좌우 인셋**(`px-3`) 적용.
- 값 라벨(점 위 숫자)은 이미 `xPct` 를 쓰므로 그대로 점과 정렬됨.

## 엣지
- 단일 포인트(50%)·2포인트(0/100%)·다포인트, compact(subTrend)·
  일반(작성 추이) 모두 점·라벨 동일 x 사용.
- `computeTrendPoints`(순수함수)·도넛 등 다른 차트는 무변경.

## 검증
- `tsc --noEmit` / `pnpm lint`(0 errors) / `pnpm test`(116 passed) /
  `knip` / `pnpm build` 통과.
- 브라우저 실측은 하지 않음(정적 검증까지).