### PR TITLE
fix: 날짜 파싱을 안전 util로 일원화 (Safari/Firefox Invalid Date 방지)

### DIFF
--- a/src/app.feature/friend/components/FriendRequestListItem.tsx
+++ b/src/app.feature/friend/components/FriendRequestListItem.tsx
@@ -2,6 +2,7 @@
 
 import { CircleAvatar, Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
+import { getDateTimestamp } from '@module/utils/date';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -37,7 +38,9 @@ export function FriendRequestListItem({
           </Text>
           {request.createdAt ? (
             <Text size="caption2" className="text-gray-400">
-              {new Date(request.createdAt).toLocaleDateString('ko-KR')}
+              {new Date(
+                getDateTimestamp(request.createdAt)
+              ).toLocaleDateString('ko-KR')}
             </Text>
           ) : null}
         </div>

--- a/src/app.feature/stories/utils/storyHelpers.ts
+++ b/src/app.feature/stories/utils/storyHelpers.ts
@@ -1,4 +1,4 @@
-import { getRelativeTimeLabel } from '@module/utils/date';
+import { getDateTimestamp, getRelativeTimeLabel } from '@module/utils/date';
 
 import { StoryGroup, StoryItem } from '../type/story';
 
@@ -18,10 +18,10 @@ export function isGroupAllSeen(group: StoryGroup): boolean {
 }
 
 // createdAt(ISO) → epoch ms. 파싱 불가 시 0.
-function toTime(iso: string): number {
-  const time = new Date(iso).getTime();
-  return Number.isNaN(time) ? 0 : time;
-}
+// raw new Date(iso) 는 백엔드의 공백구분('YYYY-MM-DD HH:mm:ss')/마이크로초
+// 타임스탬프를 Safari/Firefox 에서 Invalid Date 로 만들어 정렬이 전부 0으로
+// 붕괴한다. date.ts 의 정규화 파서를 공유한다.
+const toTime = getDateTimestamp;
 
 // 그룹 내 가장 최근 스토리의 작성 시각(ms).
 function latestStoryTime(group: StoryGroup): number {

--- a/src/app.module/utils/date.test.ts
+++ b/src/app.module/utils/date.test.ts
@@ -67,6 +67,14 @@ describe('getDateTimestamp', () => {
     );
   });
 
+  // 백엔드가 내려주는 공백구분 타임스탬프. raw new Date() 는 Safari/Firefox 에서
+  // Invalid Date(→NaN) 를 반환하므로, 정규화 파서가 T 로 바꿔 파싱해야 한다.
+  it('parses a space-separated datetime (Safari/Firefox safe)', () => {
+    expect(getDateTimestamp('2026-07-10 12:00:10')).toBe(
+      new Date('2026-07-10T12:00:10').getTime()
+    );
+  });
+
   it('returns 0 for an unparseable value', () => {
     expect(getDateTimestamp('nonsense')).toBe(0);
   });


### PR DESCRIPTION
## 문제
두 곳이 `date.ts`의 정규화 파서를 우회하고 raw `new Date(createdAt)`를 사용:
- `stories/utils/storyHelpers.ts:22` (`toTime`) — 스토리 정렬(`latestStoryTime`)의 기준
- `friend/components/FriendRequestListItem.tsx:40` — 화면 표시 날짜

백엔드가 공백구분(`'YYYY-MM-DD HH:mm:ss'`) 또는 마이크로초 타임스탬프를 내려주면 **Safari/iOS·Firefox에서 `new Date()`가 Invalid Date(→NaN)** 를 반환한다. (프로젝트가 `date.ts`에 `replace(' ','T')` 정규화 파서를, `diaryViewData`에 마이크로초 절삭 파서를 이미 둔 것 자체가 백엔드가 이 포맷을 보낸다는 방증.)

## 증상
- 스토리 링: 모든 `toTime`이 0 → 정렬 붕괴(사실상 랜덤). Chrome만 정상.
- 친구 요청: 각 항목에 문자 그대로 **"Invalid Date"** 노출.

## 수정
이미 존재하고 테스트된 `getDateTimestamp`(= `parseDateValue`, 공백→T 정규화 + 마이크로초 처리)로 두 호출부를 routing. 신규 파서 추가 없음(재사용). `getDateTimestamp`의 공백구분 케이스 회귀 테스트 1건 추가.

## 검증
- `pnpm lint` 0 errors · `pnpm test` 120 passed(+1) · `pnpm knip` clean · `pnpm build` tsc 통과
- 브라우저 런타임 검증은 프로젝트 정책상 미수행.