### PR TITLE
feat: 탐색 페이지에 공식 챌린지 섹션 추가

### DIFF
--- a/src/app.feature/explore/hooks/useExploreOfficialChallenges.ts
+++ b/src/app.feature/explore/hooks/useExploreOfficialChallenges.ts
@@ -1,0 +1,31 @@
+import { useChallengeList } from '@feature/challenge/board/hooks/useChallengeQueries';
+import { type ChallengeListItem } from '@feature/challenge/board/type/challenge';
+import { normalizeApiError } from '@module/api/error';
+
+// 첫 페이지만 노출하는 가로 스크롤 섹션이라 무한 스크롤 없이 limit 만큼만 받는다.
+const OFFICIAL_CHALLENGES_LIMIT = 10;
+
+interface OfficialChallengesResult {
+  officialChallenges: ChallengeListItem[];
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage: string | null;
+}
+
+// 공식 챌린지(OFFICIAL) 목록 — 전용 엔드포인트가 없어 챌린지 목록 API의
+// challengeType 필터를 재사용한다(보드의 "공식 운영" 필터와 동일 경로).
+export function useExploreOfficialChallenges(): OfficialChallengesResult {
+  const { data, isLoading, isError, error } = useChallengeList({
+    challengeType: 'OFFICIAL',
+    limit: OFFICIAL_CHALLENGES_LIMIT,
+  });
+
+  const officialChallenges = data?.pages.flatMap((page) => page.items) ?? [];
+
+  return {
+    officialChallenges,
+    isLoading,
+    isError,
+    errorMessage: error ? normalizeApiError(error).message : null,
+  };
+}

--- a/src/app.feature/explore/screen/ExploreScreen.tsx
+++ b/src/app.feature/explore/screen/ExploreScreen.tsx
@@ -11,6 +11,8 @@ import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useRouter } from 'next/navigation';
 import React, { useCallback } from 'react';
 
+import { useExploreOfficialChallenges } from '../hooks/useExploreOfficialChallenges';
+
 // 탐색(/explore): 홈에서 분리한 "둘러보기" 콘텐츠. 배너는 제외하고 오늘 시작해볼
 // 챌린지·오늘의 응원(추천 일지)만 노출한다. 비로그인도 열람 가능하며, 카드
 // 클릭 시 로그인 유도 다이얼로그를 띄운다.
@@ -41,6 +43,13 @@ export default function ExploreScreen(): React.ReactElement {
     diariesErrorMessage,
   } = useHomeRandomData();
 
