### PR TITLE
refactor: 홈 섹션 순서 조정 + 공지·의견 배너 데스크톱 2열

### DIFF
--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -111,28 +111,37 @@ export default function HomeScreen({
 
         {isLoggedIn ? (
           <>
-            <HomeStreakSlot
-              streakDays={streakDays}
-              isStreakLoading={isStreakLoading}
-            />
+            <Stories isLoggedIn={isLoggedIn} fetchEnabled={isStoriesEnabled} />
+
+            {/* 배너/스트릭 — 모바일 세로 스택, lg 이상 1:1 좌우 배치 */}
+            <div className="grid gap-3 lg:grid-cols-2">
+              <HomeWarmBanner />
+              <HomeStreakSlot
+                streakDays={streakDays}
+                isStreakLoading={isStreakLoading}
+              />
+            </div>
+
             <HomeTodayRecordSection
               challenges={sidebar?.challengeList ?? []}
               isAuthLoading={isStreakLoading}
             />
-            <Stories isLoggedIn={isLoggedIn} fetchEnabled={isStoriesEnabled} />
           </>
         ) : (
-          <HomeLoginCta />
+          <>
+            <HomeLoginCta />
+            <HomeWarmBanner />
+          </>
         )}
 
-        <HomeWarmBanner />
-
-        <HomeExploreEntry />
-
-        <div className="flex flex-col gap-3">
+        {/* 공지·의견 — 모바일 세로 스택, lg 이상 2열 나란히 */}
+        <div className="grid gap-3 lg:grid-cols-2">
           <HomeNoticeStrip />
           <HomeQuickActions />
         </div>
+
+        {/* 탐색 유도 진입점 — 홈 하단 */}
+        <HomeExploreEntry />
 
         <div className="flex w-full justify-center pt-4">
           <PageWatermark />


### PR DESCRIPTION
## 변경 사항
후속 피드백 반영, 두 가지 레이아웃 조정.

### 1) 나의 오늘 섹션 순서
위에서부터 **스토리 → 배너/스트릭 → 오늘의 기록 → (하단) 탐색 유도 진입점**.
- 배너·스트릭은 모바일 세로 스택, `lg` 이상 1:1 좌우 배치.
- 탐색 진입점('새로운 챌린지 둘러보기')은 공지/의견 아래 홈 최하단으로 이동.

### 2) 공지·의견 배너 2열 배치
공지 배너와 '의견을 들려주세요' 배너를 **모바일은 세로 스택 유지, `lg` 이상에서 2열 grid로 나란히** 배치.

## 검증
tsc ✅ / lint(0 errors) ✅ / vitest(120 passed) ✅ / knip ✅ / build ✅. 브라우저 수동 확인은 프로젝트 정책상 미실시.