### PR TITLE
fix: 통계 추이 차트 오늘 지점 강조 + 데이터 포인트 호버 툴팁

### DIFF
--- a/src/app.feature/member/statistics/components/LineTrend.tsx
+++ b/src/app.feature/member/statistics/components/LineTrend.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import { Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
-import React from 'react';
+import React, { useState } from 'react';
 
-import { computeTrendPoints } from '../utils/statisticsView';
+import {
+  computeTrendPoints,
+  findCurrentBucketIndex,
+} from '../utils/statisticsView';
 
 export interface TrendDatum {
   bucket: string;
@@ -19,12 +24,15 @@ interface LineTrendProps {
   className?: string;
 }
 
-// 점 지름(px) — compact 은 한 단계 작게.
-function dotSize(kind: 'peak' | 'value' | 'zero', compact: boolean): number {
+// 점 지름(px) — compact 은 한 단계 작게. 'current' 는 오늘/호버 강조점.
+function dotSize(
+  kind: 'current' | 'value' | 'zero',
+  compact: boolean
+): number {
   if (kind === 'zero') {
     return compact ? 4 : 5;
   }
-  if (kind === 'peak') {
+  if (kind === 'current') {
     return compact ? 7 : 9;
   }
   return compact ? 5 : 7;
@@ -34,6 +42,8 @@ function dotSize(kind: 'peak' | 'value' | 'zero', compact: boolean): number {
  * 순수 SVG 꺾은선 차트 (외부 의존성 없음).
  * 선은 preserveAspectRatio="none" SVG 로 폭에 맞춰 늘이고, 점/값 라벨은
  * 같은 % 좌표를 쓰는 HTML 오버레이로 그려 비균등 스케일에도 원형을 유지한다.
+ * 오늘(현재 구간)이 포함된 버킷을 상시 강조하고, 각 점은 호버/포커스/터치 시
+ * 툴팁(날짜·기간 + 작성 수)을 띄운다.
  */
 export function LineTrend({
   data,
@@ -41,16 +51,25 @@ export function LineTrend({
   ariaLabel,
   className,
 }: LineTrendProps): React.ReactElement {
-  const max = data.reduce((m, d) => Math.max(m, d.count), 0);
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+
+  const max = data.reduce((acc, datum) => Math.max(acc, datum.count), 0);
   const areaHeight = compact ? 72 : 128;
   const points = computeTrendPoints(
-    data.map((d) => d.count),
+    data.map((datum) => datum.count),
     max
   );
-  // 첫 최댓값 인덱스 — 값 라벨/강조 점 대상.
-  const peakIndex = max > 0 ? data.findIndex((d) => d.count === max) : -1;
+  // 오늘이 속한 버킷 — 강조 대상. 과거 기간을 보고 있으면 -1(강조 없음).
+  const currentIndex = findCurrentBucketIndex(
+    data.map((datum) => datum.bucket),
+    new Date()
+  );
 
-  const polyline = points.map((p) => `${p.xPct},${p.yPct}`).join(' ');
+  const polyline = points.map((point) => `${point.xPct},${point.yPct}`).join(' ');
+
+  // 점 위에서 커서/포커스가 벗어날 때, 내가 켠 호버만 끈다(다른 점 진입 레이스 방지).
+  const clearHover = (index: number): void =>
+    setHoverIndex((current) => (current === index ? null : current));
 
   return (
     // 좌우 px 인셋 — 끝점(0%/100%) 점·라벨의 절반이 밖으로 잘리지 않게
@@ -81,42 +100,106 @@ export function LineTrend({
           ) : null}
         </svg>
 
-        {points.map((p, i) => {
-          const d = data[i];
-          const isPeak = i === peakIndex;
-          const kind = d.count === 0 ? 'zero' : isPeak ? 'peak' : 'value';
+        {points.map((point, index) => {
+          const datum = data[index];
+          const isCurrent = index === currentIndex;
+          const isHover = index === hoverIndex;
+          const emphasized = isCurrent || isHover;
+          const kind = emphasized
+            ? 'current'
+            : datum.count === 0
+              ? 'zero'
+              : 'value';
           const size = dotSize(kind, compact);
           const bg =
             kind === 'zero'
               ? 'var(--gray-200)'
-              : kind === 'peak'
+              : kind === 'current'
                 ? 'var(--main-700)'
                 : 'var(--main-500)';
+          // 호버가 없을 때만 오늘 지점 값 라벨을 상시 노출(호버 시엔 툴팁으로 대체).
+          const showCurrentLabel =
+            !compact && isCurrent && datum.count > 0 && hoverIndex === null;
+          // 툴팁 가로 위치 — 양 끝 점은 카드 밖으로 새지 않게 정렬 기준을 바꾼다.
+          const tooltipAlign =
+            point.xPct < 12 ? 'left' : point.xPct > 88 ? 'right' : 'center';
+          const tooltipTransform =
+            tooltipAlign === 'left'
+              ? 'translate(0, -100%)'
+              : tooltipAlign === 'right'
+                ? 'translate(-100%, -100%)'
+                : 'translate(-50%, -100%)';
           return (
-            <React.Fragment key={`${d.bucket}-${i}`}>
-              {!compact && isPeak ? (
+            <React.Fragment key={`${datum.bucket}-${index}`}>
+              {showCurrentLabel ? (
                 <Text
                   size="caption5"
                   weight="bold"
                   className="text-main-700 absolute -translate-x-1/2 -translate-y-full"
-                  style={{ left: `${p.xPct}%`, top: `calc(${p.yPct}% - 8px)` }}
+                  style={{
+                    left: `${point.xPct}%`,
+                    top: `calc(${point.yPct}% - 8px)`,
+                  }}
                 >
-                  {d.count}
+                  {datum.count}
                 </Text>
               ) : null}
               <span
-                className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full"
+                aria-hidden
+                className={cn(
+                  'absolute -translate-x-1/2 -translate-y-1/2 rounded-full',
+                  'transition-all duration-150 ease-out'
+                )}
                 style={{
-                  left: `${p.xPct}%`,
-                  top: `${p.yPct}%`,
+                  left: `${point.xPct}%`,
+                  top: `${point.yPct}%`,
                   width: size,
                   height: size,
                   backgroundColor: bg,
                   boxShadow:
                     kind === 'zero' ? undefined : '0 0 0 2px var(--white)',
                 }}
-                title={`${d.label}: ${d.count}`}
               />
+              {/* 히트 타깃 — 점이 작아 최소 터치 영역을 확보한다(호버/포커스/터치). */}
+              <button
+                type="button"
+                aria-label={`${datum.label} ${datum.count}개`}
+                className={cn(
+                  'absolute z-[1] h-7 w-7 -translate-x-1/2 -translate-y-1/2',
+                  'rounded-full focus:outline-none'
+                )}
+                style={{ left: `${point.xPct}%`, top: `${point.yPct}%` }}
+                onPointerEnter={() => setHoverIndex(index)}
+                onPointerLeave={() => clearHover(index)}
+                onFocus={() => setHoverIndex(index)}
+                onBlur={() => clearHover(index)}
+              />
+              {isHover ? (
+                <div
+                  role="tooltip"
+                  className={cn(
+                    'pointer-events-none absolute z-10 flex items-baseline',
+                    'gap-1 whitespace-nowrap rounded-[8px] border',
+                    'border-gray-200 bg-white px-2 py-1 shadow-sm'
+                  )}
+                  style={{
+                    left: `${point.xPct}%`,
+                    top: `calc(${point.yPct}% - 10px)`,
+                    transform: tooltipTransform,
+                  }}
+                >
+                  <Text size="caption5" className="text-gray-500">
+                    {datum.label}
+                  </Text>
+                  <Text
+                    size="caption5"
+                    weight="bold"
+                    className="text-gray-800"
+                  >
+                    {datum.count}개
+                  </Text>
+                </div>
+              ) : null}
             </React.Fragment>
           );
         })}
@@ -124,17 +207,20 @@ export function LineTrend({
 
       {/* 날짜 라벨 — 점과 동일한 xPct 에 중앙 정렬로 배치해 정렬을 맞춘다. */}
       <div className="relative mt-2 h-4">
-        {points.map((p, i) => (
+        {points.map((point, index) => (
           <Text
-            key={`${data[i].bucket}-label-${i}`}
+            key={`${data[index].bucket}-label-${index}`}
             size="caption5"
             className={cn(
               'absolute -translate-x-1/2 whitespace-nowrap',
-              'text-center text-gray-400'
+              'text-center',
+              index === currentIndex
+                ? 'text-main-700 font-bold'
+                : 'text-gray-400'
             )}
-            style={{ left: `${p.xPct}%` }}
+            style={{ left: `${point.xPct}%` }}
           >
-            {data[i].label}
+            {data[index].label}
           </Text>
         ))}
       </div>

--- a/src/app.feature/member/statistics/utils/statisticsView.test.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeTrendPoints } from './statisticsView';
+import {
+  computeTrendPoints,
+  findCurrentBucketIndex,
+} from './statisticsView';
 
 describe('computeTrendPoints', () => {
   it('spaces points evenly across the width', () => {
@@ -32,5 +35,35 @@ describe('computeTrendPoints', () => {
 
   it('returns an empty array for no data', () => {
     expect(computeTrendPoints([], 0)).toEqual([]);
+  });
+});
+
+describe('findCurrentBucketIndex', () => {
+  // 2026-07-11(토) — ISO 주차는 2026-W28.
+  const now = new Date(2026, 6, 11, 15, 0, 0);
+
+  it('finds today among day buckets regardless of the peak', () => {
+    const buckets = ['2026-07-09', '2026-07-10', '2026-07-11', '2026-07-12'];
+    expect(findCurrentBucketIndex(buckets, now)).toBe(2);
+  });
+
+  it('finds the current month among month buckets', () => {
+    expect(
+      findCurrentBucketIndex(['2026-05', '2026-06', '2026-07'], now)
+    ).toBe(2);
+  });
+
+  it('finds the current ISO week among week buckets (zero-pad agnostic)', () => {
+    expect(
+      findCurrentBucketIndex(['2026-W27', '2026-W28', '2026-W29'], now)
+    ).toBe(1);
+    expect(findCurrentBucketIndex(['2026-W28'], now)).toBe(0);
+  });
+
+  it('returns -1 when today falls outside the range (past period)', () => {
+    expect(
+      findCurrentBucketIndex(['2026-06-01', '2026-06-02'], now)
+    ).toBe(-1);
+    expect(findCurrentBucketIndex([], now)).toBe(-1);
   });
 });

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -105,6 +105,66 @@ export function computeTrendPoints(
   });
 }
 
+// ISO 주차 키(YYYY-Www) — 서버가 IsoFields/WeekFields.ISO 로 주 버킷을
+// 만든다고 가정한다. 목요일 기준으로 주를 결정하는 표준 ISO-8601 규칙.
+// ponytail: 서버 주차 스킴이 ISO 가 아니면 WEEK 강조만 조용히 빠진다(오강조는
+// 없음). 어긋나면 서버 스킴에 맞춰 이 함수만 교체.
+function isoWeekParts(date: Date): { year: number; week: number } {
+  // 로컬 날짜를 UTC 자정으로 정규화해 DST/시간 성분 영향을 제거한다.
+  const utc = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  );
+  // ISO 요일: 월=0 … 일=6. 해당 주의 목요일로 이동해 주-소속 연도를 정한다.
+  const isoDay = (utc.getUTCDay() + 6) % 7;
+  utc.setUTCDate(utc.getUTCDate() - isoDay + 3);
+  const firstThursday = new Date(Date.UTC(utc.getUTCFullYear(), 0, 4));
+  const firstIsoDay = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstIsoDay + 3);
+  const week =
+    1 + Math.round((utc.getTime() - firstThursday.getTime()) / (7 * 86400000));
+  return { year: utc.getUTCFullYear(), week };
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+// buckets 중 "오늘(현재 구간)"이 속한 버킷의 인덱스. 없으면 -1(과거 기간 조회 등).
+// 버킷 포맷을 첫 항목으로 판별한다:
+//   YYYY-MM-DD(일) · YYYY-MM(월) · YYYY-Www(ISO 주).
+// 최댓값 버킷이 아니라 "지금 위치"를 강조하기 위한 매핑이라 순수 함수로 분리해
+// now 를 주입받는다(테스트 결정성 확보).
+export function findCurrentBucketIndex(buckets: string[], now: Date): number {
+  const [sample] = buckets;
+  if (!sample) {
+    return -1;
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(sample)) {
+    const key = `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(
+      now.getDate()
+    )}`;
+    return buckets.indexOf(key);
+  }
+  if (/^\d{4}-\d{2}$/.test(sample)) {
+    const key = `${now.getFullYear()}-${pad2(now.getMonth() + 1)}`;
+    return buckets.indexOf(key);
+  }
+  const isoWeek = /^(\d{4})-W(\d{1,2})$/.exec(sample);
+  if (isoWeek) {
+    const { year, week } = isoWeekParts(now);
+    // 서버가 zero-pad 를 하든 안 하든 숫자로 비교한다.
+    return buckets.findIndex((bucket) => {
+      const parsed = /^(\d{4})-W(\d{1,2})$/.exec(bucket);
+      return (
+        parsed !== null &&
+        Number(parsed[1]) === year &&
+        Number(parsed[2]) === week
+      );
+    });
+  }
+  return -1;
+}
+
 // bucket 문자열을 사람이 읽는 짧은 라벨로. 서버 포맷을 방어적으로 처리한다.
 export function formatBucketLabel(bucket: string): string {
   if (!bucket) {


### PR DESCRIPTION
## 배경
통계 '기간 내 추이'(및 '작성 추이') 꺾은선 차트에서 강조 점이 **오늘이 아니라 한 주의 시작 날짜에 찍히는** 문제가 있었습니다.

## 원인
`LineTrend` 은 `peakIndex`(= 카운트가 최댓값인 **첫 버킷**)를 '현재 위치'처럼 강조했습니다. 오늘/현재 구간이라는 개념 자체가 없었고, 주 시작일에 작성이 몰리면 그 날이 강조돼 오늘과 어긋나 보였습니다. 최댓값 버킷은 이미 '가장 활발한 날/달' 칩으로 따로 노출되므로 차트 강조는 **오늘**을 가리켜야 맞습니다.

## 변경
- `findCurrentBucketIndex(buckets, now)` 순수 함수 추가 — 오늘이 속한 버킷을 `YYYY-MM-DD`(일)·`YYYY-MM`(월)·`YYYY-Www`(ISO 주) 포맷별로 매핑. 과거 기간을 보고 있으면 `-1`(강조 없음).
- `LineTrend`: `peakIndex` → `currentIndex` 상시 강조로 교체. 하단 날짜 라벨도 현재 구간만 강조. WEEK/MONTH/YEAR 단위 모두에서 '지금 위치'가 올바르게 표시됩니다.
- **호버 인터랙션 추가**: 데이터 포인트에 hover/focus/touch 시 툴팁(날짜·기간 + 작성 수)을 띄우고 해당 점을 강조. 28px 히트 영역으로 데스크톱 hover·모바일 터치(누르고 문질러 스크럽) 모두 자연스럽게 동작, 양 끝 점은 카드 밖으로 새지 않게 정렬을 클램프. DS `Text`·gray/main 토큰 사용, 볼드는 수치 1곳만.

## 검증
- `tsc --noEmit` / `pnpm lint`(신규 에러 0) / `pnpm knip` / `pnpm test`(120 passed, `findCurrentBucketIndex` 단위 테스트 4건 추가) / `pnpm build` 통과
- 브라우저 육안 확인은 리뷰어에게 위임 (프로젝트 정책상 Claude가 dev server를 점유하지 않음)

## 참고 (엣지)
- ISO 주차는 서버가 `WeekFields.ISO` 스킴을 쓴다고 가정합니다. 다른 주차 스킴이면 WEEK 단위 강조만 조용히 빠지며(오강조 없음), `isoWeekParts` 만 교체하면 됩니다.
- '오늘'은 사용자 로컬 날짜 기준입니다(앱 대상 KST).