### PR TITLE
feat: 챌린지 통계 일지 추이 차트 제거·캘린더 DS 교체·탭 배지 정원화

### DIFF
--- a/src/app.feature/challenge/detail/components/ChallengeDiaryCalendar.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDiaryCalendar.tsx
@@ -1,61 +1,94 @@
 'use client';
 
-import { Text } from '@1d1s/design-system';
+import {
+  ScheduleCalendar,
+  type ScheduleCalendarCell,
+  Text,
+} from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import { formatMonthDayKR } from '@module/utils/date';
 import React, { useMemo } from 'react';
 
 import { ChallengeDiaryTrendPoint } from '../type/challengeStatistics';
-import {
-  parseLocalDate,
-  toHeatmapLevel,
-} from '../utils/challengeStatisticsView';
+import { parseLocalDate } from '../utils/challengeStatisticsView';
 
 const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
-
-// level(0~4) → 배경/텍스트. 0 은 일지 없는 날.
-const LEVEL_STYLE = [
-  'bg-gray-50 text-gray-400',
-  'bg-main-100 text-main-800',
-  'bg-main-200 text-main-900',
-  'bg-main-500 text-white',
-  'bg-main-800 text-white',
-];
 
 interface ChallengeDiaryCalendarProps {
   trend: ChallengeDiaryTrendPoint[];
   onSelectDate(date: string): void;
 }
 
