### PR TITLE
feat: 탐색 헤더를 최상위 화면용으로 교체 — 모바일 뒤로가기 제거

### DIFF
--- a/src/app.feature/explore/screen/ExploreScreen.tsx
+++ b/src/app.feature/explore/screen/ExploreScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MobileHeader } from '@1d1s/design-system';
+import { Text } from '@1d1s/design-system';
 import { BoardScreenLayout } from '@component/layout/BoardScreenLayout';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import HomeNoticeStrip from '@feature/home/components/HomeNoticeStrip';
@@ -10,6 +10,7 @@ import HomeRandomDiariesSection from '@feature/home/components/HomeRandomDiaries
 import { useHomeRandomData } from '@feature/home/hooks/useHomeRandomData';
 import { useHomeRandomDiaryLike } from '@feature/home/hooks/useHomeRandomDiaryLike';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { cn } from '@module/utils/cn';
 import { useRouter } from 'next/navigation';
 import React, { useCallback } from 'react';
 
@@ -62,7 +63,25 @@ export default function ExploreScreen(): React.ReactElement {
         title="탐색"
         description="오늘 시작해볼 챌린지와 다른 사람들의 기록을 만나보세요."
         mobileHeader={
-          <MobileHeader title="탐색" onBack={() => router.push('/')} />
+          // 모바일 sticky 헤더 — 탐색. 탐색은 네비 탭이 있는 최상위 화면이므로
+          // 홈/챌린지/일지처럼 뒤로가기 없이 타이틀만 노출한다. 네이티브 쉘은
+          // AppTopNav 가 같은 영역을 차지하므로 글로벌 sticky 차단 룰로 가린다.
+          <div
+            className={cn(
+              'sticky top-0 z-20 flex items-center border-b border-gray-100',
+              'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
+              'backdrop-blur lg:hidden'
+            )}
+          >
+            <Text
+              as="h1"
+              size="heading1"
+              weight="extrabold"
+              className="tracking-[-0.5px] text-gray-900"
+            >
+              탐색
+            </Text>
+          </div>
         }
       >
         <div className="flex flex-col gap-7 pt-2 lg:pt-6">


### PR DESCRIPTION
## 무엇을

탐색(`/explore`) 페이지의 모바일 헤더를 최상위 화면 패턴으로 교체합니다.

## 왜

`/explore`는 바텀 네비 탭이 있는 최상위 화면인데도, 서브페이지용으로
설계된 DS `MobileHeader`(`onBack`)를 사용해 모바일 헤더에 뒤로가기
버튼이 노출되고 있었습니다. 홈/챌린지/일지 같은 다른 최상위 화면과
헤더 구성이 어긋납니다.

## 어떻게

- `ExploreScreen`의 `MobileHeader title="탐색" onBack={...}`를 제거하고,
  챌린지 보드/일지 보드와 동일한 커스텀 sticky `div` 헤더(타이틀만,
  뒤로가기 없음)로 교체했습니다.
- 탐색은 CTA가 없으므로 타이틀 `탐색`만 노출합니다.
- 바텀 네비는 `AppLayoutShell`의 `BOTTOM_NAV_VISIBLE_ROUTES`에 `/explore`가
  이미 포함되어 있어 그대로 유지됩니다(변경 없음).

## 검증

- `tsc --noEmit` ✓
- `pnpm lint` ✓ (0 errors, 변경 파일 경고 없음)
- `pnpm test` ✓ (118 passed)
- `pnpm knip` ✓ (exit 0)
- `pnpm build` ✓ (`/explore` 정적 프리렌더 유지)

브라우저 육안 확인은 하지 않았습니다(프로젝트 정책상 preview 도구
미사용). 정적 검증까지만 수행했습니다.