### PR TITLE
feat: 홈 오늘의 기록에 챌린지 목표 목록 노출 + 2열 반응형 그리드

### DIFF
--- a/src/app.feature/home/components/HomeTodayRecordSection.tsx
+++ b/src/app.feature/home/components/HomeTodayRecordSection.tsx
@@ -27,117 +27,199 @@ interface HomeTodayRecordSectionProps {
   isAuthLoading: boolean;
 }
 
-// 행 높이를 균일하게 고정한다. 미작성/완료 재정렬은 이 고정 높이 컨테이너
-// 안에서만 순서를 바꾸므로 아래 섹션으로 시프트가 전파되지 않는다.
-const ROW_BASE = 'flex min-h-[76px] items-center gap-3 rounded-3 border p-3';
+// 목표 영역은 최대 3개까지만 노출한다(그 이상은 "+N개"). 로딩/개수와
+// 무관하게 목표 블록 높이를 고정해 그리드 셀 높이·시프트를 안정화한다.
+const MAX_GOALS = 3;
+const GOALS_BLOCK = 'min-h-[62px]';
+// 카드 최소 높이를 고정해 로딩→확정, 목표 개수 변화에도 그리드가 흔들리지
+// 않게 한다.
+const CARD_BASE =
+  'flex min-h-[148px] flex-col gap-2.5 rounded-3 border p-3.5';
 
