### PR TITLE
feat: 챌린지 일지 캘린더를 DS MonthCalendar로 교체 — 월 이동·풀폭 지원

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@1d1s/design-system": "^2.8.0",
+    "@1d1s/design-system": "^2.9.0",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-aspect-ratio": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@1d1s/design-system':
-        specifier: ^2.8.0
-        version: 2.8.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^2.9.0
+        version: 2.9.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.0.1(react-hook-form@7.55.0(react@19.2.4))
@@ -252,8 +252,8 @@ importers:
 
 packages:
 
-  '@1d1s/design-system@2.8.0':
-    resolution: {integrity: sha512-VImo1qe2dw8vCYsjVTOG373Za1bd85jNMLTCwgvt8zrwYlcC3rUBhmXl5KoysvLu4+5ZvfHDeITVT54+05NAQQ==}
+  '@1d1s/design-system@2.9.0':
+    resolution: {integrity: sha512-qCx+MxIhe9n2c8dxCaQBOollv/6p9d0L9rj1QaBygwCuwdwT+Hcscg6oEt3D4VsA/gMxUDFw87dduzYSHUKg1A==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0
       react: ^19.0.0
@@ -4916,7 +4916,7 @@ packages:
 
 snapshots:
 
-  '@1d1s/design-system@2.8.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@1d1s/design-system@2.9.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-checkbox': 1.1.5(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/app.feature/challenge/detail/components/ChallengeDiaryCalendar.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDiaryCalendar.tsx
@@ -1,113 +1,48 @@
 'use client';
 
 import {
-  ScheduleCalendar,
-  type ScheduleCalendarCell,
+  MonthCalendar,
+  type MonthCalendarDay,
   Text,
 } from '@1d1s/design-system';
-import { cn } from '@module/utils/cn';
-import { formatMonthDayKR } from '@module/utils/date';
+import { formatDateISO } from '@module/utils/date';
 import React, { useMemo } from 'react';
 
 import { ChallengeDiaryTrendPoint } from '../type/challengeStatistics';
 import { parseLocalDate } from '../utils/challengeStatisticsView';
-
-const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
 interface ChallengeDiaryCalendarProps {
   trend: ChallengeDiaryTrendPoint[];
   onSelectDate(date: string): void;
 }
 
-// DS ScheduleCalendar 는 셀 클릭 API 가 없어, 클릭이 필요한 날짜는 content 에
-// 버튼을 넣어 상호작용을 부여한다. 빈 칸은 muted 셀로 채운다.
-function toDateCell(
-  point: ChallengeDiaryTrendPoint,
-  onSelectDate: (date: string) => void
-): ScheduleCalendarCell {
-  const day = parseLocalDate(point.date).getDate();
-  const label = `${formatMonthDayKR(point.date) || point.date} 일지 ${
-    point.count
-  }개`;
-  return {
-    id: point.date,
-    content: (
-      <button
-        type="button"
-        onClick={() => onSelectDate(point.date)}
-        aria-label={label}
-        className={cn(
-          'flex h-full w-full flex-col items-center justify-center gap-0.5',
-          'rounded-[8px] transition-colors hover:bg-gray-50',
-          point.count > 0 && 'text-main-800'
-        )}
-      >
-        <span className="text-[11px] leading-none font-medium tabular-nums">
-          {day}
-        </span>
-        {point.count > 0 ? (
-          <span
-            className={cn(
-              'rounded-full bg-brand-soft px-1 text-[9px] leading-none',
-              'font-semibold tabular-nums text-brand'
-            )}
-          >
-            {point.count}
-          </span>
-        ) : null}
-      </button>
-    ),
-  };
-}
-
 /**
- * 날짜별 일지 캘린더 — DS ScheduleCalendar(주 단위 표) 위에 챌린지 기간의
- * 날짜별 일지 수를 표시한다. 셀 클릭 시 그 날짜로 필터된 일지 목록으로 이동한다.
+ * 날짜별 일지 캘린더 — DS MonthCalendar 로 챌린지 기간의 날짜별 일지 수를
+ * 표시한다. 날짜 클릭 시 그 날짜로 필터된 일지 목록으로 이동하고, 월 이동으로
+ * 챌린지 기간 내 다른 달도 볼 수 있다. 기간(첫~마지막 날) 밖 날짜는 비활성.
  */
 export function ChallengeDiaryCalendar({
   trend,
   onSelectDate,
 }: ChallengeDiaryCalendarProps): React.ReactElement {
-  // 첫 날짜 요일만큼 앞을 비우고, 마지막 주를 7칸으로 채운 뒤 주 단위로 자른다.
-  const rows = useMemo<ScheduleCalendarCell[][]>(() => {
-    if (trend.length === 0) {
-      return [];
-    }
-    const empty: ScheduleCalendarCell = { muted: true };
-    const cells: ScheduleCalendarCell[] = [];
-    const lead = parseLocalDate(trend[0].date).getDay();
-    for (let i = 0; i < lead; i += 1) {
-      cells.push(empty);
-    }
-    trend.forEach((point) => cells.push(toDateCell(point, onSelectDate)));
-    while (cells.length % 7 !== 0) {
-      cells.push(empty);
-    }
-    const weeks: ScheduleCalendarCell[][] = [];
-    for (let i = 0; i < cells.length; i += 7) {
-      weeks.push(cells.slice(i, i + 7));
-    }
-    return weeks;
-  }, [trend, onSelectDate]);
+  const days = useMemo<MonthCalendarDay[]>(
+    () => trend.map((point) => ({ date: point.date, count: point.count })),
+    [trend]
+  );
 
-  const monthLabel = useMemo(() => {
+  // 기본 표시 월: 오늘이 챌린지 기간 안이면 이번 달, 아니면 가장 가까운 경계 달.
+  const defaultMonth = useMemo(() => {
     if (trend.length === 0) {
-      return '';
+      return undefined;
     }
-    const start = parseLocalDate(trend[0].date);
-    const end = parseLocalDate(trend[trend.length - 1].date);
-    const startMonth = start.getMonth() + 1;
-    const endMonth = end.getMonth() + 1;
-    if (start.getFullYear() !== end.getFullYear()) {
-      return `${start.getFullYear()}.${startMonth} – ${end.getFullYear()}.${endMonth}`;
-    }
-    if (startMonth === endMonth) {
-      return `${start.getFullYear()}년 ${startMonth}월`;
-    }
-    return `${start.getFullYear()}년 ${startMonth}–${endMonth}월`;
+    const min = trend[0].date;
+    const max = trend[trend.length - 1].date;
+    const today = formatDateISO(new Date());
+    const anchor = today < min ? min : today > max ? max : today;
+    return parseLocalDate(anchor);
   }, [trend]);
 
-  if (rows.length === 0) {
+  if (trend.length === 0) {
     return (
       <Text size="caption1" className="block text-gray-400">
         표시할 기간이 없어요.
@@ -116,15 +51,13 @@ export function ChallengeDiaryCalendar({
   }
 
   return (
-    <div className="max-w-[420px]">
-      <Text size="caption1" weight="medium" className="mb-2 block text-gray-500">
-        {monthLabel}
-      </Text>
-      <ScheduleCalendar
-        rows={rows}
-        weekLabels={WEEKDAYS}
-        cellMinHeight={44}
-      />
-    </div>
+    <MonthCalendar
+      days={days}
+      indicator="count"
+      minDate={trend[0].date}
+      maxDate={trend[trend.length - 1].date}
+      defaultMonth={defaultMonth}
+      onSelectDate={onSelectDate}
+    />
   );
 }


### PR DESCRIPTION
## 배경
챌린지 상세 일지 탭 캘린더가 컨테이너 폭을 안 채우고(좁은 고정폭) 월 이동이 불가했다. DS 2.9.0에 추가된 신규 `MonthCalendar`로 교체한다.

## 변경
- 의존성: `@1d1s/design-system` `^2.8.0` → `^2.9.0`
- `ChallengeDiaryCalendar`: 수동 주 단위 청킹(`content` 버튼 주입) 로직 제거하고 `MonthCalendar` 사용
  - 날짜별 일지 수 표시 (`indicator="count"`, 카운트 배지)
  - 날짜 클릭 → 기존 `onSelectDate`로 `?tab=diary&date=<yyyy-MM-dd>` 이동 (동작 유지)
  - `minDate`/`maxDate` = 챌린지 기간(추이 배열 첫~마지막 날) → 기간 밖 날짜 자동 비활성
  - 기본 표시 월: 오늘이 기간 안이면 이번 달, 밖이면 가장 가까운 경계 달
  - 월 이동으로 챌린지 기간 내 다른 달도 열람 가능
  - 컨테이너 폭을 꽉 채움(기존 `max-w-[420px]` 래퍼 제거)

## 검증
- `tsc --noEmit` ✅
- `lint` ✅ (신규 파일 경고 0)
- `knip` ✅
- `vitest` ✅ (13 files / 118 tests)
- `next build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)