### PR TITLE
fix: 통계 헤더 뒤로가기 복구 — SubPageShell hideBack 제거

### DIFF
--- a/src/app.component/layout/SubPageShell.tsx
+++ b/src/app.component/layout/SubPageShell.tsx
@@ -14,8 +14,6 @@ interface SubPageShellProps {
   headerAction?: React.ReactNode;
   /** 뒤로가기 동작 (기본값: router.back) */
   onBack?(): void;
-  /** 최상위 진입 화면 등 뒤로가기가 불필요할 때 헤더 좌측 버튼을 숨긴다. */
-  hideBack?: boolean;
   children: React.ReactNode;
 }
 
@@ -33,7 +31,6 @@ export function SubPageShell({
   description,
   headerAction,
   onBack,
-  hideBack = false,
   children,
 }: SubPageShellProps): React.ReactElement {
   const router = useRouter();
@@ -43,7 +40,7 @@ export function SubPageShell({
     <div className="min-h-screen w-full">
       <MobileHeader
         title={title}
-        onBack={hideBack ? undefined : handleBack}
+        onBack={handleBack}
         right={headerAction}
       />
 

--- a/src/app.feature/member/statistics/screen/StatisticsScreen.tsx
+++ b/src/app.feature/member/statistics/screen/StatisticsScreen.tsx
@@ -36,7 +36,7 @@ export default function StatisticsScreen(): React.ReactElement | null {
   }
 
   return (
-    <SubPageShell title="통계" description="나의 활동을 한눈에" hideBack>
+    <SubPageShell title="통계" description="나의 활동을 한눈에">
       <div className="data-fade-in space-y-4 pb-10">
         <PeriodSummarySection />
         <FeelingDistributionSection />


### PR DESCRIPTION
## 배경
`#176`에서 통계 화면 진입 시 헤더 좌측 뒤로가기를 숨기려고
`SubPageShell`에 `hideBack` prop을 추가했다. 하지만 통계
(`/mypage/statistics`)는 마이페이지 하위 서브 페이지이므로 설정·친구·알림
등 다른 서브 페이지와 동일하게 뒤로가기 버튼이 노출되어야 한다.

## 변경
- `StatisticsScreen`에서 `hideBack` 전달 제거 → 헤더 뒤로가기 복구
- `SubPageShell`에서 `hideBack` prop 정의·분기 로직 제거
  - 다른 사용처가 없어 prop 자체를 정리 (knip 통과)

## 검증
- `tsc --noEmit` ✅ / `pnpm lint` ✅(0 errors) / `pnpm test` ✅(118 passed)
- `pnpm knip` ✅ / `pnpm build` ✅
- 브라우저 확인은 하지 않음 (사용자 직접 확인)

> 참고: 탐색 헤더 폰트 통일은 이미 `#177`에서 챌린지·일지 보드와 동일한
> 패턴(`heading1` / `extrabold` / `tracking-[-0.5px]`)으로 반영 완료됨.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored consistent back navigation on subpages by ensuring the mobile header’s back action is always available.
  * Updated the statistics screen to use the standard back-navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->