### PR TITLE
feat: 홈에 내가 참여한 챌린지 바로가기 섹션 추가

### DIFF
--- a/src/app.feature/home/components/HomeMineSection.tsx
+++ b/src/app.feature/home/components/HomeMineSection.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { SectionHeader } from '@1d1s/design-system';
+import type { SidebarChallenge } from '@feature/member/type/member';
+import React from 'react';
+
+import HomeMyChallengesSection from './HomeMyChallengesSection';
+import HomeStreakSlot from './HomeStreakSlot';
+import HomeWarmBanner from './HomeWarmBanner';
+
+interface HomeMineSectionProps {
+  isLoggedIn: boolean;
+  streakDays: number;
+  isStreakLoading: boolean;
+  challenges: SidebarChallenge[];
+}
+
+// 배너·현재 스트릭·내 참여 챌린지를 "나와 관련된" 하나의 그룹으로 묶는다.
+// 각 하위 블록이 로그인/로딩별로 동일 높이를 유지하므로 그룹 전체도 인증
+// 상태 전환 시 레이아웃 시프트가 없다. 비로그인 시엔 스트릭·챌린지 블록이
+// 각자 로그인 CTA 로 자연스럽게 전환된다.
+export default function HomeMineSection({
+  isLoggedIn,
+  streakDays,
+  isStreakLoading,
+  challenges,
+}: HomeMineSectionProps): React.ReactElement {
+  return (
+    // 가로 스크롤(내 챌린지)이 화면 끝까지 흐르며 홈 콘텐츠 라인에 맞도록,
+    // 그룹 컨테이너에는 좌우 패딩을 주지 않는다. 그룹감은 공통 헤더 + 하위
+    // 블록보다 좁은 내부 간격(gap-4 < 페이지 gap-7)으로 표현한다.
+    <section className="w-full">
+      <SectionHeader
+        title="나의 활동"
+        subtitle="스트릭과 참여 중인 챌린지를 한눈에"
+        className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
+      />
+
+      <div className="mt-4 flex flex-col gap-4">
+        {/* 모바일/태블릿: 스트릭 슬롯을 배너 위로 올림 */}
+        <div className="lg:hidden">
+          <HomeStreakSlot
+            isLoggedIn={isLoggedIn}
+            streakDays={streakDays}
+            isStreakLoading={isStreakLoading}
+          />
+        </div>
+
+        {/* 배너 + 스트릭 (lg부터 1:1 좌우, 그 이하에선 위쪽 슬롯 사용) */}
+        <div className="grid gap-3 lg:grid-cols-2 lg:gap-5">
+          <HomeWarmBanner />
+          <div className="hidden lg:block">
+            <HomeStreakSlot
+              isLoggedIn={isLoggedIn}
+              streakDays={streakDays}
+              isStreakLoading={isStreakLoading}
+            />
+          </div>
+        </div>
+
+        <HomeMyChallengesSection
+          challenges={challenges}
+          isLoggedIn={isLoggedIn}
+          isLoading={isStreakLoading}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/app.feature/home/components/HomeMyChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeMyChallengesSection.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { Button, SectionHeader } from '@1d1s/design-system';
+import FadeInImage from '@component/FadeInImage';
+import { Skeleton } from '@component/Skeleton';
+import { CategoryIcon, getCategoryStripeTone } from '@constants/categories';
+import { isInfiniteChallengeEndDate } from '@feature/challenge/board/utils/challengePeriod';
+import type { SidebarChallenge } from '@feature/member/type/member';
+import { cn } from '@module/utils/cn';
+import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+import {
+  formatChallengeRemainingLabel,
+  isChallengeEndedOrArchived,
+} from '../utils/homeFormatters';
+
+interface HomeMyChallengesSectionProps {
+  challenges: SidebarChallenge[];
+  isLoggedIn: boolean;
+  /** sidebar 인증/데이터가 아직 확정되지 않은 구간 — 스켈레톤을 노출한다. */
+  isLoading: boolean;
+}
+
+// 로그인/로딩/빈 상태/CTA 가 모두 같은 높이를 차지하도록 body 영역 높이를
+// 예약해, 인증 상태가 확정되며 콘텐츠가 바뀌어도 레이아웃 시프트가 없게 한다.
+const BODY_MIN = 'min-h-[168px]';
+
+const CARD_ITEM = 'w-[128px] shrink-0';
+
+function CompactCardThumb({
+  challenge,
+}: {
+  challenge: SidebarChallenge;
+}): React.ReactElement {
+  return (
+    <div className="bg-main-100 relative aspect-[4/3] overflow-hidden rounded-lg">
+      {challenge.thumbnailImage ? (
+        <FadeInImage
+          src={challenge.thumbnailImage}
+          alt={challenge.title}
+          fill
+          sizes="128px"
+          className="object-cover"
+        />
+      ) : (
+        <span
+          className={cn(
+            'absolute inset-0 flex items-center justify-center text-white',
+            '[&_svg]:!h-6 [&_svg]:!w-6'
+          )}
+          style={{ backgroundColor: getCategoryStripeTone(challenge.category) }}
+          aria-hidden
+        >
+          <CategoryIcon category={challenge.category} className="h-6 w-6" />
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function HomeMyChallengesSection({
+  challenges,
+  isLoggedIn,
+  isLoading,
+}: HomeMyChallengesSectionProps): React.ReactElement {
+  const router = useRouter();
+
+  // 진행 중 위주 — 종료/아카이브된 챌린지는 바로가기에서 제외한다.
+  const ongoing = challenges.filter(
+    (challenge) =>
+      !isChallengeEndedOrArchived(challenge.endDate, challenge.participantCnt)
+  );
+
+  const showList = isLoggedIn && !isLoading && ongoing.length > 0;
+
+  return (
+    <section className="w-full">
+      <SectionHeader
+        title="내가 참여한 챌린지"
+        subtitle="바로 이어서 도전해보세요"
+        actionLabel={showList ? '전체보기 →' : undefined}
+        onActionClick={showList ? () => router.push('/challenge') : undefined}
+        className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
+      />
+
+      {/* 비로그인 CTA */}
+      {!isLoggedIn ? (
+        <button
+          type="button"
+          onClick={() => router.push(loginUrlFromCurrentLocation())}
+          aria-label="로그인하고 내 챌린지 확인하기"
+          className={cn(
+            'rounded-3 mt-4 flex w-full flex-col justify-center gap-2',
+            BODY_MIN,
+            'from-main-100 via-main-200/40 to-main-200 bg-gradient-to-br',
+            'group cursor-pointer p-5 text-left transition',
+            'hover:brightness-105'
+          )}
+        >
+          <span className="text-[15px] font-extrabold tracking-tight text-gray-900">
+            로그인하고 내 챌린지 확인하기
+          </span>
+          <span className="text-[12px] text-gray-600">
+            참여 중인 챌린지를 홈에서 바로 이어가세요.
+          </span>
+          <span
+            className={cn(
+              'mt-1 inline-flex items-center self-start rounded-full',
+              'bg-brand px-3 py-1 text-[11px] font-bold text-white'
+            )}
+          >
+            로그인하기 →
+          </span>
+        </button>
+      ) : null}
+
+      {/* 로딩 스켈레톤 — 리스트와 동일 높이 */}
+      {isLoggedIn && isLoading ? (
+        <div
+          className={cn(
+            '-mx-5 mt-4 flex gap-3 overflow-x-auto px-5 py-2',
+            'scrollbar-hide',
+            BODY_MIN
+          )}
+        >
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className={CARD_ITEM}>
+              <Skeleton shape="rounded" className="aspect-[4/3] w-full" />
+              <Skeleton shape="text" className="mt-2 h-4 w-4/5" />
+              <Skeleton shape="text" className="mt-1.5 h-3 w-1/2" />
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {/* 로그인 + 진행 중 챌린지 리스트 */}
+      {showList ? (
+        <div
+          className={cn(
+            '-mx-5 mt-4 flex gap-3 overflow-x-auto px-5 py-2',
+            'scrollbar-hide data-fade-in',
+            BODY_MIN
+          )}
+        >
+          {ongoing.map((challenge) => {
+            const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
+            const remainingLabel = formatChallengeRemainingLabel(
+              challenge.endDate,
+              isInfinite,
+              false
+            );
+
+            return (
+              <Link
+                key={challenge.challengeId}
+                href={`/challenge/${challenge.challengeId}`}
+                aria-label={`${challenge.title} 챌린지 보기`}
+                className={cn(CARD_ITEM, 'group')}
+              >
+                <CompactCardThumb challenge={challenge} />
+                <p
+                  className={cn(
+                    'mt-2 line-clamp-2 min-h-[2.4em] text-[13px]',
+                    'leading-tight font-semibold text-gray-800',
+                    'group-hover:text-main-800 transition-colors'
+                  )}
+                >
+                  {challenge.title}
+                </p>
+                <span className="text-brand mt-0.5 block text-[11px] font-bold">
+                  {remainingLabel}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {/* 로그인 + 진행 중 0개 빈 상태 */}
+      {isLoggedIn && !isLoading && ongoing.length === 0 ? (
+        <div
+          className={cn(
+            'mt-4 flex w-full flex-col items-center justify-center gap-3',
+            BODY_MIN,
+            'rounded-3 border-main-200 border border-dashed p-5 text-center'
+          )}
+        >
+          <p className="text-[13px] text-gray-600">
+            아직 참여 중인 챌린지가 없어요.
+          </p>
+          <Button size="sm" onClick={() => router.push('/challenge')}>
+            챌린지 둘러보기
+          </Button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app.feature/home/components/HomeMyChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeMyChallengesSection.tsx
@@ -38,8 +38,12 @@ const ROW_MIN = 'min-h-[288px]';
 // 모바일에서 다음 카드가 살짝 보이도록(peek) 카드 폭을 고정한다.
 const CARD_ITEM = 'w-[260px] shrink-0 snap-start';
 
+// 스크롤 컨테이너는 화면 끝까지 흐르되, 내부 좌우 패딩을 홈 콘텐츠 라인
+// (모바일 px-5 / lg px-8)과 동일하게 줘 첫 카드 좌측·마지막 카드 우측 정렬을
+// 다른 홈 섹션과 맞춘다.
 const SCROLL_ROW = cn(
   '-mx-5 mt-4 flex gap-3 overflow-x-auto px-5 py-2',
+  'lg:-mx-8 lg:px-8',
   'scrollbar-hide snap-x snap-mandatory',
   ROW_MIN
 );
@@ -62,11 +66,10 @@ export default function HomeMyChallengesSection({
   return (
     <section className="w-full">
       <SectionHeader
-        title="내가 참여한 챌린지"
-        subtitle="바로 이어서 도전해보세요"
+        size="sm"
+        title="참여 중인 챌린지"
         actionLabel={showList ? '전체보기 →' : undefined}
         onActionClick={showList ? () => router.push('/challenge') : undefined}
-        className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
       />
 
       {/* 비로그인 CTA — 리스트와 동일 높이 */}

--- a/src/app.feature/home/components/HomeMyChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeMyChallengesSection.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import { Button, SectionHeader } from '@1d1s/design-system';
-import FadeInImage from '@component/FadeInImage';
-import { Skeleton } from '@component/Skeleton';
-import { CategoryIcon, getCategoryStripeTone } from '@constants/categories';
+import ChallengeCard, {
+  type ChallengeCardGoalType,
+} from '@component/cards/ChallengeCard';
+import { ChallengeCardSkeleton } from '@component/skeletons/ChallengeCardSkeleton';
+import {
+  CategoryIcon,
+  getCategoryLabel,
+  getCategoryStripeTone,
+} from '@constants/categories';
 import { isInfiniteChallengeEndDate } from '@feature/challenge/board/utils/challengePeriod';
 import type { SidebarChallenge } from '@feature/member/type/member';
 import { cn } from '@module/utils/cn';
 import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -24,42 +29,20 @@ interface HomeMyChallengesSectionProps {
   isLoading: boolean;
 }
 
-// 로그인/로딩/빈 상태/CTA 가 모두 같은 높이를 차지하도록 body 영역 높이를
-// 예약해, 인증 상태가 확정되며 콘텐츠가 바뀌어도 레이아웃 시프트가 없게 한다.
-const BODY_MIN = 'min-h-[168px]';
+// 리스트/스켈레톤/빈 상태/비로그인 CTA 4개 상태가 모두 같은 높이를 차지하도록
+// ChallengeCard 실제 높이(썸네일 21/9 + 제목 2줄 클램프 + 고정 메타 ≈ 280px)에
+// 맞춰 영역 높이를 예약한다. 카드보다 살짝 크게 잡아 CTA 가 카드보다 낮아지며
+// 생기는 시프트를 막는다(넉넉한 쪽은 중앙 정렬이라 눈에 띄지 않는다).
+const ROW_MIN = 'min-h-[288px]';
 
-const CARD_ITEM = 'w-[128px] shrink-0';
+// 모바일에서 다음 카드가 살짝 보이도록(peek) 카드 폭을 고정한다.
+const CARD_ITEM = 'w-[260px] shrink-0 snap-start';
 
-function CompactCardThumb({
-  challenge,
-}: {
-  challenge: SidebarChallenge;
-}): React.ReactElement {
-  return (
-    <div className="bg-main-100 relative aspect-[4/3] overflow-hidden rounded-lg">
-      {challenge.thumbnailImage ? (
-        <FadeInImage
-          src={challenge.thumbnailImage}
-          alt={challenge.title}
-          fill
-          sizes="128px"
-          className="object-cover"
-        />
-      ) : (
-        <span
-          className={cn(
-            'absolute inset-0 flex items-center justify-center text-white',
-            '[&_svg]:!h-6 [&_svg]:!w-6'
-          )}
-          style={{ backgroundColor: getCategoryStripeTone(challenge.category) }}
-          aria-hidden
-        >
-          <CategoryIcon category={challenge.category} className="h-6 w-6" />
-        </span>
-      )}
-    </div>
-  );
-}
+const SCROLL_ROW = cn(
+  '-mx-5 mt-4 flex gap-3 overflow-x-auto px-5 py-2',
+  'scrollbar-hide snap-x snap-mandatory',
+  ROW_MIN
+);
 
 export default function HomeMyChallengesSection({
   challenges,
@@ -86,7 +69,7 @@ export default function HomeMyChallengesSection({
         className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
       />
 
-      {/* 비로그인 CTA */}
+      {/* 비로그인 CTA — 리스트와 동일 높이 */}
       {!isLoggedIn ? (
         <button
           type="button"
@@ -94,22 +77,22 @@ export default function HomeMyChallengesSection({
           aria-label="로그인하고 내 챌린지 확인하기"
           className={cn(
             'rounded-3 mt-4 flex w-full flex-col justify-center gap-2',
-            BODY_MIN,
+            ROW_MIN,
             'from-main-100 via-main-200/40 to-main-200 bg-gradient-to-br',
-            'group cursor-pointer p-5 text-left transition',
+            'group cursor-pointer p-6 text-left transition',
             'hover:brightness-105'
           )}
         >
-          <span className="text-[15px] font-extrabold tracking-tight text-gray-900">
+          <span className="text-[17px] font-extrabold tracking-tight text-gray-900">
             로그인하고 내 챌린지 확인하기
           </span>
-          <span className="text-[12px] text-gray-600">
+          <span className="text-[13px] text-gray-600">
             참여 중인 챌린지를 홈에서 바로 이어가세요.
           </span>
           <span
             className={cn(
               'mt-1 inline-flex items-center self-start rounded-full',
-              'bg-brand px-3 py-1 text-[11px] font-bold text-white'
+              'bg-brand px-3.5 py-1.5 text-[12px] font-bold text-white'
             )}
           >
             로그인하기 →
@@ -117,20 +100,12 @@ export default function HomeMyChallengesSection({
         </button>
       ) : null}
 
-      {/* 로딩 스켈레톤 — 리스트와 동일 높이 */}
+      {/* 로딩 스켈레톤 — 카드와 동일 크기/높이 */}
       {isLoggedIn && isLoading ? (
-        <div
-          className={cn(
-            '-mx-5 mt-4 flex gap-3 overflow-x-auto px-5 py-2',
-            'scrollbar-hide',
-            BODY_MIN
-          )}
-        >
+        <div className={SCROLL_ROW}>
           {Array.from({ length: 4 }).map((_, index) => (
             <div key={index} className={CARD_ITEM}>
-              <Skeleton shape="rounded" className="aspect-[4/3] w-full" />
-              <Skeleton shape="text" className="mt-2 h-4 w-4/5" />
-              <Skeleton shape="text" className="mt-1.5 h-3 w-1/2" />
+              <ChallengeCardSkeleton />
             </div>
           ))}
         </div>
@@ -138,13 +113,7 @@ export default function HomeMyChallengesSection({
 
       {/* 로그인 + 진행 중 챌린지 리스트 */}
       {showList ? (
-        <div
-          className={cn(
-            '-mx-5 mt-4 flex gap-3 overflow-x-auto px-5 py-2',
-            'scrollbar-hide data-fade-in',
-            BODY_MIN
-          )}
-        >
+        <div className={cn(SCROLL_ROW, 'data-fade-in')}>
           {ongoing.map((challenge) => {
             const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
             const remainingLabel = formatChallengeRemainingLabel(
@@ -154,41 +123,45 @@ export default function HomeMyChallengesSection({
             );
 
             return (
-              <Link
-                key={challenge.challengeId}
-                href={`/challenge/${challenge.challengeId}`}
-                aria-label={`${challenge.title} 챌린지 보기`}
-                className={cn(CARD_ITEM, 'group')}
-              >
-                <CompactCardThumb challenge={challenge} />
-                <p
-                  className={cn(
-                    'mt-2 line-clamp-2 min-h-[2.4em] text-[13px]',
-                    'leading-tight font-semibold text-gray-800',
-                    'group-hover:text-main-800 transition-colors'
-                  )}
-                >
-                  {challenge.title}
-                </p>
-                <span className="text-brand mt-0.5 block text-[11px] font-bold">
-                  {remainingLabel}
-                </span>
-              </Link>
+              <div key={challenge.challengeId} className={CARD_ITEM}>
+                <ChallengeCard
+                  title={challenge.title}
+                  category={getCategoryLabel(challenge.category)}
+                  categoryIcon={
+                    <CategoryIcon
+                      category={challenge.category}
+                      className="h-3 w-3"
+                    />
+                  }
+                  stripeTone={getCategoryStripeTone(challenge.category)}
+                  imageUrl={challenge.thumbnailImage ?? undefined}
+                  currentParticipantCount={challenge.participantCnt}
+                  maxParticipantCount={challenge.maxParticipantCnt}
+                  remainingLabel={remainingLabel}
+                  startDate={challenge.startDate}
+                  endDate={challenge.endDate}
+                  isInfinite={isInfinite}
+                  goalType={challenge.goalType as ChallengeCardGoalType}
+                  isGroup={challenge.participationType === 'GROUP'}
+                  isEnded={false}
+                  href={`/challenge/${challenge.challengeId}`}
+                />
+              </div>
             );
           })}
         </div>
       ) : null}
 
-      {/* 로그인 + 진행 중 0개 빈 상태 */}
+      {/* 로그인 + 진행 중 0개 빈 상태 — 리스트와 동일 높이 */}
       {isLoggedIn && !isLoading && ongoing.length === 0 ? (
         <div
           className={cn(
             'mt-4 flex w-full flex-col items-center justify-center gap-3',
-            BODY_MIN,
-            'rounded-3 border-main-200 border border-dashed p-5 text-center'
+            ROW_MIN,
+            'rounded-3 border-main-200 border border-dashed p-6 text-center'
           )}
         >
-          <p className="text-[13px] text-gray-600">
+          <p className="text-[14px] text-gray-600">
             아직 참여 중인 챌린지가 없어요.
           </p>
           <Button size="sm" onClick={() => router.push('/challenge')}>

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -11,14 +11,12 @@ import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { useCallback, useState } from 'react';
 
-import HomeMyChallengesSection from '../components/HomeMyChallengesSection';
+import HomeMineSection from '../components/HomeMineSection';
 import HomeNoticeStrip from '../components/HomeNoticeStrip';
 import HomePopup from '../components/HomePopup';
 import HomeQuickActions from '../components/HomeQuickActions';
 import HomeRandomChallengesSection from '../components/HomeRandomChallengesSection';
 import HomeRandomDiariesSection from '../components/HomeRandomDiariesSection';
-import HomeStreakSlot from '../components/HomeStreakSlot';
-import HomeWarmBanner from '../components/HomeWarmBanner';
 import HomeWarmGreeting from '../components/HomeWarmGreeting';
 import { useHomeRandomData } from '../hooks/useHomeRandomData';
 import { useHomeRandomDiaryLike } from '../hooks/useHomeRandomDiaryLike';
@@ -158,40 +156,20 @@ export default function HomeScreen({
           <HomeWarmGreeting />
         </div>
 
-        {/* 모바일/태블릿: 스트릭 슬롯을 배너 위로 올림 */}
-        <div className="lg:hidden">
-          <HomeStreakSlot
-            isLoggedIn={isLoggedIn}
-            streakDays={streakDays}
-            isStreakLoading={isStreakLoading}
-          />
-        </div>
-
-        {/* Banner + StreakHero row (lg부터 1:1 좌우, 그 이하에선 위쪽 슬롯 사용) */}
-        <div className="grid gap-3 lg:grid-cols-2 lg:gap-5">
-          <HomeWarmBanner />
-          <div className="hidden lg:block">
-            <HomeStreakSlot
-              isLoggedIn={isLoggedIn}
-              streakDays={streakDays}
-              isStreakLoading={isStreakLoading}
-            />
-          </div>
-        </div>
+        {/* 나와 관련된 블록(배너·현재 스트릭·내 참여 챌린지)을 하나의 그룹으로.
+            sidebar 로딩 판정은 스트릭·챌린지 블록이 공유(isStreakLoading)해
+            인증 확정 전에도 동일 높이를 예약, 레이아웃 시프트를 막는다. */}
+        <HomeMineSection
+          isLoggedIn={isLoggedIn}
+          streakDays={streakDays}
+          isStreakLoading={isStreakLoading}
+          challenges={sidebar?.challengeList ?? []}
+        />
 
         <div className="flex flex-col gap-3">
           <HomeNoticeStrip />
           <HomeQuickActions />
         </div>
-
-        {/* 내가 참여한 챌린지 바로가기 — 비로그인 시 로그인 유도 CTA.
-            sidebar 로딩 판정은 스트릭 슬롯과 동일한 신호(isStreakLoading)를
-            재사용해 인증 확정 전에도 동일 높이를 예약한다. */}
-        <HomeMyChallengesSection
-          challenges={sidebar?.challengeList ?? []}
-          isLoggedIn={isLoggedIn}
-          isLoading={isStreakLoading}
-        />
 
         <HomeRandomChallengesSection
           challenges={randomChallenges}

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -11,6 +11,7 @@ import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { useCallback, useState } from 'react';
 
+import HomeMyChallengesSection from '../components/HomeMyChallengesSection';
 import HomeNoticeStrip from '../components/HomeNoticeStrip';
 import HomePopup from '../components/HomePopup';
 import HomeQuickActions from '../components/HomeQuickActions';
@@ -182,6 +183,15 @@ export default function HomeScreen({
           <HomeNoticeStrip />
           <HomeQuickActions />
         </div>
+
+        {/* 내가 참여한 챌린지 바로가기 — 비로그인 시 로그인 유도 CTA.
+            sidebar 로딩 판정은 스트릭 슬롯과 동일한 신호(isStreakLoading)를
+            재사용해 인증 확정 전에도 동일 높이를 예약한다. */}
+        <HomeMyChallengesSection
+          challenges={sidebar?.challengeList ?? []}
+          isLoggedIn={isLoggedIn}
+          isLoading={isStreakLoading}
+        />
 
         <HomeRandomChallengesSection
           challenges={randomChallenges}


### PR DESCRIPTION
## 요약

홈에 **내가 참여한 챌린지 바로가기** 섹션을 추가했습니다. `HomeQuickActions` 아래, 기존 "오늘 시작해볼 챌린지"(랜덤) 섹션 위에 배치됩니다.

## 동작

- **로그인**: 진행 중인 챌린지를 가로 스크롤 컴팩트 카드(썸네일·제목·남은 기간)로 노출. 각 카드는 `<Link href="/challenge/{id}">`(prefetch)로 상세 이동.
- **비로그인**: 같은 자리에 "로그인하고 내 챌린지 확인하기" CTA → 로그인 동선(`loginUrlFromCurrentLocation`).
- **진행 중 0개**: "챌린지 둘러보기" 빈 상태(→ `/challenge`).

## 데이터 소스 (재사용)

- 홈에서 이미 호출 중인 `useSidebar()`의 `challengeList`를 그대로 재사용 — **신규 네트워크 요청 없음**.
- 진행 중 기준: `!isChallengeEndedOrArchived(endDate, participantCnt)`로 종료/아카이브 제외 (MyPage·랜덤 섹션과 동일한 판정 유틸 재사용).

## 레이아웃 시프트 방지

- 로그인/로딩/빈 상태/CTA **4개 상태 모두 동일한 고정 높이**(`min-h-[168px]`)를 차지하도록 body 영역을 예약.
- sidebar 인증/데이터가 확정되기 전 구간에는 스트릭 슬롯과 **동일한 로딩 신호**(`isStreakLoading`)로 컴팩트 카드 스켈레톤을 노출 → 인증 상태 확정 시 점프 없음.

## 엣지 케이스

- 로딩: 동일 높이 스켈레톤 4개.
- 0개: 동일 높이 빈 상태 + CTA.
- 썸네일 없음: 카테고리 색 배경 + 카테고리 아이콘 fallback.
- 에러: 별도 UI 없이 sidebar 캐시가 비면 빈 상태로 수렴(홈 다른 섹션과 동일 정책).

## 검증

- `tsc --noEmit` ✅ / `pnpm lint`(신규 파일 클린) ✅ / `vitest`(118 통과) ✅ / `knip` ✅ / `next build` ✅
- CLAUDE.md 정책에 따라 브라우저 preview 확인은 하지 않았습니다(사용자 직접 확인).