### PR TITLE
fix: 성공-리다이렉트 재시도 경로 무한 refresh 루프 차단

### DIFF
--- a/src/app.module/api/interceptors.ts
+++ b/src/app.module/api/interceptors.ts
@@ -87,11 +87,16 @@ export const attachInterceptors = (
         return response;
       }
 
+      // 재시도 전 _retry 를 세워, refresh 후에도 리다이렉트가 지속되면(백엔드가
+      // 특정 GET 을 계속 로그인으로 넘기거나 wasRedirected 오탐) 위 63행 가드로
+      // 응답을 그대로 반환하고 무한 refresh 루프를 끊는다. 401 에러 경로(124행)와
+      // 동일한 1회 재시도 계약을 이 성공-리다이렉트 경로에도 맞춘다.
+      config._retry = true;
+
       if (isRefreshing) {
         return new Promise<AxiosResponse>((resolve, reject) => {
           addRefreshSubscriber({
             resolve: () => {
-              config._retry = false;
               resolve(client(response.config));
             },
             reject,


### PR DESCRIPTION
## 문제
`apiClient` 응답(2xx) 인터셉터는 GET 응답이 로그인으로 리다이렉트됐다고 감지하면(`wasRedirected`, `responseURL` 휴리스틱) `/auth/token` refresh 후 요청을 재시도한다. 그런데 **이 경로는 `_retry` 플래그를 세우지 않는다** — leader(`interceptors.ts:102-107`)는 미설정, follower resolve(94행)는 `false`로 리셋. 반면 401 에러 경로는 재시도 전 `_retry=true`(124행)를 세워 반복을 막는다.

따라서 refresh 이후에도 `wasRedirected`가 계속 참이면(백엔드가 특정 GET을 지속적으로 로그인으로 넘기거나 휴리스틱 오탐) `refresh → 재시도 → 또 리다이렉트 → refresh …`가 무한 반복된다. 공유 single-flight(`inFlight`)는 매 호출 `finally`에서 비워져 **순차 반복은 막지 못한다.**

## 원인
성공-리다이렉트 재시도 경로가 401 경로와 달리 "1회 재시도" 계약(`_retry` 가드, 63행)을 지키지 않음.

## 수정
재시도 직전에 `config._retry = true`를 세팅 → refresh 후에도 리다이렉트가 지속되면 63행 가드(`if (config._retry) return response`)가 응답을 그대로 반환하고 루프를 끊는다. leader/follower 모두 동일하게 1회로 제한(follower의 `_retry=false` 리셋 제거).

## 검증
- `pnpm lint` 0 errors
- `pnpm test` 119 passed
- `pnpm knip` clean
- `pnpm build` tsc 통과
- 브라우저 런타임 검증은 프로젝트 정책상 미수행(정적 검증까지).

## 영향
세션 만료·리다이렉트 상황에서 탭 행/백엔드 `/auth/token` 폭주 방지. 정상 경로 동작 변화 없음(refresh 1회 후 성공 시 기존과 동일).