-// 유한 챌린지의 경과 진행률(%). 무기한/유효하지 않은 기간은 null.
-function computeProgress(startDate: string, endDate: string): number | null {
-  const start = new Date(startDate).getTime();
-  const end = new Date(endDate).getTime();
-  if (Number.isNaN(start) || Number.isNaN(end) || end <= start) {
-    return null;
-  }
-  const ratio = (Date.now() - start) / (end - start);
-  return Math.min(100, Math.max(0, Math.round(ratio * 100)));
-}
-
-interface RecordRowProps {
+interface RecordCardProps {
   challenge: SidebarChallenge;
   writtenToday: boolean;
   isStatusLoading: boolean;
+  goals: string[];
+  goalsLoading: boolean;
 }
 
-function RecordRow({
+function GoalsBlock({
+  goals,
+  goalsLoading,
+  isFree,
+}: {
+  goals: string[];
+  goalsLoading: boolean;
+  isFree: boolean;
+}): React.ReactElement {
+  if (goalsLoading) {
+    return (
+      <div className={cn(GOALS_BLOCK, 'flex flex-col gap-1.5')}>
+        <span className="skeleton-pulse h-3 w-4/5 rounded bg-gray-100" />
+        <span className="skeleton-pulse h-3 w-3/5 rounded bg-gray-100" />
+        <span className="skeleton-pulse h-3 w-2/3 rounded bg-gray-100" />
+      </div>
+    );
+  }
+
+  if (goals.length === 0) {
+    return (
+      <div className={cn(GOALS_BLOCK, 'flex items-center')}>
+        <span className="text-[12px] text-gray-400">
+          {isFree ? '자유 목표 챌린지예요' : '등록된 목표가 없어요'}
+        </span>
+      </div>
+    );
+  }
+
+  const shown = goals.slice(0, MAX_GOALS);
+  const restCount = goals.length - shown.length;
+
+  return (
+    <ul className={cn(GOALS_BLOCK, 'flex flex-col gap-1')}>
+      {shown.map((goal, index) => (
+        <li
+          key={`${goal}-${index}`}
+          className="flex items-start gap-1.5"
+        >
+          <span
+            aria-hidden
+            className="bg-main-400 mt-[7px] h-1 w-1 shrink-0 rounded-full"
+          />
+          <span className="truncate text-[13px] font-medium text-gray-800">
+            {goal}
+          </span>
+        </li>
+      ))}
+      {restCount > 0 ? (
+        <li className="pl-[10px] text-[11px] font-medium text-gray-400">
+          +{restCount}개 더
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+function RecordCard({
   challenge,
   writtenToday,
   isStatusLoading,
-}: RecordRowProps): React.ReactElement {
+  goals,
+  goalsLoading,
+}: RecordCardProps): React.ReactElement {
   const router = useRouter();
   const tone = getCategoryStripeTone(challenge.category);
   const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
+  const isFree = challenge.goalType === 'FLEXIBLE';
   const remainingLabel = formatChallengeRemainingLabel(
     challenge.endDate,
     isInfinite,
     false
   );
-  const progress = isInfinite
-    ? null
-    : computeProgress(challenge.startDate, challenge.endDate);
 
   return (
     <li
       className={cn(
-        ROW_BASE,
+        CARD_BASE,
         writtenToday
           ? 'border-gray-200 bg-white'
           : 'border-main-200 bg-main-100'
       )}
     >
-      <Link
-        href={`/challenge/${challenge.challengeId}`}
-        className="flex min-w-0 flex-1 items-center gap-3"
-      >
-        <span
-          className={cn(
-            'inline-flex h-8 w-8 shrink-0 items-center justify-center',
-            'rounded-full bg-white'
-          )}
-          style={{ color: tone }}
+      <div className="flex items-start gap-2.5">
+        <Link
+          href={`/challenge/${challenge.challengeId}`}
+          className="flex min-w-0 flex-1 items-center gap-2.5"
         >
-          <CategoryIcon category={challenge.category} className="h-4 w-4" />
-        </span>
-        <span className="flex min-w-0 flex-1 flex-col gap-1">
-          <span className="truncate text-[14px] font-medium text-gray-900">
-            {challenge.title}
-          </span>
-          <span className="flex items-center gap-2">
-            {progress !== null ? (
-              <span className="h-1 w-16 overflow-hidden rounded-full bg-gray-100">
-                <span
-                  className="bg-main-500 block h-full"
-                  style={{ width: `${progress}%` }}
-                />
-              </span>
-            ) : null}
-            <span className="text-[11px] text-gray-500">
-              {getCategoryLabel(challenge.category)} · {remainingLabel}
-            </span>
-          </span>
-        </span>
-      </Link>
-
-      {/* 상태/액션 — 폭을 고정해 로딩→확정 전환 시 시프트를 막는다. */}
-      <div className="flex w-[92px] shrink-0 justify-end">
-        {isStatusLoading ? (
-          <span className="skeleton-pulse h-7 w-[84px] rounded-full bg-gray-100" />
-        ) : writtenToday ? (
           <span
             className={cn(
-              'inline-flex items-center gap-1 rounded-full',
-              'bg-gray-100 px-3 py-1.5 text-[12px] font-medium text-gray-500'
+              'inline-flex h-8 w-8 shrink-0 items-center justify-center',
+              'rounded-full bg-white'
             )}
+            style={{ color: tone }}
           >
-            <Check className="h-3.5 w-3.5" />
-            완료
+            <CategoryIcon category={challenge.category} className="h-4 w-4" />
           </span>
-        ) : (
-          <button
-            type="button"
-            onClick={() =>
-              router.push(`/diary/create?challengeId=${challenge.challengeId}`)
-            }
-            aria-label={`${challenge.title} 오늘 기록하기`}
-            className={cn(
-              'bg-brand inline-flex items-center rounded-full',
-              'px-3.5 py-1.5 text-[12px] font-bold text-white',
-              'cursor-pointer transition hover:brightness-105'
-            )}
-          >
-            기록하기
-          </button>
-        )}
+          <span className="min-w-0 flex-1">
+            <span className="flex items-center gap-1.5">
+              <span className="truncate text-[14px] font-bold text-gray-900">
+                {challenge.title}
+              </span>
+              {isFree ? (
+                <span
+                  className={cn(
+                    'shrink-0 rounded-full bg-gray-100 px-1.5 py-0.5',
+                    'text-[10px] font-medium text-gray-500'
+                  )}
+                >
+                  자유
+                </span>
+              ) : null}
+            </span>
+          </span>
+        </Link>
+
+        {/* 상태/액션 — 폭을 고정해 로딩→확정 전환 시 시프트를 막는다. */}
+        <div className="flex shrink-0 justify-end">
+          {isStatusLoading ? (
+            <span className="skeleton-pulse h-7 w-[76px] rounded-full bg-gray-100" />
+          ) : writtenToday ? (
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 rounded-full',
+                'bg-gray-100 px-2.5 py-1.5 text-[12px] font-medium text-gray-500'
+              )}
+            >
+              <Check className="h-3.5 w-3.5" />
+              완료
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={() =>
+                router.push(
+                  `/diary/create?challengeId=${challenge.challengeId}`
+                )
+              }
+              aria-label={`${challenge.title} 오늘 기록하기`}
+              className={cn(
+                'bg-brand inline-flex items-center rounded-full',
+                'px-3 py-1.5 text-[12px] font-bold text-white',
+                'cursor-pointer transition hover:brightness-105'
+              )}
+            >
+              기록하기
+            </button>
+          )}
+        </div>
       </div>
+
+      <GoalsBlock goals={goals} goalsLoading={goalsLoading} isFree={isFree} />
+
+      {/* 카테고리·기간은 보조 정보로 축소해 하단에 배치. */}
+      <span className="mt-auto truncate text-[11px] text-gray-400">
+        {getCategoryLabel(challenge.category)} · {remainingLabel}
+      </span>
+    </li>
+  );
+}
+
+// 스켈레톤 카드 — 확정 전 그리드 높이/열을 그대로 예약한다.
+function SkeletonCard(): React.ReactElement {
+  return (
+    <li className={cn(CARD_BASE, 'border-gray-200')}>
+      <div className="flex items-center gap-2.5">
+        <span className="skeleton-pulse h-8 w-8 shrink-0 rounded-full bg-gray-100" />
+        <span className="skeleton-pulse h-3.5 w-1/2 rounded bg-gray-100" />
+        <span className="skeleton-pulse ml-auto h-7 w-[76px] shrink-0 rounded-full bg-gray-100" />
+      </div>
+      <div className={cn(GOALS_BLOCK, 'flex flex-col gap-1.5')}>
+        <span className="skeleton-pulse h-3 w-4/5 rounded bg-gray-100" />
+        <span className="skeleton-pulse h-3 w-3/5 rounded bg-gray-100" />
+        <span className="skeleton-pulse h-3 w-2/3 rounded bg-gray-100" />
+      </div>
+      <span className="skeleton-pulse mt-auto h-2.5 w-1/3 rounded bg-gray-100" />
     </li>
   );
 }
@@ -177,21 +259,14 @@ export default function HomeTodayRecordSection({
     );
   }
 
-  // 인증/사이드바 로딩 중 — 진행 챌린지 수를 아직 모르므로 3행을 예약한다.
+  // 인증/사이드바 로딩 중 — 진행 챌린지 수를 아직 모르므로 2행을 예약한다.
   if (isAuthLoading) {
     return (
       <section className="w-full">
         <SectionHeader size="sm" title="오늘의 기록" />
-        <ul className="mt-3 flex flex-col gap-2">
-          {Array.from({ length: 3 }).map((_, index) => (
-            <li key={index} className={cn(ROW_BASE, 'border-gray-200')}>
-              <span className="skeleton-pulse h-8 w-8 shrink-0 rounded-full bg-gray-100" />
-              <span className="flex min-w-0 flex-1 flex-col gap-1.5">
-                <span className="skeleton-pulse h-3.5 w-2/3 rounded bg-gray-100" />
-                <span className="skeleton-pulse h-3 w-1/3 rounded bg-gray-100" />
-              </span>
-              <span className="skeleton-pulse h-7 w-[84px] shrink-0 rounded-full bg-gray-100" />
-            </li>
+        <ul className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <SkeletonCard key={index} />
           ))}
         </ul>
       </section>
@@ -233,22 +308,21 @@ export default function HomeTodayRecordSection({
           <span className="text-[14px] font-medium text-gray-800">
             오늘 기록을 모두 마쳤어요 🎉 {doneCount}개 완료
           </span>
-          <Link
-            href="/explore"
-            className="text-brand text-[13px] font-bold"
-          >
+          <Link href="/explore" className="text-brand text-[13px] font-bold">
             새로운 챌린지 둘러보기 →
           </Link>
         </div>
       ) : null}
 
-      <ul className="data-fade-in mt-3 flex flex-col gap-2">
+      <ul className="data-fade-in mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
         {ordered.map((item) => (
-          <RecordRow
+          <RecordCard
             key={item.challenge.challengeId}
             challenge={item.challenge}
             writtenToday={item.writtenToday}
             isStatusLoading={item.isLoading}
+            goals={item.goals}
+            goalsLoading={item.goalsLoading}
           />
         ))}
       </ul>

--- a/src/app.feature/home/hooks/useTodayRecords.ts
+++ b/src/app.feature/home/hooks/useTodayRecords.ts
@@ -2,6 +2,7 @@
 
 import { challengeBoardApi } from '@feature/challenge/board/api/challengeBoardApi';
 import { CHALLENGE_QUERY_KEYS } from '@feature/challenge/board/consts/queryKeys';
+import { challengeDetailApi } from '@feature/challenge/detail/api/challengeDetailApi';
 import type { SidebarChallenge } from '@feature/member/type/member';
 import { formatDateISO } from '@module/utils/date';
 import { useQueries } from '@tanstack/react-query';
@@ -13,6 +14,10 @@ export interface TodayRecordItem {
   writtenToday: boolean;
   /** 이 챌린지의 check-write 쿼리가 아직 로딩 중인지 */
   isLoading: boolean;
+  /** 이 챌린지의 목표 목록 (FIXED=공통, FLEXIBLE=내 목표) */
+  goals: string[];
+  /** 목표(상세) 쿼리가 아직 로딩 중인지 — 스켈레톤 유지용 */
+  goalsLoading: boolean;
 }
 
 export interface TodayRecordsResult {
@@ -28,11 +33,14 @@ export interface TodayRecordsResult {
   allResolved: boolean;
 }
 
-// 진행 중 챌린지별로 "오늘 일지 작성 여부"를 판정한다. 사이드바 데이터에는
-// per-challenge 작성 플래그가 없어, 챌린지 상세와 동일한 check-write 엔드포인트
-// (3일 내 작성 날짜 목록)를 챌린지 수만큼 병렬 조회해 오늘 날짜 포함 여부로
-// 미작성/완료를 가른다. 쿼리 키는 상세 화면과 동일 팩토리를 공유하므로 캐시가
-// 겹친다(상세 진입 시 재요청 없음).
+// 진행 중 챌린지별로 "오늘 일지 작성 여부"와 "목표 목록"을 판정한다.
+// 사이드바 데이터에는 per-challenge 작성 플래그도 목표도 없어 두 벌의
+// 병렬 쿼리를 챌린지 수만큼 돌린다.
+//  - check-write(3일 내 작성 날짜 목록): 오늘 날짜 포함 여부로 미작성/완료.
+//  - detail(챌린지 상세): challengeGoals 로 목표 목록. FIXED 는 공통 목표,
+//    FLEXIBLE 은 서버가 내 목표를 내려준다(일지 작성 체크리스트와 동일 필드).
+// 두 쿼리 모두 상세 화면과 동일 키 팩토리를 공유하므로 캐시가 겹친다
+// (상세/일지 작성 진입 시 재요청 없음).
 export function useTodayRecords(
   challenges: SidebarChallenge[]
 ): TodayRecordsResult {
@@ -44,16 +52,29 @@ export function useTodayRecords(
       enabled: Boolean(challenge.challengeId),
     })),
   });
+  const detailResults = useQueries({
+    queries: challenges.map((challenge) => ({
+      queryKey: CHALLENGE_QUERY_KEYS.detail(challenge.challengeId),
+      queryFn: () =>
+        challengeDetailApi.getChallengeDetail(challenge.challengeId),
+      enabled: Boolean(challenge.challengeId),
+    })),
+  });
 
   return useMemo(() => {
     const today = formatDateISO(new Date());
     const items: TodayRecordItem[] = challenges.map((challenge, index) => {
       const result = results[index];
+      const detailResult = detailResults[index];
       const dates = result?.data ?? [];
+      const goals =
+        detailResult?.data?.challengeGoals.map((goal) => goal.content) ?? [];
       return {
         challenge,
         writtenToday: dates.includes(today),
         isLoading: result?.isLoading ?? false,
+        goals,
+        goalsLoading: detailResult?.isLoading ?? false,
       };
     });
     const resolved = items.filter((item) => !item.isLoading);
@@ -64,5 +85,5 @@ export function useTodayRecords(
       isLoading: results.some((result) => result.isLoading),
       allResolved: results.every((result) => !result.isLoading),
     };
-  }, [challenges, results]);
+  }, [challenges, results, detailResults]);
 }


### PR DESCRIPTION
## 배경
홈 "오늘의 기록"이 카테고리·기간("개발 · 무제한") 위주라, 정작 사용자에게
중요한 **각 챌린지의 목표**가 보이지 않았습니다.

## 변경
- 각 챌린지 카드에 **목표 목록 나열**
  - FIXED: 공통 목표, FLEXIBLE: 내 목표 (둘 다 `challengeGoals` 필드)
  - 최대 3개 노출 + `+N개 더`, FLEXIBLE 은 `자유` 태그 표시
- **목표 데이터 출처**: `getChallengeDetail(id)`의 `challengeGoals`
  - 쿼리 키 `CHALLENGE_QUERY_KEYS.detail(id)`를 챌린지 상세 화면·일지 작성
    폼과 공유 → 캐시 중복 없음(상세/작성 진입 시 재요청 없음)
  - 일지 작성 체크리스트가 같은 필드를 쓰므로 FLEXIBLE 도 내 목표가 내려옴
- 카테고리·기간은 카드 하단 **보조 정보로 축소**, 진행률 바 제거
- 오늘 작성 여부(완료 배지)·`기록하기` 동선 유지
- **1열 → 2열 반응형 그리드**(`sm` 이상 2열)
- 목표 블록/카드 **높이 고정**으로 로딩→확정, 목표 개수 변화에도 시프트 방지

## 검증
- `tsc --noEmit` ✅ / `pnpm lint` (0 errors) ✅ / `vitest` 118 passed ✅
- `knip` ✅ / `next build` ✅
- 브라우저 확인은 하지 않았습니다(프로젝트 정책 — 사용자 직접 확인).