### PR TITLE
feat: 챌린지 생성 시 종료 후 일지 작성 기본 허용

### DIFF
--- a/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
+++ b/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
@@ -161,7 +161,8 @@ export function useChallengeCreateForm(): ReturnType<
       // 허용으로 둔다. 작성자는 필요 시 토글로 비허용으로 바꿀 수 있다.
       allowMidJoin: true,
       isPhotoRequired: false,
-      postEndWriteAllowed: false,
+      // 종료 후 일지 작성을 기본 허용으로 둔다. 작성자는 토글로 끌 수 있다.
+      postEndWriteAllowed: true,
       challengeType: 'PUBLIC',
       password: '',
       goals: [],


### PR DESCRIPTION
## 변경 사항

챌린지 생성 폼에서 `postEndWriteAllowed`(종료 후 일지 작성 허용) 옵션의 기본값을 `false` → `true`로 변경.

- `useChallengeCreateForm`의 `defaultValues.postEndWriteAllowed`를 `true`로 설정. 작성자는 필요 시 토글로 끌 수 있음.
- 수정 폼(`useChallengeEditForm`)은 해당 필드를 다루지 않고 서버에서 받은 `defaults`를 그대로 반영하므로 영향 없음.

## 검증

- `tsc --noEmit` ✅
- `lint` ✅ (0 errors)
- `vitest` ✅ (120 passed)
- `knip` ✅
- `build` ✅