### PR TITLE
feat: 홈에 어드민 설정 팝업 노출 + 쿠키 다시 보지 않기

### DIFF
--- a/src/app.feature/home/api/popupApi.ts
+++ b/src/app.feature/home/api/popupApi.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@module/api/client';
+import { requestData } from '@module/api/request';
+
+import type { ActivePopup } from '../type/popup';
+
+export const popupApi = {
+  // 오늘(KST) 게시 중 팝업 목록 (시작일 오름차순). 없으면 빈 배열.
+  getActivePopups: (): Promise<ActivePopup[]> =>
+    requestData<ActivePopup[]>(apiClient, {
+      url: '/popups/active',
+      method: 'GET',
+    }),
+};

--- a/src/app.feature/home/components/HomePopup.tsx
+++ b/src/app.feature/home/components/HomePopup.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from '@1d1s/design-system';
+import FadeInImage from '@component/FadeInImage';
+import { cn } from '@module/utils/cn';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+
+import { useActivePopups } from '../hooks/usePopupQueries';
+import {
+  dismissPopupKeys,
+  getDismissedPopupKeys,
+} from '../utils/popupDismissal';
+
+const SLIDE_INTERVAL_MS = 3_000;
+
+interface HomePopupProps {
+  /** 로그인 사용자에게만 노출. false 면 조회하지 않는다. */
+  enabled: boolean;
+}
+
+export default function HomePopup({
+  enabled,
+}: HomePopupProps): React.ReactElement | null {
+  const router = useRouter();
+  const { data: popups = [] } = useActivePopups(enabled);
+
+  // 쿠키에 등록된(=다시 보지 않기) key 는 마운트 시 1회만 읽는다.
+  const [dismissedKeys] = useState(() => new Set(getDismissedPopupKeys()));
+  const [closed, setClosed] = useState(false);
+  const [index, setIndex] = useState(0);
+
+  // 노출 대상 = 응답 팝업 중 쿠키에 없는 것. 시작일 오름차순은 서버가 보장.
+  const visiblePopups = popups.filter(
+    (popup) => popup.imageUrl && !dismissedKeys.has(popup.popupKey)
+  );
+  const count = visiblePopups.length;
+
+  // 노출 대상이 2개 이상이면 3초 간격으로 순환 슬라이드.
+  useEffect(() => {
+    if (closed || count < 2) {
+      return;
+    }
+    const timer = setInterval(() => {
+      setIndex((prev) => (prev + 1) % count);
+    }, SLIDE_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [closed, count]);
+
+  if (closed || count === 0) {
+    return null;
+  }
+
+  const safeIndex = index % count;
+  const current = visiblePopups[safeIndex];
+
+  const close = (): void => setClosed(true);
+
+  // "다시 보지 않기": 현재 노출된 모든 팝업 key 를 쿠키에 등록 후 닫는다.
+  const handleDismiss = (): void => {
+    dismissPopupKeys(visiblePopups.map((popup) => popup.popupKey));
+    close();
+  };
+
+  // CTA: 외부 URL 은 새 탭(noopener), 내부 경로는 클라이언트 이동.
+  const handleCta = (): void => {
+    if (/^https?:\/\//i.test(current.linkUrl)) {
+      window.open(current.linkUrl, '_blank', 'noopener,noreferrer');
+    } else {
+      router.push(current.linkUrl);
+    }
+    close();
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && close()}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogContent
+          className={cn(
+            'fixed top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2',
+            'w-auto max-w-[92vw] rounded-2xl bg-white px-5 pt-5 pb-4'
+          )}
+        >
+          <DialogTitle className="sr-only">이벤트 팝업</DialogTitle>
+          <DialogDescription className="sr-only">
+            {current.ctaText}
+          </DialogDescription>
+          <div className="relative h-[200px] w-[200px] overflow-hidden rounded-xl bg-gray-100">
+            <FadeInImage
+              src={current.imageUrl}
+              alt=""
+              fill
+              sizes="200px"
+              className="object-cover"
+            />
+            {count >= 2 && (
+              <span
+                className={cn(
+                  'absolute right-2 bottom-2 rounded-full',
+                  'bg-black/60 px-2 py-0.5 text-xs text-white'
+                )}
+              >
+                {safeIndex + 1}/{count}
+              </span>
+            )}
+          </div>
+          <div className="mt-4 flex w-[200px] gap-2">
+            <Button
+              variant="secondary"
+              className="h-11 flex-1 rounded-[10px]"
+              onClick={handleDismiss}
+            >
+              다시 보지 않기
+            </Button>
+            <Button
+              variant="primary"
+              className="h-11 flex-1 rounded-[10px]"
+              onClick={handleCta}
+            >
+              {current.ctaText}
+            </Button>
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+}

--- a/src/app.feature/home/consts/popupQueryKeys.ts
+++ b/src/app.feature/home/consts/popupQueryKeys.ts
@@ -1,0 +1,4 @@
+export const POPUP_QUERY_KEYS = {
+  all: ['popups'] as const,
+  active: () => [...POPUP_QUERY_KEYS.all, 'active'] as const,
+};

--- a/src/app.feature/home/hooks/usePopupQueries.ts
+++ b/src/app.feature/home/hooks/usePopupQueries.ts
@@ -1,0 +1,17 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+
+import { popupApi } from '../api/popupApi';
+import { POPUP_QUERY_KEYS } from '../consts/popupQueryKeys';
+import type { ActivePopup } from '../type/popup';
+
+// 로그인 사용자에게만 조회한다. 비로그인/비활성 시 요청하지 않고,
+// 실패해도 조용히 빈 상태로 둔다(호출부에서 미노출 처리).
+export function useActivePopups(
+  enabled: boolean
+): UseQueryResult<ActivePopup[], Error> {
+  return useQuery({
+    queryKey: POPUP_QUERY_KEYS.active(),
+    queryFn: popupApi.getActivePopups,
+    enabled,
+  });
+}

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -12,6 +12,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { useCallback, useState } from 'react';
 
 import HomeNoticeStrip from '../components/HomeNoticeStrip';
+import HomePopup from '../components/HomePopup';
 import HomeQuickActions from '../components/HomeQuickActions';
 import HomeRandomChallengesSection from '../components/HomeRandomChallengesSection';
 import HomeRandomDiariesSection from '../components/HomeRandomDiariesSection';
@@ -135,6 +136,7 @@ export default function HomeScreen({
         description={loginDialogDescription}
         returnTo={loginReturnTo}
       />
+      <HomePopup enabled={isLoggedIn} />
       <div
         className={cn(
           'mx-auto flex w-full max-w-[1200px] flex-col gap-7',

--- a/src/app.feature/home/type/popup.ts
+++ b/src/app.feature/home/type/popup.ts
@@ -1,0 +1,6 @@
+export interface ActivePopup {
+  popupKey: string;
+  imageUrl: string;
+  ctaText: string;
+  linkUrl: string;
+}

--- a/src/app.feature/home/utils/popupDismissal.ts
+++ b/src/app.feature/home/utils/popupDismissal.ts
@@ -1,0 +1,35 @@
+import Cookies from 'js-cookie';
+
+// "다시 보지 않기"로 등록된 팝업 key 목록을 담는 장기 쿠키(JSON 배열).
+// JS 접근 가능한 일반 쿠키다.
+const DISMISSED_POPUPS_COOKIE = '1d1s:dismissedPopups';
+const EXPIRES_DAYS = 365;
+
+export function getDismissedPopupKeys(): string[] {
+  const raw = Cookies.get(DISMISSED_POPUPS_COOKIE);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((key): key is string => typeof key === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+// 현재 노출된 모든 팝업 key 를 기존 목록과 합쳐 쿠키에 등록한다.
+export function dismissPopupKeys(keys: string[]): void {
+  const merged = Array.from(
+    new Set([...getDismissedPopupKeys(), ...keys])
+  );
+  Cookies.set(DISMISSED_POPUPS_COOKIE, JSON.stringify(merged), {
+    expires: EXPIRES_DAYS,
+    sameSite: 'lax',
+    secure:
+      typeof window !== 'undefined' &&
+      window.location.protocol === 'https:',
+  });
+}


### PR DESCRIPTION
## 요약
어드민이 설정한 팝업을 홈(`/`) 첫 진입 시 노출하는 기능. 서버 PR #323(`GET /popups/active`)과 연동.

## 동작
- **조회**: 로그인 사용자 홈 진입 시 `GET /popups/active`(인증) 조회. 비로그인·실패·빈 배열이면 조용히 미노출.
- **쿠키 "다시 보지 않기"**: 응답 팝업 중 **쿠키에 등록되지 않은 것**만 노출 대상. "다시 보지 않기"를 누르면 **현재 노출된 모든 팝업 key 를 일괄 등록**(하나가 아니라 전부)하고 닫는다. 장기 쿠키(365일, JSON 배열, JS 접근 가능).
- **표시**: 200×200 이미지 + 하단에 `다시 보지 않기` / CTA 버튼(서버 `ctaText`). CTA 클릭 시 `linkUrl` 이동 — 외부(http/https)는 `noopener` 새 탭, 내부 경로는 클라이언트 라우팅.
- **여러 개**: 노출 대상 2개 이상이면 **3초 간격 순환 슬라이드**, 이미지 우측 하단 `n/N` 인덱스 표시.
- **닫기(X)**: 쿠키 등록 없이 이번만 닫기.

## 엣지 케이스
| 상황 | 동작 |
|---|---|
| 0개 / 빈 배열 | 미노출 |
| 1개 | 슬라이드·인덱스 없이 단일 노출 |
| N개 | 3초 순환 + `n/N` |
| 전부 쿠키에 등록됨 | 미노출 |
| 비로그인 / 조회 실패 | 미노출(요청 안 함) |

## 파일
- `api/popupApi.ts` · `hooks/usePopupQueries.ts` · `consts/popupQueryKeys.ts` · `type/popup.ts` — `getActivePopups` + `useActivePopups` + `POPUP_QUERY_KEYS`
- `utils/popupDismissal.ts` — 쿠키 get/merge-set (js-cookie 재사용)
- `components/HomePopup.tsx` — 팝업 UI (DS `Dialog` + `FadeInImage`)
- `screen/HomeScreen.tsx` — `isLoggedIn` 게이팅으로 마운트

## 검증
로컬: `tsc --noEmit` · `pnpm lint`(0 errors) · `pnpm test`(116 passed) · `pnpm knip` · `pnpm build` 통과.
브라우저 실동작 확인은 미수행 — 서버 #323 배포 후 확인 필요.