### PR TITLE
feat: 네비게이션에 탐색 탭 추가

### DIFF
--- a/src/app.component/layout/AppBottomNav.tsx
+++ b/src/app.component/layout/AppBottomNav.tsx
@@ -7,7 +7,7 @@ import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { cn } from '@module/utils/cn';
 import { resolveDiaryImageUrl } from '@module/utils/diaryImageUrl';
 import { buildLoginUrl } from '@module/utils/returnTo';
-import { BookOpen, Home, User } from 'lucide-react';
+import { BookOpen, Compass, Home, User } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import React, { useCallback, useEffect, useMemo, useTransition } from 'react';
@@ -25,6 +25,7 @@ interface BottomNavConfigItem {
 
 const ITEMS: BottomNavConfigItem[] = [
   { id: 'home', label: '홈', href: '/', Icon: Home },
+  { id: 'explore', label: '탐색', href: '/explore', Icon: Compass },
   {
     id: 'challenge',
     label: '챌린지',

--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -45,7 +45,13 @@ const RIGHT_RAIL_HIDDEN_ROUTES = [
 
 // 바텀 네비는 최상위 4개 탭에서만 노출한다. 그 외 서브/상세 화면은
 // 각자 모바일 sticky 헤더(뒤로가기)를 사용하므로 바텀 네비를 숨긴다.
-const BOTTOM_NAV_VISIBLE_ROUTES = ['/', '/challenge', '/diary', '/mypage'];
+const BOTTOM_NAV_VISIBLE_ROUTES = [
+  '/',
+  '/explore',
+  '/challenge',
+  '/diary',
+  '/mypage',
+];
 
 function matchesRoute(pathname: string, routes: readonly string[]): boolean {
   return routes.some(
@@ -63,6 +69,9 @@ function isBottomNavVisible(pathname: string): boolean {
 }
 
 function resolveActiveNavId(pathname: string): string {
+  if (pathname.startsWith('/explore')) {
+    return 'explore';
+  }
   if (pathname.startsWith('/challenge')) {
     return 'challenge';
   }

--- a/src/app.component/layout/AppTopNav.tsx
+++ b/src/app.component/layout/AppTopNav.tsx
@@ -5,7 +5,7 @@ import { ChallengeTrophyIcon } from '@component/ChallengeTrophyIcon';
 import { Skeleton } from '@component/Skeleton';
 import { cn } from '@module/utils/cn';
 import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
-import { BookOpen, User } from 'lucide-react';
+import { BookOpen, Compass, User } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -20,6 +20,7 @@ const NAV_ITEMS: ReadonlyArray<{
   NavIcon?: React.ComponentType<{ className?: string }>;
 }> = [
   { id: 'home', label: '홈', href: '/' },
+  { id: 'explore', label: '탐색', href: '/explore', NavIcon: Compass },
   {
     id: 'challenge',
     label: '챌린지',

--- a/src/app.feature/home/components/HomeExploreEntry.tsx
+++ b/src/app.feature/home/components/HomeExploreEntry.tsx
@@ -3,8 +3,8 @@ import { Compass } from 'lucide-react';
 import Link from 'next/link';
 import React from 'react';
 
-// 홈(나의 오늘) → 탐색(/explore) 유도 진입점. 바텀 네비에 5번째 탭을 넣지 않고
-// 홈 본문의 카드로 탐색을 연다.
+// 홈(나의 오늘) → 탐색(/explore) 유도 진입점. 상단/바텀 네비의 탐색 탭과
+// 별개로, 홈 본문에서도 카드로 탐색을 바로 열 수 있게 한다.
 export default function HomeExploreEntry(): React.ReactElement {
   return (
     <Link


### PR DESCRIPTION
## 요약
`/explore`(탐색) 페이지를 데스크톱 상단(GNB)과 모바일 바텀 네비에 노출한다.
위치는 홈 다음. 아이콘은 홈 탐색 진입점과 동일한 lucide `Compass`(나침반).

## 변경 사항
- `AppTopNav`: GNB에 `탐색`(/explore) 항목 추가 (홈 → 탐색 → 챌린지 → 일지 → 마이페이지)
- `AppBottomNav`: 바텀 탭 4→5개, `탐색` 추가 + prefetch 대상 자동 포함
- `AppLayoutShell`:
  - `BOTTOM_NAV_VISIBLE_ROUTES`에 `/explore` 포함 → 탐색 화면에서 바텀 네비 노출
  - `resolveActiveNavId`에 `explore` 분기 추가 → 현재 경로 강조
- `HomeExploreEntry`: 홈 하단 탐색 유도 진입점 유지(주석만 최신화)

## 아이콘
- DS `Icon`에는 나침반/탐색 계열이 없고 `Search`(돋보기)만 존재.
- 기존 홈 탐색 진입점이 이미 lucide `Compass`를 사용 중이고 네비 아이콘도
  lucide 세트라, 시각·의미 일관성을 위해 lucide `Compass` 채택.

## 바텀 네비 5개 레이아웃
- DS `BottomNav`가 `grid-template-columns: repeat(n, 1fr)`로 균등 분배.
- 라벨이 2~3자(홈/탐색/챌린지/일지/마이)로 짧아 좁은 화면에서도
  깨지지 않음 → 폰트/패딩 조정 불필요.

## 검증
- ✅ `tsc --noEmit`
- ✅ `pnpm lint` (0 errors)
- ✅ `pnpm test` (120 passed)
- ✅ `pnpm knip`
- ✅ `pnpm build` (/explore 라우트 정상 생성)

브라우저 확인은 CLAUDE.md 정책에 따라 사용자가 직접 진행합니다.