+  const {
+    officialChallenges,
+    isLoading: isOfficialLoading,
+    isError: isOfficialError,
+    errorMessage: officialErrorMessage,
+  } = useExploreOfficialChallenges();
+
   return (
     <>
       <LoginRequiredDialog
@@ -55,6 +64,19 @@ export default function ExploreScreen(): React.ReactElement {
         }
       >
         <div className="flex flex-col gap-7 pt-2 lg:pt-6">
+          <HomeRandomChallengesSection
+            challenges={officialChallenges}
+            isLoading={isOfficialLoading}
+            isError={isOfficialError}
+            errorMessage={officialErrorMessage}
+            isLoggedIn={isLoggedIn}
+            onMoreClick={handleMoreChallenges}
+            onRequireLogin={handleRequireLogin}
+            title="공식 챌린지"
+            subtitle="1D1S가 엄선한 챌린지에 참여해보세요"
+            emptyTitle="아직 공식 챌린지가 없어요!"
+          />
+
           <HomeRandomChallengesSection
             challenges={randomChallenges}
             isLoading={isChallengesLoading}

--- a/src/app.feature/home/components/HomeRandomChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeRandomChallengesSection.tsx
@@ -27,6 +27,10 @@ interface HomeRandomChallengesSectionProps {
   isLoggedIn: boolean;
   onMoreClick(): void;
   onRequireLogin(): void;
+  // 아래는 탐색(/explore)에서 공식 챌린지 섹션으로 재사용하기 위한 표시 옵션.
+  title?: string;
+  subtitle?: string;
+  emptyTitle?: string;
 }
 
 export default function HomeRandomChallengesSection({
@@ -37,13 +41,16 @@ export default function HomeRandomChallengesSection({
   isLoggedIn,
   onMoreClick,
   onRequireLogin,
+  title = '오늘 시작해볼 챌린지',
+  subtitle = '함께 도전할 친구를 찾아보세요',
+  emptyTitle = '표시할 챌린지가 없어요',
 }: HomeRandomChallengesSectionProps): React.ReactElement {
   const showSkeleton = useMinimumLoading(isLoading);
   return (
     <section className="w-full">
       <SectionHeader
-        title="오늘 시작해볼 챌린지"
-        subtitle="함께 도전할 친구를 찾아보세요"
+        title={title}
+        subtitle={subtitle}
         actionLabel="전체보기 →"
         onActionClick={onMoreClick}
         className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
@@ -116,6 +123,7 @@ export default function HomeRandomChallengesSection({
                   isInfinite={isInfinite}
                   goalType={challenge.goalType}
                   isGroup={challenge.participationType === 'GROUP'}
+                  isOfficial={challenge.challengeType === 'OFFICIAL'}
                   isEnded={ended}
                   isPhotoRequired={challenge.photoRequired}
                   participants={challenge.randomParticipants}
@@ -132,11 +140,7 @@ export default function HomeRandomChallengesSection({
         </div>
       ) : null}
       {!showSkeleton && !isError && challenges.length === 0 ? (
-        <EmptyState
-          variant="challenge"
-          title="표시할 챌린지가 없어요"
-          className="py-8"
-        />
+        <EmptyState variant="challenge" title={emptyTitle} className="py-8" />
       ) : null}
     </section>
   );


### PR DESCRIPTION
## 요약
`/explore` 최상단에 **공식 챌린지(OFFICIAL)** 가로 스크롤 섹션을 추가합니다.

## 사용한 API
공식 챌린지 전용 엔드포인트는 없어, 기존 챌린지 목록 API의 `challengeType` 필터를 재사용했습니다.
- `GET /challenges?challengeType=OFFICIAL&limit=10` (`getChallengeList` → `useChallengeList`)
- 보드의 "공식 운영" 필터와 동일 경로

## 변경
- `useExploreOfficialChallenges` 훅 신설 — `useChallengeList({ challengeType: 'OFFICIAL' })`를 감싸 첫 페이지만 평탄화
- 홈 챌린지 섹션 컴포넌트(`HomeRandomChallengesSection`, 현재 explore 전용)를 `title`/`subtitle`/`emptyTitle` 옵션으로 확장해 재사용
- `ChallengeCard`의 `isOfficial`(공식 배지)를 `challengeType === 'OFFICIAL'` 기준으로 연결

## UX
- 섹션 위치: `/explore` 최상단(“오늘 시작해볼 챌린지” 위)
- 공식 챌린지 없으면 `아직 공식 챌린지가 없어요!` 빈 상태
- 스켈레톤/빈 상태/리스트가 같은 스크롤 컨테이너를 공유 → 레이아웃 시프트 없음
- 첫 카드 좌측 정렬은 기존 홈 패턴(`-mx-5 px-5`) 그대로

## 검증
- ✅ `tsc --noEmit`
- ✅ `pnpm lint` (0 errors)
- ✅ `pnpm test` (120 passed)
- ✅ `pnpm knip`
- ✅ `pnpm build`
- 브라우저 확인은 하지 않았습니다(정적 검증까지만).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated official challenges section to the Explore screen.
  * Official challenges now display distinct labeling on challenge cards.
  * Added loading, error, and empty states for official challenges.
  * Challenge sections now support customizable titles, subtitles, and empty-state messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->