### PR TITLE
feat: 챌린지 통계 캘린더·주단위 추이 + 정보 카드·일지 탭 배지 다듬기

### DIFF
--- a/src/app.feature/challenge/detail/components/ChallengeDiaryCalendar.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDiaryCalendar.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { formatMonthDayKR } from '@module/utils/date';
+import React, { useMemo } from 'react';
+
+import { ChallengeDiaryTrendPoint } from '../type/challengeStatistics';
+import {
+  parseLocalDate,
+  toHeatmapLevel,
+} from '../utils/challengeStatisticsView';
+
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+// level(0~4) → 배경/텍스트. 0 은 일지 없는 날.
+const LEVEL_STYLE = [
+  'bg-gray-50 text-gray-400',
+  'bg-main-100 text-main-800',
+  'bg-main-200 text-main-900',
+  'bg-main-500 text-white',
+  'bg-main-800 text-white',
+];
+
+interface ChallengeDiaryCalendarProps {
+  trend: ChallengeDiaryTrendPoint[];
+  onSelectDate(date: string): void;
+}
+
+/**
+ * 날짜별 일지 캘린더 — 주(일~토) 단위 행으로 챌린지 기간의 날짜별 일지 수를
+ * 색 농도로 표시한다. 셀 클릭 시 그 날짜로 필터된 일지 목록으로 이동한다.
+ */
+export function ChallengeDiaryCalendar({
+  trend,
+  onSelectDate,
+}: ChallengeDiaryCalendarProps): React.ReactElement {
+  const maxCount = useMemo(
+    () => trend.reduce((max, point) => Math.max(max, point.count), 0),
+    [trend]
+  );
+
+  // 첫 날짜 요일만큼 앞을 비우고, 마지막 주를 7칸으로 채운다.
+  const cells = useMemo<Array<ChallengeDiaryTrendPoint | null>>(() => {
+    if (trend.length === 0) {
+      return [];
+    }
+    const lead = parseLocalDate(trend[0].date).getDay();
+    const filled: Array<ChallengeDiaryTrendPoint | null> = [];
+    for (let i = 0; i < lead; i += 1) {
+      filled.push(null);
+    }
+    trend.forEach((point) => filled.push(point));
+    while (filled.length % 7 !== 0) {
+      filled.push(null);
+    }
+    return filled;
+  }, [trend]);
+
+  const monthLabel = useMemo(() => {
+    if (trend.length === 0) {
+      return '';
+    }
+    const start = parseLocalDate(trend[0].date);
+    const end = parseLocalDate(trend[trend.length - 1].date);
+    const startMonth = start.getMonth() + 1;
+    const endMonth = end.getMonth() + 1;
+    if (start.getFullYear() !== end.getFullYear()) {
+      return `${start.getFullYear()}.${startMonth} – ${end.getFullYear()}.${endMonth}`;
+    }
+    if (startMonth === endMonth) {
+      return `${start.getFullYear()}년 ${startMonth}월`;
+    }
+    return `${start.getFullYear()}년 ${startMonth}–${endMonth}월`;
+  }, [trend]);
+
+  if (cells.length === 0) {
+    return (
+      <Text size="caption1" className="block text-gray-400">
+        표시할 기간이 없어요.
+      </Text>
+    );
+  }
+
+  return (
+    <div className="max-w-[380px]">
+      <Text size="caption1" weight="medium" className="mb-2 block text-gray-500">
+        {monthLabel}
+      </Text>
+      <div className="grid grid-cols-7 gap-1">
+        {WEEKDAYS.map((weekday, index) => (
+          <div key={weekday} className="pb-0.5 text-center">
+            <Text
+              size="caption2"
+              weight="regular"
+              className={cn(
+                'text-gray-400',
+                index === 0 && 'text-red-400',
+                index === 6 && 'text-blue-400'
+              )}
+            >
+              {weekday}
+            </Text>
+          </div>
+        ))}
+        {cells.map((cell, index) => {
+          if (!cell) {
+            return <div key={`empty-${index}`} className="aspect-square" />;
+          }
+          const day = parseLocalDate(cell.date).getDate();
+          const level = toHeatmapLevel(cell.count, maxCount);
+          return (
+            <button
+              key={cell.date}
+              type="button"
+              onClick={() => onSelectDate(cell.date)}
+              aria-label={`${
+                formatMonthDayKR(cell.date) || cell.date
+              } 일지 ${cell.count}개`}
+              className={cn(
+                'flex aspect-square flex-col items-center justify-center',
+                'gap-0.5 rounded-[8px] transition-transform',
+                'hover:scale-[1.04]',
+                LEVEL_STYLE[level]
+              )}
+            >
+              <span className="text-[11px] leading-none font-bold tabular-nums">
+                {day}
+              </span>
+              {cell.count > 0 ? (
+                <span className="text-[9px] leading-none font-semibold opacity-80">
+                  {cell.count}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/challenge/detail/components/ChallengeStatisticsSection.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeStatisticsSection.tsx
@@ -1,21 +1,26 @@
 'use client';
 
-import { Heatmap, Text } from '@1d1s/design-system';
+import { Text } from '@1d1s/design-system';
 import { Skeleton } from '@component/Skeleton';
 import { LineTrend, type TrendDatum } from '@feature/member/statistics/components/LineTrend';
-import { formatBucketLabel } from '@feature/member/statistics/utils/statisticsView';
+import {
+  formatBucketLabel,
+  toIsoWeekKey,
+} from '@feature/member/statistics/utils/statisticsView';
 import { normalizeApiError } from '@module/api/error';
 import { cn } from '@module/utils/cn';
-import { formatMonthDayKR } from '@module/utils/date';
 import { useRouter } from 'next/navigation';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { useChallengeStatistics } from '../hooks/useChallengeDiaryQueries';
-import { toHeatmapLevel } from '../utils/challengeStatisticsView';
+import { parseLocalDate } from '../utils/challengeStatisticsView';
+import { ChallengeDiaryCalendar } from './ChallengeDiaryCalendar';
 
 interface ChallengeStatisticsSectionProps {
   challengeId: number;
 }
+
+type TrendUnit = 'day' | 'week';
 
 function StatTile({
   label,
@@ -37,9 +42,8 @@ function StatTile({
 }
 
 /**
- * 챌린지 통계 — 참여율/완료 목표수 KPI + 일자별 일지 추이(꺾은선) +
- * 날짜별 일지 개수 히트맵 캘린더. 셀 클릭 시 그 날짜로 필터된 일지 목록으로
- * 이동한다.
+ * 챌린지 통계 — 참여율/완료 목표수 KPI + 일자별 일지 추이(꺾은선, 일/주 전환) +
+ * 날짜별 일지 캘린더. 캘린더 셀 클릭 시 그 날짜로 필터된 일지 목록으로 이동한다.
  */
 export function ChallengeStatisticsSection({
   challengeId,
@@ -47,13 +51,12 @@ export function ChallengeStatisticsSection({
   const router = useRouter();
   const { data, isPending, isError, error } =
     useChallengeStatistics(challengeId);
+  const [trendUnit, setTrendUnit] = useState<TrendUnit>('day');
 
   const trend = useMemo(() => data?.diaryTrend ?? [], [data]);
-  const maxCount = useMemo(
-    () => trend.reduce((max, point) => Math.max(max, point.count), 0),
-    [trend]
-  );
-  const barData: TrendDatum[] = useMemo(
+
+  // 일간: 날짜별 그대로.
+  const dailyData: TrendDatum[] = useMemo(
     () =>
       trend.map((point) => ({
         bucket: point.date,
@@ -62,12 +65,26 @@ export function ChallengeStatisticsSection({
       })),
     [trend]
   );
-  const cells = useMemo(
-    () => trend.map((point) => toHeatmapLevel(point.count, maxCount)),
-    [trend, maxCount]
-  );
-  // Heatmap 은 컬럼 우선(7행) — 한 컬럼이 연속 7일. 컬럼 수만 계산해 전달.
-  const cols = Math.max(1, Math.ceil(trend.length / 7));
+
+  // 주간: ISO 주차로 합산. 첫 등장 순서(=시간순)를 유지한다.
+  const weeklyData: TrendDatum[] = useMemo(() => {
+    const sums = new Map<string, number>();
+    const order: string[] = [];
+    trend.forEach((point) => {
+      const key = toIsoWeekKey(parseLocalDate(point.date));
+      if (!sums.has(key)) {
+        order.push(key);
+      }
+      sums.set(key, (sums.get(key) ?? 0) + (point.count ?? 0));
+    });
+    return order.map((key) => ({
+      bucket: key,
+      count: sums.get(key) ?? 0,
+      label: formatBucketLabel(key),
+    }));
+  }, [trend]);
+
+  const trendData = trendUnit === 'week' ? weeklyData : dailyData;
   const totalDiaries = useMemo(
     () => trend.reduce((sum, point) => sum + (point.count ?? 0), 0),
     [trend]
@@ -119,17 +136,36 @@ export function ChallengeStatisticsSection({
           </div>
 
           <div>
-            <Text
-              size="caption1"
-              weight="bold"
-              className="mb-2 block text-gray-500"
-            >
-              일자별 일지 추이
-            </Text>
-            {barData.length > 0 && totalDiaries > 0 ? (
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <Text size="caption1" weight="bold" className="text-gray-500">
+                일자별 일지 추이
+              </Text>
+              <div className="flex gap-0.5 rounded-full bg-gray-100 p-0.5">
+                {(['day', 'week'] as const).map((unit) => (
+                  <button
+                    key={unit}
+                    type="button"
+                    aria-pressed={trendUnit === unit}
+                    onClick={() => setTrendUnit(unit)}
+                    className={cn(
+                      'rounded-full px-2.5 py-1 text-[11px] font-bold',
+                      'transition-colors',
+                      trendUnit === unit
+                        ? 'bg-white text-gray-900 shadow-sm'
+                        : 'text-gray-500 hover:text-gray-700'
+                    )}
+                  >
+                    {unit === 'day' ? '일간' : '주간'}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {trendData.length > 0 && totalDiaries > 0 ? (
               <LineTrend
-                data={barData}
-                ariaLabel={`일자별 일지 추이 꺾은선 차트, 총 ${totalDiaries}건`}
+                data={trendData}
+                ariaLabel={`${
+                  trendUnit === 'week' ? '주간' : '일자별'
+                } 일지 추이 꺾은선 차트, 총 ${totalDiaries}건`}
               />
             ) : (
               <Text size="caption1" className="block text-gray-400">
@@ -146,55 +182,12 @@ export function ChallengeStatisticsSection({
             >
               날짜별 일지 (날짜를 눌러 그 날 일지만 보기)
             </Text>
-            {cells.length > 0 ? (
-              <div className="overflow-x-auto">
-                <Heatmap
-                  cells={cells}
-                  cols={cols}
-                  tone="main"
-                  ariaLabel={(index) => {
-                    const point = trend[index];
-                    if (!point) {
-                      return '';
-                    }
-                    const label = formatMonthDayKR(point.date) || point.date;
-                    return point.count > 0
-                      ? `${label} · 일지 ${point.count}개`
-                      : `${label} · 일지 없음`;
-                  }}
-                  renderCellTooltip={({ index }) => {
-                    const point = trend[index];
-                    if (!point) {
-                      return null;
-                    }
-                    const label = formatMonthDayKR(point.date) || point.date;
-                    return (
-                      <div className="flex flex-col gap-0.5">
-                        <span className="font-semibold">{label}</span>
-                        <span className="text-gray-200">
-                          {point.count > 0
-                            ? `일지 ${point.count}개`
-                            : '일지 없음'}
-                        </span>
-                      </div>
-                    );
-                  }}
-                  onCellClick={({ index }) => {
-                    const point = trend[index];
-                    if (point) {
-                      // 상세 탭 뷰의 일지 탭으로 이동해 그 날짜만 필터한다.
-                      router.push(
-                        `/challenge/${challengeId}?tab=diary&date=${point.date}`
-                      );
-                    }
-                  }}
-                />
-              </div>
-            ) : (
-              <Text size="caption1" className="block text-gray-400">
-                표시할 기간이 없어요.
-              </Text>
-            )}
+            <ChallengeDiaryCalendar
+              trend={trend}
+              onSelectDate={(date) =>
+                router.push(`/challenge/${challengeId}?tab=diary&date=${date}`)
+              }
+            />
           </div>
         </div>
       )}

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -43,6 +43,7 @@ import { ChallengeRulesCard } from '../components/ChallengeRulesCard';
 import { ChallengeStatisticsSection } from '../components/ChallengeStatisticsSection';
 import { ExpandableText } from '../components/ExpandableText';
 import { PendingMemberItem } from '../components/PendingMemberItem';
+import { useChallengeStatistics } from '../hooks/useChallengeDiaryQueries';
 import { useChallengeGoalEditors } from '../hooks/useChallengeGoalEditors';
 import {
   useAcceptParticipant,
@@ -84,6 +85,24 @@ function isChallengeTab(value: string | null): value is ChallengeTabId {
   return value !== null && ids.includes(value);
 }
 
+// 탭 라벨 옆 카운트 배지 — 원형 배경. 활성 탭은 브랜드 톤.
+function renderTabCountBadge(
+  value: number,
+  active: boolean
+): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        'inline-flex min-w-[1.125rem] items-center justify-center',
+        'rounded-full px-1 text-[11px] leading-none font-bold',
+        active ? 'bg-main-100 text-main-800' : 'bg-gray-100 text-gray-500'
+      )}
+    >
+      {value}
+    </span>
+  );
+}
+
 export function ChallengeDetailScreen({
   id,
 }: ChallengeDetailScreenProps): React.ReactElement {
@@ -112,6 +131,12 @@ export function ChallengeDetailScreen({
 
   const { data, isLoading, isError, error } = useChallengeDetail(challengeId);
   const showSkeleton = useMinimumLoading(isLoading);
+
+  // 일지 탭 배지용 총 일지 수. 통계 쿼리(소개 탭과 공유·캐시)의 일자별 합계다.
+  const { data: statsData } = useChallengeStatistics(challengeId);
+  const diaryCount = statsData
+    ? statsData.diaryTrend.reduce((sum, point) => sum + point.count, 0)
+    : undefined;
 
   const joinChallenge = useJoinChallenge();
   const leaveChallenge = useLeaveChallenge();
@@ -464,11 +489,24 @@ export function ChallengeDetailScreen({
 
   const tabItems = [
     { id: 'overview', label: '소개' },
-    { id: 'diary', label: '일지' },
+    {
+      id: 'diary',
+      label: '일지',
+      badge:
+        diaryCount !== undefined
+          ? renderTabCountBadge(diaryCount, activeTab === 'diary')
+          : undefined,
+    },
     {
       id: 'participants',
       label: '참여자',
-      badge: summaryParticipantCnt > 0 ? summaryParticipantCnt : undefined,
+      badge:
+        summaryParticipantCnt > 0
+          ? renderTabCountBadge(
+              summaryParticipantCnt,
+              activeTab === 'participants'
+            )
+          : undefined,
     },
   ];
 
@@ -712,7 +750,7 @@ export function ChallengeDetailScreen({
                       >
                         챌린지 정보
                       </Text>
-                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      <div className="flex flex-col gap-1.5">
                         {infoRows.map((row) => (
                           <div
                             key={row.label}
@@ -723,15 +761,20 @@ export function ChallengeDetailScreen({
                           >
                             <Text
                               size="caption1"
-                              weight="medium"
-                              className="w-16 shrink-0 text-gray-400"
+                              weight="regular"
+                              className={cn(
+                                'shrink-0 whitespace-nowrap text-gray-400'
+                              )}
                             >
                               {row.label}
                             </Text>
                             <Text
                               size="caption1"
-                              weight="bold"
-                              className="min-w-0 flex-1 break-keep text-gray-800"
+                              weight="medium"
+                              className={cn(
+                                'min-w-0 flex-1 truncate text-right',
+                                'text-gray-700'
+                              )}
                             >
                               {row.value}
                             </Text>

--- a/src/app.feature/challenge/detail/utils/challengeStatisticsView.ts
+++ b/src/app.feature/challenge/detail/utils/challengeStatisticsView.ts
@@ -6,3 +6,10 @@ export function toHeatmapLevel(count: number, max: number): number {
   }
   return Math.max(1, Math.min(4, Math.ceil((count / max) * 4)));
 }
+
+// 'YYYY-MM-DD' → 로컬 Date. new Date(str) 의 UTC 파싱으로 인한 하루 시프트를
+// 막기 위해 연/월/일을 직접 분해해 로컬 자정으로 만든다.
+export function parseLocalDate(value: string): Date {
+  const [year, month, day] = value.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -129,6 +129,12 @@ function pad2(value: number): string {
   return String(value).padStart(2, '0');
 }
 
+// 로컬 Date → ISO 주차 키(YYYY-Www). 주단위 버킷 집계에 사용한다.
+export function toIsoWeekKey(date: Date): string {
+  const { year, week } = isoWeekParts(date);
+  return `${year}-W${pad2(week)}`;
+}
+
 // buckets 중 "오늘(현재 구간)"이 속한 버킷의 인덱스. 없으면 -1(과거 기간 조회 등).
 // 버킷 포맷을 첫 항목으로 판별한다:
 //   YYYY-MM-DD(일) · YYYY-MM(월) · YYYY-Www(ISO 주).


### PR DESCRIPTION
## 요청 반영
1. **날짜별 일지 → 캘린더 뷰**
   - 기존 GitHub식 히트맵을 **주(일~토) 단위 행 캘린더**(`ChallengeDiaryCalendar` 신설)로 교체.
   - 날짜별 일지 수를 색 농도(0~4레벨)로 표시, 요일 헤더·월 라벨 포함. 셀 클릭 시
     `?tab=diary&date=` 로 그 날짜 필터 진입(기존 동작 유지).
2. **일자별 일지 추이 → 주단위 보기**
   - 추이 차트에 **일간/주간 토글** 추가. 주간은 **ISO 주차**로 합산
     (`toIsoWeekKey` 신설). 30일 챌린지에서 일간의 과밀 라벨을 주간으로 정리.
3. **챌린지 정보 카드 — 볼드/줄바꿈 정리**
   - 값 굵기 완화(bold→medium), 라벨 회색·regular.
   - **1열 배치** + 라벨 `whitespace-nowrap`, 값 우측 정렬 + `truncate` 로
     **줄바꿈 제거**.
4. **일지 탭 카운트 배지**
   - 일지 탭 옆에 **총 일지 수** 표시. 배지는 **원형 배경**으로 렌더하고
     참여자 배지도 동일 스타일로 통일.

## 구현 메모
- 일지 총계는 `useChallengeStatistics`(소개 탭 통계와 **동일 쿼리키 → 캐시 공유**,
  중복 요청 없음)의 `diaryTrend` 합계에서 얻는다. 배지 상시 노출을 위해 상세
  진입 시 통계 1건을 조회(캐시·5분 stale).
- 헬퍼: `parseLocalDate`(UTC 파싱 하루 시프트 방지), `toIsoWeekKey`.

## 검증
- `pnpm tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors; 남은 warning 은 무관한 기존 파일)
- `pnpm knip` ✅
- `pnpm vitest run` ✅ (120 passed)
- `pnpm build` ✅
- ⚠️ 브라우저 실렌더는 프로젝트 정책상 미확인(캘린더 셀 크기·주간 차트·배지 원형은
  실기기 확인 권장).