### PR TITLE
feat: 챌린지 상세 탭을 시안(소개·일지·참여자 3탭)에 맞춰 재구성

### DIFF
--- a/src/app.component/skeletons/ChallengeDetailSkeleton.tsx
+++ b/src/app.component/skeletons/ChallengeDetailSkeleton.tsx
@@ -113,7 +113,7 @@ export function ChallengeDetailSkeleton(): React.ReactElement {
             <div className="flex min-w-0 flex-col">
               {/* 탭 바 */}
               <div className="flex gap-5 border-b border-gray-100 pb-2.5">
-                {Array.from({ length: 4 }).map((_, index) => (
+                {Array.from({ length: 3 }).map((_, index) => (
                   <Skeleton key={index} shape="text" className="h-5 w-10" />
                 ))}
               </div>

--- a/src/app.feature/challenge/detail/components/ChallengeLeaderboardCard.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeLeaderboardCard.tsx
@@ -55,6 +55,7 @@ interface ChallengeLeaderboardCardProps {
 
 interface MemberRowProps {
   entry: LeaderboardEntry;
+  isMe: boolean;
   onSelect(): void;
   onGoals(): void;
 }
@@ -106,6 +107,7 @@ function MedalIcon({ rank }: { rank: number }): React.ReactElement {
 // 아바타 + 닉네임 + HOST/참여중 배지 + 목표 버튼.
 function MemberRow({
   entry,
+  isMe,
   onSelect,
   onGoals,
 }: MemberRowProps): React.ReactElement {
@@ -173,7 +175,7 @@ function MemberRow({
                   'text-[10px] font-extrabold text-gray-600'
                 )}
               >
-                참여 중
+                {isMe ? '나' : '참여 중'}
               </span>
             )}
           </div>
@@ -289,6 +291,7 @@ export function ChallengeLeaderboardCard({
               >
                 <MemberRow
                   entry={entry}
+                  isMe={isMe}
                   onSelect={() => onMemberClick?.(entry.memberId)}
                   onGoals={() => setGoalsOf(entry)}
                 />

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Card, Stripe, Tabs, Tag, Text } from '@1d1s/design-system';
+import { Button, Card, Tabs, Tag, Text } from '@1d1s/design-system';
 import { AlertDialog } from '@component/AlertDialog';
 import { MobileBottomActionBar } from '@component/layout/MobileBottomActionBar';
 import LikeBurst from '@component/LikeBurst';
@@ -17,7 +17,6 @@ import { cn } from '@module/utils/cn';
 import { formatDateISO } from '@module/utils/date';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import { ArrowLeft, CircleAlert, Heart } from 'lucide-react';
-import Image from 'next/image';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React, { useEffect, useMemo, useState } from 'react';
 
@@ -76,8 +75,8 @@ interface ChallengeDetailScreenProps {
 // 이 신호를 받으면 비밀번호 다이얼로그를 목표 입력 단계로 전환한다.
 const FREE_GOAL_REQUIRED_CODE = 'CHALLENGE_022';
 
-// 상세 탭 뷰 — URL ?tab= 으로 보존. 기본은 개요.
-const CHALLENGE_TAB_IDS = ['overview', 'diary', 'stats', 'participants'] as const;
+// 상세 탭 뷰 — URL ?tab= 으로 보존. 기본은 소개.
+const CHALLENGE_TAB_IDS = ['overview', 'diary', 'participants'] as const;
 type ChallengeTabId = (typeof CHALLENGE_TAB_IDS)[number];
 
 function isChallengeTab(value: string | null): value is ChallengeTabId {
@@ -171,9 +170,12 @@ export function ChallengeDetailScreen({
   const myStatus = detail?.myStatus ?? 'NONE';
   const isHost = myStatus === 'HOST';
   // 상세 응답 participants 는 등수순 상위 5명이라 PENDING 이 빠진다.
-  // 대기 승인 카드는 status=PENDING 목록을 호스트일 때만 별도 조회한다.
+  // 대기 승인 카드는 참여자 탭에 있으므로, 호스트가 그 탭을 볼 때만 조회한다.
   const { data: pendingParticipants = EMPTY_PARTICIPANTS } =
-    useChallengePendingParticipants(challengeId, isHost);
+    useChallengePendingParticipants(
+      challengeId,
+      isHost && activeTab === 'participants'
+    );
   const isJoinRequestPending = myStatus === 'PENDING';
   const isParticipating = PARTICIPATING_STATUS.includes(myStatus);
   const canJoinByStatus = myStatus === 'NONE' || myStatus === 'REJECTED';
@@ -461,13 +463,29 @@ export function ChallengeDetailScreen({
         : undefined;
 
   const tabItems = [
-    { id: 'overview', label: '개요' },
+    { id: 'overview', label: '소개' },
     { id: 'diary', label: '일지' },
-    { id: 'stats', label: '통계' },
     {
       id: 'participants',
       label: '참여자',
       badge: summaryParticipantCnt > 0 ? summaryParticipantCnt : undefined,
+    },
+  ];
+
+  // 소개 탭 하단 "챌린지 정보" — 히어로/진행률과 겹치지 않는 규칙·옵션 위주.
+  const infoRows: Array<{ label: string; value: string }> = [
+    { label: '기간', value: dateRangeText },
+    { label: '인원', value: participantsLabel },
+    {
+      label: '방식',
+      value: `${formatChallengeTypeLabel(summary.goalType)} 목표 · ${
+        isGroupChallenge ? '단체' : '개인'
+      }`,
+    },
+    { label: '인증샷', value: detail.photoRequired ? '필수' : '자유' },
+    {
+      label: '종료 후 작성',
+      value: summary.postEndWriteAllowed ? '허용' : '미허용',
     },
   ];
 
@@ -583,45 +601,34 @@ export function ChallengeDetailScreen({
             </button>
           </div>
 
-          {activeParticipants.length > 0 ? (
-            <div
-              className={cn(
-                'mt-4 flex items-center gap-2.5 rounded-[12px]',
-                'bg-main-100 px-3.5 py-3'
-              )}
+          {/* 모바일 진행률 요약 — 우측 rail 대신 컴팩트 바 */}
+          <div
+            className={cn(
+              'mt-3.5 flex items-center gap-2.5 rounded-[12px]',
+              'border-main-300 bg-main-100 border px-3.5 py-2.5'
+            )}
+          >
+            <Text
+              size="caption1"
+              weight="bold"
+              className="shrink-0 text-gray-600"
             >
-              <div className="flex">
-                {activeParticipants.slice(0, 4).map((participant, idx) => (
-                  <div
-                    key={participant.participantId}
-                    className={cn(
-                      'relative h-7 w-7 overflow-hidden rounded-full',
-                      'bg-main-200 border-2 border-white',
-                      idx > 0 && '-ml-2.5'
-                    )}
-                  >
-                    {participant.profileImg ? (
-                      <Image
-                        src={participant.profileImg}
-                        alt=""
-                        width={28}
-                        height={28}
-                        className="h-full w-full object-cover"
-                      />
-                    ) : (
-                      <Stripe tone="var(--main-300)" />
-                    )}
-                  </div>
-                ))}
-              </div>
-              <Text size="caption1" weight="regular" className="text-gray-700">
-                <span className="font-extrabold">
-                  {activeParticipants.length}명
-                </span>
-                이 함께 도전 중이에요
-              </Text>
+              진행률
+            </Text>
+            <div className="h-[7px] flex-1 overflow-hidden rounded-full bg-white">
+              <div
+                className="bg-main-800 h-full rounded-full"
+                style={{ width: `${participationRate}%` }}
+              />
             </div>
-          ) : null}
+            <Text
+              size="body2"
+              weight="extrabold"
+              className="text-main-800 shrink-0 tabular-nums"
+            >
+              {participationRate}%
+            </Text>
+          </div>
         </div>
 
         <div
@@ -630,59 +637,28 @@ export function ChallengeDetailScreen({
             'sm:pt-6 md:px-6 lg:gap-4 lg:px-8 lg:pt-8'
           )}
         >
-          {isHost && pendingParticipants.length > 0 ? (
-            <Card radius="lg" className="border-main-300 p-5 md:p-6">
-              <div className="flex items-center gap-2">
-                <CircleAlert className="text-main-800 h-5 w-5" />
-                <Text size="heading2" weight="bold" className="text-gray-900">
-                  참여 인원 대기
-                </Text>
-                <Tag tone="brand" size="sm">
-                  {pendingParticipants.length}명
-                </Tag>
-              </div>
-              <div
-                className={cn('mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3')}
-              >
-                {pendingParticipants.map((participant) => (
-                  <PendingMemberItem
-                    key={participant.participantId}
-                    name={participant.nickname}
-                    joinedAt={formatRelativeJoinedText(participant.status)}
-                    profileImg={participant.profileImg}
-                    goals={isFreeChallenge ? participant.goals : undefined}
-                    onProfileClick={() =>
-                      router.push(`/member/${participant.memberId}`)
-                    }
-                    onAccept={() =>
-                      handleAcceptParticipant(participant.participantId)
-                    }
-                    onReject={() =>
-                      handleRejectParticipant(participant.participantId)
-                    }
-                    isLoading={
-                      acceptParticipant.isPending || rejectParticipant.isPending
-                    }
-                  />
-                ))}
-              </div>
-            </Card>
-          ) : null}
-
           <div
             className={cn(
               'grid grid-cols-1 gap-4',
               'lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-7'
             )}
           >
-            {/* 메인 콘텐츠: 탭(개요 / 일지 / 통계 / 참여자) */}
+            {/* 메인 콘텐츠: 탭(소개 / 일지 / 참여자) */}
             <div className="flex min-w-0 flex-col">
-              <div className="scrollbar-hide -mx-1 overflow-x-auto px-1">
-                <Tabs
-                  activeId={activeTab}
-                  onChange={handleTabChange}
-                  items={tabItems}
-                />
+              {/* 모바일에선 compact 헤더(h-14) 아래에 sticky 로 붙인다. */}
+              <div
+                className={cn(
+                  'sticky top-14 z-20 bg-white',
+                  'lg:static lg:top-auto lg:z-auto'
+                )}
+              >
+                <div className="scrollbar-hide -mx-1 overflow-x-auto px-1">
+                  <Tabs
+                    activeId={activeTab}
+                    onChange={handleTabChange}
+                    items={tabItems}
+                  />
+                </div>
               </div>
 
               <div className="mt-4 flex min-w-0 flex-col gap-3.5 lg:gap-4">
@@ -721,6 +697,50 @@ export function ChallengeDetailScreen({
                       editLabel={rulesEditLabel}
                       onEdit={rulesOnEdit}
                     />
+
+                    <section
+                      className={cn(
+                        'rounded-[14px] border border-gray-200 bg-white',
+                        'p-4 sm:p-5 lg:p-6'
+                      )}
+                    >
+                      <Text
+                        as="h2"
+                        size="heading2"
+                        weight="extrabold"
+                        className="mb-3 block tracking-[-0.3px] text-gray-900"
+                      >
+                        챌린지 정보
+                      </Text>
+                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                        {infoRows.map((row) => (
+                          <div
+                            key={row.label}
+                            className={cn(
+                              'flex items-center gap-3 rounded-[10px]',
+                              'bg-gray-50 px-3.5 py-2.5'
+                            )}
+                          >
+                            <Text
+                              size="caption1"
+                              weight="medium"
+                              className="w-16 shrink-0 text-gray-400"
+                            >
+                              {row.label}
+                            </Text>
+                            <Text
+                              size="caption1"
+                              weight="bold"
+                              className="min-w-0 flex-1 break-keep text-gray-800"
+                            >
+                              {row.value}
+                            </Text>
+                          </div>
+                        ))}
+                      </div>
+                    </section>
+
+                    <ChallengeStatisticsSection challengeId={challengeId} />
                   </>
                 ) : null}
 
@@ -732,12 +752,59 @@ export function ChallengeDetailScreen({
                   />
                 ) : null}
 
-                {activeTab === 'stats' ? (
-                  <ChallengeStatisticsSection challengeId={challengeId} />
-                ) : null}
-
                 {activeTab === 'participants' ? (
-                  <ChallengeLeaderboardCard
+                  <>
+                    {isHost && pendingParticipants.length > 0 ? (
+                      <Card radius="lg" className="border-main-300 p-5 md:p-6">
+                        <div className="flex items-center gap-2">
+                          <CircleAlert className="text-main-800 h-5 w-5" />
+                          <Text
+                            size="heading2"
+                            weight="bold"
+                            className="text-gray-900"
+                          >
+                            참여 인원 대기
+                          </Text>
+                          <Tag tone="brand" size="sm">
+                            {pendingParticipants.length}명
+                          </Tag>
+                        </div>
+                        <div className="mt-3 grid gap-3 md:grid-cols-2">
+                          {pendingParticipants.map((participant) => (
+                            <PendingMemberItem
+                              key={participant.participantId}
+                              name={participant.nickname}
+                              joinedAt={formatRelativeJoinedText(
+                                participant.status
+                              )}
+                              profileImg={participant.profileImg}
+                              goals={
+                                isFreeChallenge ? participant.goals : undefined
+                              }
+                              onProfileClick={() =>
+                                router.push(`/member/${participant.memberId}`)
+                              }
+                              onAccept={() =>
+                                handleAcceptParticipant(
+                                  participant.participantId
+                                )
+                              }
+                              onReject={() =>
+                                handleRejectParticipant(
+                                  participant.participantId
+                                )
+                              }
+                              isLoading={
+                                acceptParticipant.isPending ||
+                                rejectParticipant.isPending
+                              }
+                            />
+                          ))}
+                        </div>
+                      </Card>
+                    ) : null}
+
+                    <ChallengeLeaderboardCard
                     entries={activeParticipants.map((participant) => ({
                       participantId: participant.participantId,
                       memberId: participant.memberId,
@@ -764,6 +831,7 @@ export function ChallengeDetailScreen({
                     pokingMemberId={pokingMemberId}
                     pokedMemberIds={pokedMemberIds}
                   />
+                  </>
                 ) : null}
               </div>
             </div>


### PR DESCRIPTION
## 배경
Claude Design 시안(**1D1S 챌린지 상세 개선**)을 기준으로 챌린지 상세 탭 뷰를
재구성한다. 시안은 스스로 "소개 · 일지 · 참여자 3개 탭"으로 명시하며, 앞서
머지한 4탭(개요·일지·통계·참여자, #170)과 달라 **시안 우선**으로 맞춘다.

통계 처리 방향은 사용자 확인 결과 **소개 탭 하단 유지**로 결정.

## 변경 사항
- **3탭 구성**: 소개(overview) / 일지(diary) / 참여자(participants).
  - 통계 탭 제거 → `ChallengeStatisticsSection` 을 **소개 탭 하단**으로 이동해
    참여율·일자별 추이·히트맵 캘린더 + 히트맵→일지 날짜필터 진입을 보존.
- **소개 탭**: 챌린지 소개 + 목표 + **"챌린지 정보" 카드 신설**
  (기간·인원·방식·인증샷 필수·종료 후 작성 — `photoRequired`/`postEndWriteAllowed`
  등 실제 필드 사용).
- **참여자 탭**: 참여 인원 대기(호스트) 카드를 이 탭으로 이동. 리더보드는 기존
  `ChallengeLeaderboardCard`(메달 랭킹·스트릭·완료 목표수·콕 찌르기·전체 보기)
  재사용 + **"나" 배지** 추가.
- **일지 탭**: 통계(히트맵 날짜필터)를 유지하므로 필터 가능한 무한 리스트
  (`ChallengeDiaryList`)를 그대로 사용.
- **모바일**: 시트 헤더의 참여자 아바타 줄을 **진행률 컴팩트 바**로 교체.
  탭 바를 compact 헤더(top-14) 아래 **sticky** 로 고정.

## 유지 원칙
- 탭 상태 **URL `?tab=` 보존**(기본 소개).
- **비활성 탭 쿼리 미실행**: 일지 리스트는 일지 탭에서만, 호스트 대기 목록은
  호스트가 참여자 탭을 볼 때만 조회. 참여자 리더보드는 상세 데이터 재사용(추가
  쿼리 0).
- 레이아웃 시프트 방지(sticky는 리플로우 없음), 볼드 남발 금지.

## DS/토큰 매핑
시안의 인라인 스타일·`--cd-main-*` 토큰을 프로젝트 DS 컴포넌트(`Tabs`, `Card`,
`Text`, `Tag`, `ChallengeLeaderboardCard` 등)와 `main-*`/`gray-*` 토큰으로 이관.

## 시안 대비 조정
- 시안의 "공개" 정보 행은 summary/detail에 해당 필드가 없어, 실제 필드인
  **인증샷·종료 후 작성**으로 대체.
- 일지 탭은 시안의 프리뷰 그리드 대신 필터 가능한 리스트 유지(통계 날짜필터
  진입 보존 목적).

## 검증
- `pnpm tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors; 남은 warning 은 이번 변경과 무관한 기존 파일)
- `pnpm knip` ✅
- `pnpm vitest run` ✅ (120 passed)
- `pnpm build` ✅
- ⚠️ 브라우저 실제 렌더/인터랙션은 프로젝트 정책상 직접 확인하지 않았습니다
  (sticky 탭·모바일 진행률 바 등은 사용자 확인 필요).