### PR TITLE
perf: FadeInImage 를 React.memo 로 감싸 리스트 재렌더 시 이미지 깜빡임 차단

### DIFF
--- a/src/app.component/FadeInImage.tsx
+++ b/src/app.component/FadeInImage.tsx
@@ -112,4 +112,9 @@ function FadeInImage({
   );
 }
 
-export default FadeInImage;
+// 부모 리스트(일지/챌린지 보드, 스토리 등)가 스크롤·상태 변화로 재렌더돼도
+// src 등 props 가 같으면 재렌더를 건너뛴다. 재렌더 시 next/image 가 같은
+// <img> 의 src 를 다시 써 래스터가 blank→재디코드되며 깜빡이던 문제를 리프
+// 한 곳에서 차단한다. 내부 loaded/errored 상태 변화에 의한 자기 재렌더는
+// memo 와 무관하게 정상 동작한다.
+export default React.memo(FadeInImage);


### PR DESCRIPTION
## 문제
`FadeInImage`(next/image 래퍼)는 일지/챌린지 보드·스토리 링 등 **리스트 안에서 다수 인스턴스**로 렌더된다. 부모 리스트가 스크롤 위치·좋아요·로딩 등 상태 변화로 재렌더되면, `src`가 동일해도 각 `FadeInImage`가 재렌더되며 next/image가 같은 `<img>`의 `src`를 다시 써 래스터가 **blank→재디코드**되어 **눈에 보이는 깜빡임**이 발생했다.

## 수정
컴포넌트를 `React.memo`로 감싼다. `src`/`className`/`sizes` 등 props가 같으면 부모발 재렌더를 건너뛴다. 내부 `loaded`/`errored` 상태 변화에 의한 자기 재렌더는 memo와 무관하게 정상 동작하므로 페이드인/에러 폴백 로직은 그대로다. (부모가 불안정 콜백을 넘기는 경우에도 memo가 스킵을 안 할 뿐 동작 회귀는 없다.)

## 검증
- `pnpm lint` 0 errors · `pnpm test` 119 passed · `pnpm knip` clean · `pnpm build` tsc 통과
- 브라우저 런타임 검증은 프로젝트 정책상 미수행.

## 비고
0단계에서 발견한 stash `{2}`(develop 베이스, FadeInImage memo wip)와 동일 취지로, 해당 stash는 이 PR로 대체 가능합니다.