### PR TITLE
refactor: 탐색 헤더 래퍼 구조를 챌린지·일지 보드와 통일

### DIFF
--- a/src/app.feature/explore/screen/ExploreScreen.tsx
+++ b/src/app.feature/explore/screen/ExploreScreen.tsx
@@ -68,7 +68,8 @@ export default function ExploreScreen(): React.ReactElement {
           // AppTopNav 가 같은 영역을 차지하므로 글로벌 sticky 차단 룰로 가린다.
           <div
             className={cn(
-              'sticky top-0 z-20 flex items-center border-b border-gray-100',
+              'sticky top-0 z-20 flex items-center justify-between',
+              'gap-3 border-b border-gray-100',
               'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
               'backdrop-blur lg:hidden'
             )}


### PR DESCRIPTION
## 배경

탐색(/explore) 모바일 sticky 헤더의 **래퍼 구조**가 일지·챌린지 보드
헤더와 어긋나 있었다.

- 타이틀 `Text` (`size=heading1` · `weight=extrabold` ·
  `tracking-[-0.5px]`)는 이미 boards와 동일 (PR #177에서 통일됨).
- 다만 래퍼 클래스가 boards의 `flex items-center justify-between gap-3`
  패턴과 달리 `flex items-center` 만 사용해 구조가 달랐다.

## 변경

- 탐색 헤더 래퍼를 **일지 보드 헤더와 동일한 패턴**
  (`justify-between` + `gap-3`)으로 맞춤.
- 탐색은 타이틀 단독 노출이라 `justify-between`/`gap-3`는 무해하며,
  **시각적 변화 없음** — 구조/클래스 일관성만 확보.

## 참고

- 통계 헤더 뒤로가기 복구(hideBack 제거)는 이미 #178로 머지됨 —
  본 PR 범위 아님.

## 검증

- `tsc --noEmit` ✅ / `pnpm lint` ✅ / `pnpm knip` ✅
- `pnpm test` (vitest) 118 passed ✅ / `pnpm build` ✅
- 브라우저 육안 확인은 하지 않음 (프로젝트 정책상 사용자가 직접 확인).