+// DS ScheduleCalendar 는 셀 클릭 API 가 없어, 클릭이 필요한 날짜는 content 에
+// 버튼을 넣어 상호작용을 부여한다. 빈 칸은 muted 셀로 채운다.
+function toDateCell(
+  point: ChallengeDiaryTrendPoint,
+  onSelectDate: (date: string) => void
+): ScheduleCalendarCell {
+  const day = parseLocalDate(point.date).getDate();
+  const label = `${formatMonthDayKR(point.date) || point.date} 일지 ${
+    point.count
+  }개`;
+  return {
+    id: point.date,
+    content: (
+      <button
+        type="button"
+        onClick={() => onSelectDate(point.date)}
+        aria-label={label}
+        className={cn(
+          'flex h-full w-full flex-col items-center justify-center gap-0.5',
+          'rounded-[8px] transition-colors hover:bg-gray-50',
+          point.count > 0 && 'text-main-800'
+        )}
+      >
+        <span className="text-[11px] leading-none font-medium tabular-nums">
+          {day}
+        </span>
+        {point.count > 0 ? (
+          <span
+            className={cn(
+              'rounded-full bg-brand-soft px-1 text-[9px] leading-none',
+              'font-semibold tabular-nums text-brand'
+            )}
+          >
+            {point.count}
+          </span>
+        ) : null}
+      </button>
+    ),
+  };
+}
+
 /**
- * 날짜별 일지 캘린더 — 주(일~토) 단위 행으로 챌린지 기간의 날짜별 일지 수를
- * 색 농도로 표시한다. 셀 클릭 시 그 날짜로 필터된 일지 목록으로 이동한다.
+ * 날짜별 일지 캘린더 — DS ScheduleCalendar(주 단위 표) 위에 챌린지 기간의
+ * 날짜별 일지 수를 표시한다. 셀 클릭 시 그 날짜로 필터된 일지 목록으로 이동한다.
  */
 export function ChallengeDiaryCalendar({
   trend,
   onSelectDate,
 }: ChallengeDiaryCalendarProps): React.ReactElement {
-  const maxCount = useMemo(
-    () => trend.reduce((max, point) => Math.max(max, point.count), 0),
-    [trend]
-  );
-
-  // 첫 날짜 요일만큼 앞을 비우고, 마지막 주를 7칸으로 채운다.
-  const cells = useMemo<Array<ChallengeDiaryTrendPoint | null>>(() => {
+  // 첫 날짜 요일만큼 앞을 비우고, 마지막 주를 7칸으로 채운 뒤 주 단위로 자른다.
+  const rows = useMemo<ScheduleCalendarCell[][]>(() => {
     if (trend.length === 0) {
       return [];
     }
+    const empty: ScheduleCalendarCell = { muted: true };
+    const cells: ScheduleCalendarCell[] = [];
     const lead = parseLocalDate(trend[0].date).getDay();
-    const filled: Array<ChallengeDiaryTrendPoint | null> = [];
     for (let i = 0; i < lead; i += 1) {
-      filled.push(null);
+      cells.push(empty);
     }
-    trend.forEach((point) => filled.push(point));
-    while (filled.length % 7 !== 0) {
-      filled.push(null);
+    trend.forEach((point) => cells.push(toDateCell(point, onSelectDate)));
+    while (cells.length % 7 !== 0) {
+      cells.push(empty);
     }
-    return filled;
-  }, [trend]);
+    const weeks: ScheduleCalendarCell[][] = [];
+    for (let i = 0; i < cells.length; i += 7) {
+      weeks.push(cells.slice(i, i + 7));
+    }
+    return weeks;
+  }, [trend, onSelectDate]);
 
   const monthLabel = useMemo(() => {
     if (trend.length === 0) {
@@ -74,7 +107,7 @@ export function ChallengeDiaryCalendar({
     return `${start.getFullYear()}년 ${startMonth}–${endMonth}월`;
   }, [trend]);
 
-  if (cells.length === 0) {
+  if (rows.length === 0) {
     return (
       <Text size="caption1" className="block text-gray-400">
         표시할 기간이 없어요.
@@ -83,59 +116,15 @@ export function ChallengeDiaryCalendar({
   }
 
   return (
-    <div className="max-w-[380px]">
+    <div className="max-w-[420px]">
       <Text size="caption1" weight="medium" className="mb-2 block text-gray-500">
         {monthLabel}
       </Text>
-      <div className="grid grid-cols-7 gap-1">
-        {WEEKDAYS.map((weekday, index) => (
-          <div key={weekday} className="pb-0.5 text-center">
-            <Text
-              size="caption2"
-              weight="regular"
-              className={cn(
-                'text-gray-400',
-                index === 0 && 'text-red-400',
-                index === 6 && 'text-blue-400'
-              )}
-            >
-              {weekday}
-            </Text>
-          </div>
-        ))}
-        {cells.map((cell, index) => {
-          if (!cell) {
-            return <div key={`empty-${index}`} className="aspect-square" />;
-          }
-          const day = parseLocalDate(cell.date).getDate();
-          const level = toHeatmapLevel(cell.count, maxCount);
-          return (
-            <button
-              key={cell.date}
-              type="button"
-              onClick={() => onSelectDate(cell.date)}
-              aria-label={`${
-                formatMonthDayKR(cell.date) || cell.date
-              } 일지 ${cell.count}개`}
-              className={cn(
-                'flex aspect-square flex-col items-center justify-center',
-                'gap-0.5 rounded-[8px] transition-transform',
-                'hover:scale-[1.04]',
-                LEVEL_STYLE[level]
-              )}
-            >
-              <span className="text-[11px] leading-none font-bold tabular-nums">
-                {day}
-              </span>
-              {cell.count > 0 ? (
-                <span className="text-[9px] leading-none font-semibold opacity-80">
-                  {cell.count}
-                </span>
-              ) : null}
-            </button>
-          );
-        })}
-      </div>
+      <ScheduleCalendar
+        rows={rows}
+        weekLabels={WEEKDAYS}
+        cellMinHeight={44}
+      />
     </div>
   );
 }

--- a/src/app.feature/challenge/detail/components/ChallengeStatisticsSection.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeStatisticsSection.tsx
@@ -2,25 +2,17 @@
 
 import { Text } from '@1d1s/design-system';
 import { Skeleton } from '@component/Skeleton';
-import { LineTrend, type TrendDatum } from '@feature/member/statistics/components/LineTrend';
-import {
-  formatBucketLabel,
-  toIsoWeekKey,
-} from '@feature/member/statistics/utils/statisticsView';
 import { normalizeApiError } from '@module/api/error';
 import { cn } from '@module/utils/cn';
 import { useRouter } from 'next/navigation';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 
 import { useChallengeStatistics } from '../hooks/useChallengeDiaryQueries';
-import { parseLocalDate } from '../utils/challengeStatisticsView';
 import { ChallengeDiaryCalendar } from './ChallengeDiaryCalendar';
 
 interface ChallengeStatisticsSectionProps {
   challengeId: number;
 }
-
-type TrendUnit = 'day' | 'week';
 
 function StatTile({
   label,
@@ -42,8 +34,8 @@ function StatTile({
 }
 
 /**
- * 챌린지 통계 — 참여율/완료 목표수 KPI + 일자별 일지 추이(꺾은선, 일/주 전환) +
- * 날짜별 일지 캘린더. 캘린더 셀 클릭 시 그 날짜로 필터된 일지 목록으로 이동한다.
+ * 챌린지 통계 — 참여율/완료 목표수 KPI + 날짜별 일지 캘린더.
+ * 캘린더 셀 클릭 시 그 날짜로 필터된 일지 목록으로 이동한다.
  */
 export function ChallengeStatisticsSection({
   challengeId,
@@ -51,44 +43,8 @@ export function ChallengeStatisticsSection({
   const router = useRouter();
   const { data, isPending, isError, error } =
     useChallengeStatistics(challengeId);
-  const [trendUnit, setTrendUnit] = useState<TrendUnit>('day');
 
   const trend = useMemo(() => data?.diaryTrend ?? [], [data]);
-
-  // 일간: 날짜별 그대로.
-  const dailyData: TrendDatum[] = useMemo(
-    () =>
-      trend.map((point) => ({
-        bucket: point.date,
-        count: point.count ?? 0,
-        label: formatBucketLabel(point.date),
-      })),
-    [trend]
-  );
-
-  // 주간: ISO 주차로 합산. 첫 등장 순서(=시간순)를 유지한다.
-  const weeklyData: TrendDatum[] = useMemo(() => {
-    const sums = new Map<string, number>();
-    const order: string[] = [];
-    trend.forEach((point) => {
-      const key = toIsoWeekKey(parseLocalDate(point.date));
-      if (!sums.has(key)) {
-        order.push(key);
-      }
-      sums.set(key, (sums.get(key) ?? 0) + (point.count ?? 0));
-    });
-    return order.map((key) => ({
-      bucket: key,
-      count: sums.get(key) ?? 0,
-      label: formatBucketLabel(key),
-    }));
-  }, [trend]);
-
-  const trendData = trendUnit === 'week' ? weeklyData : dailyData;
-  const totalDiaries = useMemo(
-    () => trend.reduce((sum, point) => sum + (point.count ?? 0), 0),
-    [trend]
-  );
 
   const participationLabel = !data
     ? '-'
@@ -133,45 +89,6 @@ export function ChallengeStatisticsSection({
               label="완료 목표수"
               value={`${data.completedGoalCount}개`}
             />
-          </div>
-
-          <div>
-            <div className="mb-2 flex items-center justify-between gap-2">
-              <Text size="caption1" weight="bold" className="text-gray-500">
-                일자별 일지 추이
-              </Text>
-              <div className="flex gap-0.5 rounded-full bg-gray-100 p-0.5">
-                {(['day', 'week'] as const).map((unit) => (
-                  <button
-                    key={unit}
-                    type="button"
-                    aria-pressed={trendUnit === unit}
-                    onClick={() => setTrendUnit(unit)}
-                    className={cn(
-                      'rounded-full px-2.5 py-1 text-[11px] font-bold',
-                      'transition-colors',
-                      trendUnit === unit
-                        ? 'bg-white text-gray-900 shadow-sm'
-                        : 'text-gray-500 hover:text-gray-700'
-                    )}
-                  >
-                    {unit === 'day' ? '일간' : '주간'}
-                  </button>
-                ))}
-              </div>
-            </div>
-            {trendData.length > 0 && totalDiaries > 0 ? (
-              <LineTrend
-                data={trendData}
-                ariaLabel={`${
-                  trendUnit === 'week' ? '주간' : '일자별'
-                } 일지 추이 꺾은선 차트, 총 ${totalDiaries}건`}
-              />
-            ) : (
-              <Text size="caption1" className="block text-gray-400">
-                아직 작성된 일지가 없어요.
-              </Text>
-            )}
           </div>
 
           <div>

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -93,8 +93,9 @@ function renderTabCountBadge(
   return (
     <span
       className={cn(
-        'inline-flex min-w-[1.125rem] items-center justify-center',
-        'rounded-full px-1 text-[11px] leading-none font-bold',
+        'inline-flex aspect-square h-[1.125rem] min-w-[1.125rem]',
+        'items-center justify-center rounded-full px-1',
+        'text-[11px] leading-none font-bold',
         active ? 'bg-main-100 text-main-800' : 'bg-gray-100 text-gray-500'
       )}
     >

--- a/src/app.feature/challenge/detail/utils/challengeStatisticsView.test.ts
+++ b/src/app.feature/challenge/detail/utils/challengeStatisticsView.test.ts
@@ -1,21 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { toHeatmapLevel } from './challengeStatisticsView';
+import { parseLocalDate } from './challengeStatisticsView';
 
-describe('toHeatmapLevel', () => {
-  it('0건이거나 max 가 0이면 level 0', () => {
-    expect(toHeatmapLevel(0, 10)).toBe(0);
-    expect(toHeatmapLevel(-3, 10)).toBe(0);
-    expect(toHeatmapLevel(5, 0)).toBe(0);
-  });
-
-  it('작성이 있으면 최소 level 1 로 보이게 한다', () => {
-    expect(toHeatmapLevel(1, 100)).toBe(1);
-  });
-
-  it('최댓값 대비 비율로 1~4 를 매긴다 (포화 방지)', () => {
-    expect(toHeatmapLevel(10, 10)).toBe(4);
-    expect(toHeatmapLevel(5, 10)).toBe(2);
-    expect(toHeatmapLevel(6, 10)).toBe(3);
+describe('parseLocalDate', () => {
+  it('UTC 시프트 없이 로컬 자정으로 파싱한다', () => {
+    const date = parseLocalDate('2026-07-11');
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(6); // 0-based
+    expect(date.getDate()).toBe(11);
+    expect(date.getHours()).toBe(0);
   });
 });

--- a/src/app.feature/challenge/detail/utils/challengeStatisticsView.ts
+++ b/src/app.feature/challenge/detail/utils/challengeStatisticsView.ts
@@ -1,12 +1,3 @@
-// 참여자 수가 많은 챌린지는 하루 count 가 커서 raw count 를 그대로 level 에
-// 매핑하면 대부분 4로 포화된다. 기간 내 최댓값 대비 비율로 0~4 를 매긴다.
-export function toHeatmapLevel(count: number, max: number): number {
-  if (count <= 0 || max <= 0) {
-    return 0;
-  }
-  return Math.max(1, Math.min(4, Math.ceil((count / max) * 4)));
-}
-
 // 'YYYY-MM-DD' → 로컬 Date. new Date(str) 의 UTC 파싱으로 인한 하루 시프트를
 // 막기 위해 연/월/일을 직접 분해해 로컬 자정으로 만든다.
 export function parseLocalDate(value: string): Date {

--- a/src/app.feature/member/statistics/utils/statisticsView.ts
+++ b/src/app.feature/member/statistics/utils/statisticsView.ts
@@ -129,12 +129,6 @@ function pad2(value: number): string {
   return String(value).padStart(2, '0');
 }
 
-// 로컬 Date → ISO 주차 키(YYYY-Www). 주단위 버킷 집계에 사용한다.
-export function toIsoWeekKey(date: Date): string {
-  const { year, week } = isoWeekParts(date);
-  return `${year}-W${pad2(week)}`;
-}
-
 // buckets 중 "오늘(현재 구간)"이 속한 버킷의 인덱스. 없으면 -1(과거 기간 조회 등).
 // 버킷 포맷을 첫 항목으로 판별한다:
 //   YYYY-MM-DD(일) · YYYY-MM(월) · YYYY-Www(ISO 주).


### PR DESCRIPTION
## 개요
챌린지 상세(#172) 후속 수정 3건.

## 변경사항
1. **일자별 일지 추이 차트 제거** — 꺾은선 + 일/주 토글 섹션 삭제. 관련 dead code 정리 (`toHeatmapLevel`, `toIsoWeekKey` 미사용 유틸 삭제, knip 통과).
2. **캘린더를 DS `ScheduleCalendar`로 교체** — 자체 구현 주단위 캘린더 삭제. 1D1S-admin 팝업 관리와 동일한 DS 컴포넌트 재사용. 날짜별 일지 수 표시 + 셀 클릭 시 해당 날짜로 필터된 챌린지 일지로 이동하는 기존 동작 유지 (DS엔 셀 클릭 API가 없어 `content`에 버튼을 넣어 상호작용 부여).
3. **탭 카운트 배지 정원화** — `aspect-square` + 고정 크기(`h/min-w`)로 단·두 자리는 정원 유지, 3자리 이상은 자연스럽게 확장.

## 검증
- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm knip` ✅
- `vitest run` ✅ (118 passed)
- `pnpm build` ✅

브라우저 확인은 사용자에게 맡김 (직접 렌더 테스트는 하지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated challenge diary statistics with a streamlined calendar view for selecting dates.
  - Calendar entries now provide clearer date and diary-count information for accessibility.
  - Improved calendar spacing and layout for a more comfortable viewing experience.

- **Changes**
  - Removed the daily/weekly diary trend chart and its period toggle from challenge statistics.
  - Refined tab count badges with more consistent sizing and shape styling.

- **Bug Fixes**
  - Improved date handling to prevent dates from shifting across time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->