### PR TITLE
fix: 홈 "나의 활동" 섹션 최상단 이동·패널화·카드 정렬 정합

### DIFF
--- a/src/app.feature/home/components/HomeMineSection.tsx
+++ b/src/app.feature/home/components/HomeMineSection.tsx
@@ -26,43 +26,45 @@ export default function HomeMineSection({
   challenges,
 }: HomeMineSectionProps): React.ReactElement {
   return (
-    // 가로 스크롤(내 챌린지)이 화면 끝까지 흐르며 홈 콘텐츠 라인에 맞도록,
-    // 그룹 컨테이너에는 좌우 패딩을 주지 않는다. 그룹감은 공통 헤더 + 하위
-    // 블록보다 좁은 내부 간격(gap-4 < 페이지 gap-7)으로 표현한다.
+    // "나의 활동"을 테두리+연회색 배경 패널로 묶어 하나의 섹션임을 드러낸다.
+    // 하위 블록(배너·스트릭·내 챌린지)은 모두 패널 내부 패딩 기준으로 정렬되고,
+    // 내 챌린지 가로 스크롤도 패널 안에서만 좌우로 흐른다(HomeMyChallengesSection).
     <section className="w-full">
-      <SectionHeader
-        title="나의 활동"
-        subtitle="스트릭과 참여 중인 챌린지를 한눈에"
-        className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
-      />
+      <div className="rounded-4 border border-gray-200 bg-gray-50 p-5 lg:p-6">
+        <SectionHeader
+          title="나의 활동"
+          subtitle="스트릭과 참여 중인 챌린지를 한눈에"
+          className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
+        />
 
-      <div className="mt-4 flex flex-col gap-4">
-        {/* 모바일/태블릿: 스트릭 슬롯을 배너 위로 올림 */}
-        <div className="lg:hidden">
-          <HomeStreakSlot
-            isLoggedIn={isLoggedIn}
-            streakDays={streakDays}
-            isStreakLoading={isStreakLoading}
-          />
-        </div>
-
-        {/* 배너 + 스트릭 (lg부터 1:1 좌우, 그 이하에선 위쪽 슬롯 사용) */}
-        <div className="grid gap-3 lg:grid-cols-2 lg:gap-5">
-          <HomeWarmBanner />
-          <div className="hidden lg:block">
+        <div className="mt-4 flex flex-col gap-4">
+          {/* 모바일/태블릿: 스트릭 슬롯을 배너 위로 올림 */}
+          <div className="lg:hidden">
             <HomeStreakSlot
               isLoggedIn={isLoggedIn}
               streakDays={streakDays}
               isStreakLoading={isStreakLoading}
             />
           </div>
-        </div>
 
-        <HomeMyChallengesSection
-          challenges={challenges}
-          isLoggedIn={isLoggedIn}
-          isLoading={isStreakLoading}
-        />
+          {/* 배너 + 스트릭 (lg부터 1:1 좌우, 그 이하에선 위쪽 슬롯 사용) */}
+          <div className="grid gap-3 lg:grid-cols-2 lg:gap-5">
+            <HomeWarmBanner />
+            <div className="hidden lg:block">
+              <HomeStreakSlot
+                isLoggedIn={isLoggedIn}
+                streakDays={streakDays}
+                isStreakLoading={isStreakLoading}
+              />
+            </div>
+          </div>
+
+          <HomeMyChallengesSection
+            challenges={challenges}
+            isLoggedIn={isLoggedIn}
+            isLoading={isStreakLoading}
+          />
+        </div>
       </div>
     </section>
   );

--- a/src/app.feature/home/components/HomeMyChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeMyChallengesSection.tsx
@@ -38,12 +38,11 @@ const ROW_MIN = 'min-h-[288px]';
 // 모바일에서 다음 카드가 살짝 보이도록(peek) 카드 폭을 고정한다.
 const CARD_ITEM = 'w-[260px] shrink-0 snap-start';
 
-// 스크롤 컨테이너는 화면 끝까지 흐르되, 내부 좌우 패딩을 홈 콘텐츠 라인
-// (모바일 px-5 / lg px-8)과 동일하게 줘 첫 카드 좌측·마지막 카드 우측 정렬을
-// 다른 홈 섹션과 맞춘다.
+// "나의 활동" 패널 내부에 놓이므로 화면 끝까지 breakout 하지 않는다. 스크롤
+// 컨테이너는 패널 내부 패딩 라인에서 시작해(첫 카드 좌측 = 헤더·배너와 동일
+// 세로선) 우측으로만 흐른다. py-2 는 카드 그림자 세로 여백 확보용.
 const SCROLL_ROW = cn(
-  '-mx-5 mt-4 flex gap-3 overflow-x-auto px-5 py-2',
-  'lg:-mx-8 lg:px-8',
+  'mt-4 flex gap-3 overflow-x-auto py-2',
   'scrollbar-hide snap-x snap-mandatory',
   ROW_MIN
 );

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -142,6 +142,17 @@ export default function HomeScreen({
           'px-5 py-7 lg:px-8 lg:py-10'
         )}
       >
+        {/* 나와 관련된 블록(배너·현재 스트릭·내 참여 챌린지)을 하나의 그룹으로
+            묶어 홈 최상단에 노출한다. sidebar 로딩 판정은 스트릭·챌린지 블록이
+            공유(isStreakLoading)해 인증 확정 전에도 동일 높이를 예약,
+            레이아웃 시프트를 막는다. */}
+        <HomeMineSection
+          isLoggedIn={isLoggedIn}
+          streakDays={streakDays}
+          isStreakLoading={isStreakLoading}
+          challenges={sidebar?.challengeList ?? []}
+        />
+
         {/* 친구들의 일지 스토리 — 비로그인 시 로그인 유도 슬롯 노출 */}
         <div className="-mx-5 lg:-mx-8">
           <Stories
@@ -155,16 +166,6 @@ export default function HomeScreen({
         <div className="lg:hidden">
           <HomeWarmGreeting />
         </div>
-
-        {/* 나와 관련된 블록(배너·현재 스트릭·내 참여 챌린지)을 하나의 그룹으로.
-            sidebar 로딩 판정은 스트릭·챌린지 블록이 공유(isStreakLoading)해
-            인증 확정 전에도 동일 높이를 예약, 레이아웃 시프트를 막는다. */}
-        <HomeMineSection
-          isLoggedIn={isLoggedIn}
-          streakDays={streakDays}
-          isStreakLoading={isStreakLoading}
-          challenges={sidebar?.challengeList ?? []}
-        />
 
         <div className="flex flex-col gap-3">
           <HomeNoticeStrip />


### PR DESCRIPTION
## 배경
홈 "나의 활동" 섹션(#160) 관련 사용자 피드백 3건 수정.

## 변경 사항
1. **최상단 이동** — `HomeScreen`에서 나의 활동 블록(제목·배너·스트릭·참여
   중인 챌린지)을 스토리보다 위, 홈 최상단으로 옮겨 데스크톱에서 제목이
   확실히 먼저 보이게 함.
2. **패널화** — `HomeMineSection`을 `rounded-4 border border-gray-200
   bg-gray-50 p-5 lg:p-6` 패널로 묶어 하나의 섹션임을 시각적으로 드러냄.
   하위 블록은 모두 패널 내부 패딩 기준으로 정렬.
3. **카드 정렬 버그 수정** — `HomeMyChallengesSection`의 가로 스크롤에서
   화면 끝 breakout(`-mx-5 lg:-mx-8` + `px`)을 제거. 패널 내부 패딩 라인에서
   시작하므로 첫 카드 좌측이 "참여 중인 챌린지" 헤더·배너와 정확히 같은
   세로선에 맞고, 스크롤은 패널 안에서만 우측으로 흐름. (기존엔 카드가
   콘텐츠 라인보다 약 47px 왼쪽으로 삐져나옴.)

## 유지
- 4개 상태(리스트/스켈레톤/빈 상태/비로그인 CTA) 동일 높이 → 레이아웃
  시프트 방지.
- 비로그인 CTA.
- 기능 변경 없음.

## 검증
- `tsc --noEmit` ✅ / `eslint src` ✅(신규 에러 0) / `vitest` ✅(116 passed)
- `knip` ✅ / `next build` ✅
- 브라우저 확인은 진행하지 않음(프로젝트 정책상 사용자 확인). 모바일/
  데스크톱 실제 렌더 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Redesigned the “My Activity” section with a unified bordered panel, gray background, rounded corners, and responsive spacing.
  * Moved the “My Activity” section higher on the home screen for improved visibility.
  * Improved the alignment and spacing of the horizontal “My Challenges” list across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->