### PR TITLE
feat: 홈 '나의 활동' 패널에 스토리를 최상단으로 편입

### DIFF
--- a/src/app.feature/home/components/HomeMineSection.tsx
+++ b/src/app.feature/home/components/HomeMineSection.tsx
@@ -2,6 +2,7 @@
 
 import { SectionHeader } from '@1d1s/design-system';
 import type { SidebarChallenge } from '@feature/member/type/member';
+import Stories from '@feature/stories/components/Stories';
 import React from 'react';
 
 import HomeMyChallengesSection from './HomeMyChallengesSection';
@@ -13,6 +14,10 @@ interface HomeMineSectionProps {
   streakDays: number;
   isStreakLoading: boolean;
   challenges: SidebarChallenge[];
+  /** 스토리 조회 쿼리 활성화 여부 */
+  storiesFetchEnabled: boolean;
+  /** 비로그인 상태에서 스토리 클릭 시 로그인 유도 */
+  onRequireLogin(): void;
 }
 
 // 배너·현재 스트릭·내 참여 챌린지를 "나와 관련된" 하나의 그룹으로 묶는다.
@@ -24,6 +29,8 @@ export default function HomeMineSection({
   streakDays,
   isStreakLoading,
   challenges,
+  storiesFetchEnabled,
+  onRequireLogin,
 }: HomeMineSectionProps): React.ReactElement {
   return (
     // "나의 활동"을 테두리+연회색 배경 패널로 묶어 하나의 섹션임을 드러낸다.
@@ -38,6 +45,15 @@ export default function HomeMineSection({
         />
 
         <div className="mt-4 flex flex-col gap-4">
+          {/* 친구들의 일지 스토리 — 패널 최상단. 비로그인 시 로그인 유도 슬롯.
+              좌우 패딩 없이 패널 내부 라인에서 시작해 배너·챌린지 카드와
+              좌측 세로선을 맞춘다. */}
+          <Stories
+            isLoggedIn={isLoggedIn}
+            fetchEnabled={storiesFetchEnabled}
+            onRequireLogin={onRequireLogin}
+          />
+
           {/* 모바일/태블릿: 스트릭 슬롯을 배너 위로 올림 */}
           <div className="lg:hidden">
             <HomeStreakSlot

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -4,7 +4,6 @@ import { PageWatermark } from '@1d1s/design-system';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
-import Stories from '@feature/stories/components/Stories';
 import { useHasMounted } from '@module/hooks/useHasMounted';
 import { cn } from '@module/utils/cn';
 import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
@@ -151,16 +150,9 @@ export default function HomeScreen({
           streakDays={streakDays}
           isStreakLoading={isStreakLoading}
           challenges={sidebar?.challengeList ?? []}
+          storiesFetchEnabled={isStoriesEnabled}
+          onRequireLogin={handleRequireLogin}
         />
-
-        {/* 친구들의 일지 스토리 — 비로그인 시 로그인 유도 슬롯 노출 */}
-        <div className="-mx-5 lg:-mx-8">
-          <Stories
-            isLoggedIn={isLoggedIn}
-            fetchEnabled={isStoriesEnabled}
-            onRequireLogin={() => setShowLoginDialog(true)}
-          />
-        </div>
 
         {/* 모바일 인사 hero — 데스크탑/태블릿은 시안에 따라 생략 */}
         <div className="lg:hidden">

--- a/src/app.feature/stories/components/Stories.tsx
+++ b/src/app.feature/stories/components/Stories.tsx
@@ -51,7 +51,7 @@ function StoryLoginPrompt({
     <div
       className={cn(
         'scrollbar-hide flex w-full overflow-x-auto',
-        'gap-3 px-5 py-3.5 lg:px-8'
+        'gap-3 py-3.5'
       )}
     >
       {lockedCards.map((card, index) => (

--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -90,7 +90,9 @@ function StoryRing({
     <div
       className={cn(
         'scrollbar-hide flex w-full overflow-x-auto',
-        compact ? 'gap-2.5 px-4 py-3' : 'gap-3 px-5 py-3.5 lg:px-8'
+        // "나의 활동" 패널 내부에 놓이므로 좌우 패딩 없이 패널 내부 라인에서
+        // 시작한다(첫 카드 좌측 = 헤더·배너와 동일 세로선).
+        compact ? 'gap-2.5 px-4 py-3' : 'gap-3 py-3.5'
       )}
     >
       {showMySlot && !hasMyStory ? (

--- a/src/app.feature/stories/components/StoryRingSkeleton.tsx
+++ b/src/app.feature/stories/components/StoryRingSkeleton.tsx
@@ -22,7 +22,7 @@ export default function StoryRingSkeleton({
     <div
       className={cn(
         'scrollbar-hide flex w-full overflow-x-auto',
-        'gap-3 px-5 py-3.5 lg:px-8'
+        'gap-3 py-3.5'
       )}
       aria-busy
       aria-label="스토리 불러오는 중"


### PR DESCRIPTION
## 요약
홈의 '나의 활동' 패널 내부 순서를 **스토리 → 배너(+현재 스트릭) → 참여 중인 챌린지** 순으로 정리했습니다. 기존에 패널 밖에 있던 스토리 캐러셀을 패널 안 최상단으로 이동합니다.

## 변경 사항
- `HomeMineSection`이 `Stories`를 패널 콘텐츠 스택 최상단에서 렌더 (섹션 헤더 아래)
- `Stories` / `StoryRing` / `StoryRingSkeleton`의 좌우 패딩(`px-5 lg:px-8`) 제거 → 스토리 카드 좌측 라인이 패널 내부 배너·챌린지 카드와 동일 세로선에 정렬
- `HomeScreen`에서 스토리 breakout 래퍼(`-mx-5 lg:-mx-8`) 제거, 스토리 조회 활성화 여부·로그인 유도 콜백을 `HomeMineSection` props로 전달
- 비로그인 CTA·스켈레톤 높이 유지로 인증 상태 전환 시 레이아웃 시프트 없음

## 검증
- `tsc --noEmit` / `pnpm lint`(신규 에러 0) / `pnpm knip` / `pnpm test`(116 passed) / `pnpm build` 통과
- 브라우저 육안 확인은 리뷰어에게 위임 (프로젝트 정책상 Claude가 dev server를 점유하지 않음)