### PR TITLE
feat: 통계 헤더 뒤로가기 제거 · 일지 탭 날짜 필터 · 히스토리 정리 · 홈 배너 배치

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@1d1s/design-system": "^2.9.0",
+    "@1d1s/design-system": "^2.10.0",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-aspect-ratio": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@1d1s/design-system':
-        specifier: ^2.9.0
-        version: 2.9.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^2.10.0
+        version: 2.10.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.0.1(react-hook-form@7.55.0(react@19.2.4))
@@ -252,8 +252,8 @@ importers:
 
 packages:
 
-  '@1d1s/design-system@2.9.0':
-    resolution: {integrity: sha512-qCx+MxIhe9n2c8dxCaQBOollv/6p9d0L9rj1QaBygwCuwdwT+Hcscg6oEt3D4VsA/gMxUDFw87dduzYSHUKg1A==}
+  '@1d1s/design-system@2.10.0':
+    resolution: {integrity: sha512-AJRcITFpzsserqzHgMpp3BAUc5j5o+bIqM/4+YmYz3h3w22GpJgakqR9Lf0MSv8rLE5s918yp9vPY+wJf6Zdrw==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0
       react: ^19.0.0
@@ -4916,7 +4916,7 @@ packages:
 
 snapshots:
 
-  '@1d1s/design-system@2.9.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@1d1s/design-system@2.10.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-checkbox': 1.1.5(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/app.component/layout/SubPageShell.tsx
+++ b/src/app.component/layout/SubPageShell.tsx
@@ -14,6 +14,8 @@ interface SubPageShellProps {
   headerAction?: React.ReactNode;
   /** 뒤로가기 동작 (기본값: router.back) */
   onBack?(): void;
+  /** 최상위 진입 화면 등 뒤로가기가 불필요할 때 헤더 좌측 버튼을 숨긴다. */
+  hideBack?: boolean;
   children: React.ReactNode;
 }
 
@@ -31,6 +33,7 @@ export function SubPageShell({
   description,
   headerAction,
   onBack,
+  hideBack = false,
   children,
 }: SubPageShellProps): React.ReactElement {
   const router = useRouter();
@@ -38,7 +41,11 @@ export function SubPageShell({
   const handleBack = onBack ?? ((): void => router.back());
   return (
     <div className="min-h-screen w-full">
-      <MobileHeader title={title} onBack={handleBack} right={headerAction} />
+      <MobileHeader
+        title={title}
+        onBack={hideBack ? undefined : handleBack}
+        right={headerAction}
+      />
 
       <section className="mx-auto w-full max-w-[980px] p-4 lg:p-6">
         {/* 데스크탑 헤더 */}

--- a/src/app.feature/challenge/detail/components/ChallengeDiaryCalendar.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDiaryCalendar.tsx
@@ -14,6 +14,8 @@ import { parseLocalDate } from '../utils/challengeStatisticsView';
 interface ChallengeDiaryCalendarProps {
   trend: ChallengeDiaryTrendPoint[];
   onSelectDate(date: string): void;
+  // 선택된 날짜(YYYY-MM-DD). 지정 시 해당 셀을 강조한다.
+  selectedDate?: string;
 }
 
 /**
@@ -24,6 +26,7 @@ interface ChallengeDiaryCalendarProps {
 export function ChallengeDiaryCalendar({
   trend,
   onSelectDate,
+  selectedDate,
 }: ChallengeDiaryCalendarProps): React.ReactElement {
   const days = useMemo<MonthCalendarDay[]>(
     () => trend.map((point) => ({ date: point.date, count: point.count })),
@@ -57,6 +60,7 @@ export function ChallengeDiaryCalendar({
       minDate={trend[0].date}
       maxDate={trend[trend.length - 1].date}
       defaultMonth={defaultMonth}
+      selectedDate={selectedDate}
       onSelectDate={onSelectDate}
     />
   );

--- a/src/app.feature/challenge/detail/components/ChallengeDiaryDateFilter.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDiaryDateFilter.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { Tag, Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { formatMonthDayKR } from '@module/utils/date';
+import { CalendarDays, X } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+
+import { useChallengeStatistics } from '../hooks/useChallengeDiaryQueries';
+import { ChallengeDiaryCalendar } from './ChallengeDiaryCalendar';
+
+interface ChallengeDiaryDateFilterProps {
+  challengeId: number;
+  // 현재 활성 날짜 필터 (YYYY-MM-DD). 없으면 전체.
+  activeDate?: string;
+  onSelectDate(date: string): void;
+  onClear(): void;
+}
+
+/**
+ * 일지 탭 날짜 필터 — 캘린더에서 넘어온 date 를 탭 안에서 확인·해제·변경한다.
+ * 선택된 날짜 칩 + 해제 버튼과, 접었다 펼치는 날짜 선택 캘린더로 구성한다.
+ * 날짜 변경은 부모가 URL(?tab=diary&date=)에 replace 로 동기화한다.
+ */
+export function ChallengeDiaryDateFilter({
+  challengeId,
+  activeDate,
+  onSelectDate,
+  onClear,
+}: ChallengeDiaryDateFilterProps): React.ReactElement | null {
+  const { data } = useChallengeStatistics(challengeId);
+  const trend = useMemo(() => data?.diaryTrend ?? [], [data]);
+  const validDate =
+    activeDate && /^\d{4}-\d{2}-\d{2}$/.test(activeDate)
+      ? activeDate
+      : undefined;
+  const [open, setOpen] = useState(false);
+
+  // 표시할 기간이 없으면(통계 미도착 등) 필터 UI 를 렌더하지 않는다.
+  if (trend.length === 0 && !validDate) {
+    return null;
+  }
+
+  const filterLabel = validDate ? formatMonthDayKR(validDate) : '';
+  const hasCalendar = trend.length > 0;
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex flex-wrap items-center gap-2">
+        {validDate ? (
+          <>
+            <Tag tone="brand" size="sm">
+              {filterLabel} 일지만 보기
+            </Tag>
+            <button
+              type="button"
+              onClick={onClear}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-full border',
+                'border-gray-200 px-2.5 py-1 text-[12px] text-gray-600',
+                'transition hover:bg-gray-50'
+              )}
+            >
+              <X className="h-3.5 w-3.5" />
+              필터 해제
+            </button>
+          </>
+        ) : (
+          <Text size="caption1" weight="medium" className="text-gray-500">
+            전체 일지
+          </Text>
+        )}
+
+        {hasCalendar ? (
+          <button
+            type="button"
+            onClick={() => setOpen((prev) => !prev)}
+            aria-expanded={open}
+            className={cn(
+              'ml-auto inline-flex items-center gap-1 rounded-full border px-2.5 py-1',
+              'text-[12px] font-semibold transition',
+              open
+                ? 'border-main-300 bg-main-100 text-main-800'
+                : 'border-gray-200 text-gray-700 hover:bg-gray-50'
+            )}
+          >
+            <CalendarDays className="h-3.5 w-3.5" />
+            {validDate ? '날짜 변경' : '날짜 선택'}
+          </button>
+        ) : null}
+      </div>
+
+      {open && hasCalendar ? (
+        <div className="rounded-[14px] border border-gray-200 bg-white p-3 sm:p-4">
+          <ChallengeDiaryCalendar
+            trend={trend}
+            selectedDate={validDate}
+            onSelectDate={(date) => {
+              onSelectDate(date);
+              setOpen(false);
+            }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app.feature/challenge/detail/components/ChallengeDiaryList.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDiaryList.tsx
@@ -36,6 +36,8 @@ interface ChallengeDiaryListProps {
   date?: string;
   // "필터 해제" 링크 목적지 — 라우트/탭에 따라 다르다.
   clearHref: string;
+  // 기본 날짜 필터 칩 노출 여부. 상세 탭은 별도 필터 UI 를 쓰므로 끈다.
+  showDefaultFilter?: boolean;
 }
 
 interface ChallengeDiaryListItemProps {
@@ -97,6 +99,7 @@ export function ChallengeDiaryList({
   id,
   date,
   clearHref,
+  showDefaultFilter = true,
 }: ChallengeDiaryListProps): React.ReactElement {
   const challengeId = Number(id);
   // 잘못된 형식은 무시해 쿼리키/요청에 오염이 들어가지 않게 한다.
@@ -167,7 +170,7 @@ export function ChallengeDiaryList({
         onOpenChange={setShowLoginDialog}
       />
 
-      {activeDate ? (
+      {showDefaultFilter && activeDate ? (
         <div className="flex items-center gap-2">
           <Tag tone="brand" size="sm">
             {filterLabel} 일지만 보기

--- a/src/app.feature/challenge/detail/components/ChallengeStatisticsSection.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeStatisticsSection.tsx
@@ -102,7 +102,11 @@ export function ChallengeStatisticsSection({
             <ChallengeDiaryCalendar
               trend={trend}
               onSelectDate={(date) =>
-                router.push(`/challenge/${challengeId}?tab=diary&date=${date}`)
+                // 탭/필터 변경은 history 를 오염시키지 않도록 replace 로 처리.
+                router.replace(
+                  `/challenge/${challengeId}?tab=diary&date=${date}`,
+                  { scroll: false }
+                )
               }
             />
           </div>

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -44,6 +44,7 @@ import {
 } from '../../board/utils/challengePeriod';
 import { ChallengeDetailCompactHeader } from '../components/ChallengeDetailCompactHeader';
 import { ChallengeDetailHero } from '../components/ChallengeDetailHero';
+import { ChallengeDiaryDateFilter } from '../components/ChallengeDiaryDateFilter';
 import { ChallengeDiaryList } from '../components/ChallengeDiaryList';
 import { ChallengeGoalModals } from '../components/ChallengeGoalModals';
 import { ChallengeLeaderboardCard } from '../components/ChallengeLeaderboardCard';
@@ -135,6 +136,19 @@ export function ChallengeDetailScreen({
     params.set('tab', nextId);
     // 일지 탭을 떠나면 날짜 필터를 흘려보내지 않는다.
     if (nextId !== 'diary') {
+      params.delete('date');
+    }
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  };
+
+  // 일지 탭 날짜 필터 변경 — 탭 유지 + date 만 갱신. 탭 전환과 마찬가지로
+  // history 를 쌓지 않도록 replace 로 처리한다(뒤로가기는 챌린지 목록으로).
+  const setDiaryDateFilter = (date?: string): void => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', 'diary');
+    if (date) {
+      params.set('date', date);
+    } else {
       params.delete('date');
     }
     router.replace(`${pathname}?${params.toString()}`, { scroll: false });
@@ -814,11 +828,20 @@ export function ChallengeDetailScreen({
                 ) : null}
 
                 {activeTab === 'diary' ? (
-                  <ChallengeDiaryList
-                    id={id}
-                    date={diaryDate}
-                    clearHref={`/challenge/${id}?tab=diary`}
-                  />
+                  <>
+                    <ChallengeDiaryDateFilter
+                      challengeId={challengeId}
+                      activeDate={diaryDate}
+                      onSelectDate={(date) => setDiaryDateFilter(date)}
+                      onClear={() => setDiaryDateFilter(undefined)}
+                    />
+                    <ChallengeDiaryList
+                      id={id}
+                      date={diaryDate}
+                      clearHref={`/challenge/${id}?tab=diary`}
+                      showDefaultFilter={false}
+                    />
+                  </>
                 ) : null}
 
                 {activeTab === 'participants' ? (

--- a/src/app.feature/explore/screen/ExploreScreen.tsx
+++ b/src/app.feature/explore/screen/ExploreScreen.tsx
@@ -3,6 +3,8 @@
 import { MobileHeader } from '@1d1s/design-system';
 import { BoardScreenLayout } from '@component/layout/BoardScreenLayout';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
+import HomeNoticeStrip from '@feature/home/components/HomeNoticeStrip';
+import HomeQuickActions from '@feature/home/components/HomeQuickActions';
 import HomeRandomChallengesSection from '@feature/home/components/HomeRandomChallengesSection';
 import HomeRandomDiariesSection from '@feature/home/components/HomeRandomDiariesSection';
 import { useHomeRandomData } from '@feature/home/hooks/useHomeRandomData';
@@ -64,6 +66,12 @@ export default function ExploreScreen(): React.ReactElement {
         }
       >
         <div className="flex flex-col gap-7 pt-2 lg:pt-6">
+          {/* 공지·문의 배너 — 탐색 페이지에서는 맨 위에 노출 */}
+          <div className="grid gap-3 lg:grid-cols-2">
+            <HomeNoticeStrip />
+            <HomeQuickActions />
+          </div>
+
           <HomeRandomChallengesSection
             challenges={officialChallenges}
             isLoading={isOfficialLoading}

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -95,6 +95,14 @@ export default function HomeScreen({
     isSidebarFetching ||
     (!hasMounted && initialHasAuthHint);
 
+  // 공지·의견 — 모바일 세로 스택, lg 이상 2열 나란히. 여러 위치에서 재사용.
+  const noticeRow = (
+    <div className="grid gap-3 lg:grid-cols-2">
+      <HomeNoticeStrip />
+      <HomeQuickActions />
+    </div>
+  );
+
   return (
     <>
       <HomePopup enabled={isLoggedIn} />
@@ -104,8 +112,9 @@ export default function HomeScreen({
           'px-5 py-7 lg:px-8 lg:py-10'
         )}
       >
-        {/* 모바일 인사 hero — 데스크탑/태블릿은 시안에 따라 생략 */}
-        <div className="lg:hidden">
+        {/* 모바일 인사 hero — 데스크탑/태블릿은 시안에 따라 생략.
+            인사~스토리 간격이 과해 보여 모바일에서만 gap 을 좁힌다. */}
+        <div className="-mb-3 lg:mb-0 lg:hidden">
           <HomeWarmGreeting />
         </div>
 
@@ -122,6 +131,9 @@ export default function HomeScreen({
               />
             </div>
 
+            {/* 공지·문의는 오늘의 기록 위로 노출한다. */}
+            {noticeRow}
+
             <HomeTodayRecordSection
               challenges={sidebar?.challengeList ?? []}
               isAuthLoading={isStreakLoading}
@@ -131,14 +143,9 @@ export default function HomeScreen({
           <>
             <HomeLoginCta />
             <HomeWarmBanner />
+            {noticeRow}
           </>
         )}
-
-        {/* 공지·의견 — 모바일 세로 스택, lg 이상 2열 나란히 */}
-        <div className="grid gap-3 lg:grid-cols-2">
-          <HomeNoticeStrip />
-          <HomeQuickActions />
-        </div>
 
         {/* 탐색 유도 진입점 — 홈 하단 */}
         <HomeExploreEntry />

--- a/src/app.feature/member/statistics/screen/StatisticsScreen.tsx
+++ b/src/app.feature/member/statistics/screen/StatisticsScreen.tsx
@@ -36,7 +36,7 @@ export default function StatisticsScreen(): React.ReactElement | null {
   }
 
   return (
-    <SubPageShell title="통계" description="나의 활동을 한눈에">
+    <SubPageShell title="통계" description="나의 활동을 한눈에" hideBack>
       <div className="data-fade-in space-y-4 pb-10">
         <PeriodSummarySection />
         <FeelingDistributionSection />


### PR DESCRIPTION
## 개요
챌린지 상세/통계/홈 화면 다듬기 5건. DS `MonthCalendar` 시각 개선(2.10.0) 포함.

## 변경 사항

### 1. 통계 화면 헤더 뒤로가기 버튼 제거
- 통계(`/mypage/statistics`)는 최상위 진입 화면이라 뒤로가기가 불필요.
- `SubPageShell`에 `hideBack` 옵션 추가 → `onBack` 미전달로 `MobileHeader` 좌측 버튼 미렌더.

### 2. 챌린지 일지 캘린더 디자인 개선 (DS 수정)
- 관리자 팝업 관리의 `ScheduleCalendar` 톤(테두리 프레임·셀 구분선·`bg-gray-50` 요일 헤더·`rounded-3`)에 맞춰 DS `MonthCalendar`를 격자형으로 재스타일.
- 기존 기능(월 이동, 날짜별 일지 수, 클릭 이동, 기간 밖 비활성) 유지.
- DS PR/릴리즈: `1D1S-design-system` `main` [minor] → **v2.10.0** 배포, 클라 `^2.10.0` 반영.

### 3. 일지 탭 날짜 필터 UI
- `ChallengeDiaryDateFilter` 추가: 선택 날짜 칩 + 해제 버튼 + 접이식 날짜 선택 캘린더.
- URL `?tab=diary&date=` 와 동기화. 선택된 날짜는 캘린더에서 강조(`selectedDate`).

### 4. 뒤로가기 동작 수정
- 탭/날짜 필터 변경을 모두 `router.replace`로 처리해 history 오염 제거
  (기존 소개 탭 캘린더의 `router.push` 포함).
- 결과적으로 헤더/브라우저 뒤로가기가 탭을 거치지 않고 챌린지 목록으로 이동.

### 5. 홈 레이아웃
- 인사(안녕하세요)~스토리 간격 축소(모바일 `-mb-3`).
- 공지·문의 배너를 오늘의 기록 위로 이동.
- 탐색(`/explore`)에서는 공지·문의 배너를 맨 위에 노출.

## 검증
- `tsc --noEmit` ✅ / `pnpm lint` ✅ (0 errors) / `vitest` ✅ (118 passed) / `knip` ✅ / `next build` ✅
- 브라우저 확인은 미수행(프로젝트 정책상 사용자 직접 확인).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diary date filtering with calendar selection, selected-date highlighting, and URL-based filter state.
  * Added options to hide the mobile back button and control default diary filters.
  * Added notice banners and quick actions to the Explore page and logged-in Home screen.

* **Bug Fixes**
  * Updated diary filter navigation to avoid adding unnecessary browser history entries.
  * Updated the design system dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->