### PR TITLE
refactor: 스토리 상세 뷰어 디자인 시스템 정합화

### DIFF
--- a/src/app.feature/stories/components/StoryViewer.tsx
+++ b/src/app.feature/stories/components/StoryViewer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CircleAvatar, Icon, Stripe, Text } from '@1d1s/design-system';
+import { Button, CircleAvatar, Icon, Stripe, Text } from '@1d1s/design-system';
 import FadeInImage from '@component/FadeInImage';
 import { cn } from '@module/utils/cn';
 import { resolveDiaryImageUrl } from '@module/utils/diaryImageUrl';
@@ -191,7 +191,7 @@ export default function StoryViewer({
           'bg-white/15 text-white backdrop-blur sm:left-6 sm:flex'
         )}
       >
-        ‹
+        <Icon name="ChevronLeft" size={22} aria-hidden />
       </button>
       <button
         type="button"
@@ -203,7 +203,7 @@ export default function StoryViewer({
           'bg-white/15 text-white backdrop-blur sm:right-6 sm:flex'
         )}
       >
-        ›
+        <Icon name="ChevronRight" size={22} aria-hidden />
       </button>
 
       <div
@@ -267,7 +267,7 @@ export default function StoryViewer({
               'bg-black/40 text-white backdrop-blur-sm'
             )}
           >
-            ✕
+            <Icon name="Close" size={18} aria-hidden />
           </button>
 
           <button
@@ -318,7 +318,7 @@ export default function StoryViewer({
               <div className="flex min-w-0 flex-col">
                 <Text
                   size="caption1"
-                  weight="bold"
+                  weight="semibold"
                   className="truncate text-gray-900"
                 >
                   {name}
@@ -332,18 +332,16 @@ export default function StoryViewer({
               </div>
             </div>
 
-            <button
-              type="button"
+            <Button
+              variant="primary"
+              size="sm"
+              pill
+              className="shrink-0"
               onClick={handleOpenDiary}
-              className={cn(
-                'inline-flex shrink-0 cursor-pointer items-center gap-1',
-                'bg-main-700 hover:bg-main-800 rounded-full px-3.5 py-2',
-                'text-xs font-bold text-white transition-colors'
-              )}
+              iconRight={<Icon name="ChevronRight" size={14} aria-hidden />}
             >
               일지 보기
-              <Icon name="ChevronRight" size={12} />
-            </button>
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 개요
레거시 톤이 남아 있던 **스토리 상세 뷰어**(`StoryViewer`)를 현행 디자인 시스템(@1d1s/design-system)에 맞춰 정합화했습니다. 기능·데이터 흐름은 그대로 두고 디자인/구조만 현행화합니다.

## 레거시로 판단한 항목 → 교체
- 이전/다음/닫기 컨트롤이 **텍스트 글리프**(`‹` `›` `✕`)로 구현되어 있어 플랫폼별 렌더가 들쭉날쭉 → **DS `Icon`**(`ChevronLeft` / `ChevronRight` / `Close`)로 교체
- '일지 보기' CTA가 **자체 구현 버튼**(`bg-main-700` 하드코딩 + `text-xs font-bold` + 수동 hover/transition) → **DS `Button`**(`variant="primary"`, `pill`, `iconRight`)으로 대체
- 작성자 이름의 불필요한 `font-bold` → `semibold`로 완화(볼드는 위계상 필요한 타이틀에만 유지)

## 적용한 DS 컴포넌트
- `Button` (primary / pill / iconRight) — '일지 보기' CTA
- `Icon` (`ChevronLeft`, `ChevronRight`, `Close`) — 이전/다음/닫기 컨트롤

## Before / After (구조)
- Before: 오버레이 컨트롤·CTA가 각각 raw `<button>` + 하드코딩 클래스/글리프
- After: 오버레이 컨트롤은 DS `Icon`, CTA는 DS `Button`으로 통일. 진행바·자동 전환·인덱스 로직 등 동작 코드는 무변경

## 범위 밖 (의도적으로 두지 않음)
- 홈 스토리 캐러셀(`StoryRing`/`Stories`/`StoryRingSkeleton`)은 최근 리뉴얼된 화면들과 동일한 warm-gradient 카드 언어를 이미 따르고 있어 '상세' 범위에서 제외

## 검증 (로컬, 정적)
- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test` (vitest) ✅ 116 passed
- `pnpm knip` ✅
- `pnpm build` ✅

브라우저 실사용 확인은 프로젝트 정책에 따라 사용자 확인에 맡깁니다(직접 preview로 띄워 확인하지 않음).