### PR TITLE
perf: 홈 오늘의 기록 N+1 제거 — GET /challenges/my/today 단일 API 교체

### DIFF
--- a/src/app.feature/diary/detail/hooks/useDiaryMutations.ts
+++ b/src/app.feature/diary/detail/hooks/useDiaryMutations.ts
@@ -8,6 +8,7 @@ import {
 } from '@tanstack/react-query';
 
 import { CHALLENGE_QUERY_KEYS } from '../../../challenge/board/consts/queryKeys';
+import { HOME_QUERY_KEYS } from '../../../home/consts/homeQueryKeys';
 import { MEMBER_QUERY_KEYS } from '../../../member/consts/queryKeys';
 import { DIARY_QUERY_KEYS } from '../../board/consts/queryKeys';
 import {
@@ -38,6 +39,7 @@ export function useCreateDiary(): UseMutationResult<
         MEMBER_QUERY_KEYS.myPage(),
         MEMBER_QUERY_KEYS.sidebar(),
         CHALLENGE_QUERY_KEYS.checkWrite(variables.challengeId),
+        HOME_QUERY_KEYS.todayChallenges(),
       ]);
     },
   });

--- a/src/app.feature/home/api/homeApi.ts
+++ b/src/app.feature/home/api/homeApi.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@module/api/client';
+import { requestData } from '@module/api/request';
+
+import type { MyTodayChallenge } from '../type/todayChallenge';
+
+export const homeApi = {
+  // 진행 중 챌린지의 오늘(KST) 작성 여부 + 목표 목록. 없으면 빈 배열.
+  getMyTodayChallenges: (): Promise<MyTodayChallenge[]> =>
+    requestData<MyTodayChallenge[]>(apiClient, {
+      url: '/challenges/my/today',
+      method: 'GET',
+    }),
+};

--- a/src/app.feature/home/components/HomeTodayRecordSection.tsx
+++ b/src/app.feature/home/components/HomeTodayRecordSection.tsx
@@ -15,10 +15,7 @@ import { useRouter } from 'next/navigation';
 import React from 'react';
 
 import { useTodayRecords } from '../hooks/useTodayRecords';
-import {
-  formatChallengeRemainingLabel,
-  isChallengeEndedOrArchived,
-} from '../utils/homeFormatters';
+import { formatChallengeRemainingLabel } from '../utils/homeFormatters';
 
 interface HomeTodayRecordSectionProps {
   /** 사이드바의 참여 챌린지 전체 목록 */
@@ -39,30 +36,16 @@ const CARD_BASE =
 interface RecordCardProps {
   challenge: SidebarChallenge;
   writtenToday: boolean;
-  isStatusLoading: boolean;
   goals: string[];
-  goalsLoading: boolean;
 }
 
 function GoalsBlock({
   goals,
-  goalsLoading,
   isFree,
 }: {
   goals: string[];
-  goalsLoading: boolean;
   isFree: boolean;
 }): React.ReactElement {
-  if (goalsLoading) {
-    return (
-      <div className={cn(GOALS_BLOCK, 'flex flex-col gap-1.5')}>
-        <span className="skeleton-pulse h-3 w-4/5 rounded bg-gray-100" />
-        <span className="skeleton-pulse h-3 w-3/5 rounded bg-gray-100" />
-        <span className="skeleton-pulse h-3 w-2/3 rounded bg-gray-100" />
-      </div>
-    );
-  }
-
   if (goals.length === 0) {
     return (
       <div className={cn(GOALS_BLOCK, 'flex items-center')}>
@@ -104,14 +87,13 @@ function GoalsBlock({
 function RecordCard({
   challenge,
   writtenToday,
-  isStatusLoading,
   goals,
-  goalsLoading,
 }: RecordCardProps): React.ReactElement {
   const router = useRouter();
   const tone = getCategoryStripeTone(challenge.category);
   const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
   const isFree = challenge.goalType === 'FLEXIBLE';
+  const categoryLabel = getCategoryLabel(challenge.category);
   const remainingLabel = formatChallengeRemainingLabel(
     challenge.endDate,
     isInfinite,
@@ -160,11 +142,9 @@ function RecordCard({
           </span>
         </Link>
 
-        {/* 상태/액션 — 폭을 고정해 로딩→확정 전환 시 시프트를 막는다. */}
+        {/* 상태/액션 — 폭을 고정해 그리드 시프트를 막는다. */}
         <div className="flex shrink-0 justify-end">
-          {isStatusLoading ? (
-            <span className="skeleton-pulse h-7 w-[76px] rounded-full bg-gray-100" />
-          ) : writtenToday ? (
+          {writtenToday ? (
             <span
               className={cn(
                 'inline-flex items-center gap-1 rounded-full',
@@ -195,11 +175,12 @@ function RecordCard({
         </div>
       </div>
 
-      <GoalsBlock goals={goals} goalsLoading={goalsLoading} isFree={isFree} />
+      <GoalsBlock goals={goals} isFree={isFree} />
 
-      {/* 카테고리·기간은 보조 정보로 축소해 하단에 배치. */}
+      {/* 카테고리·기간은 보조 정보로 축소해 하단에 배치. 사이드바에 없어
+          보조 정보를 못 채운 경우엔 라인을 비워 시프트만 방지한다. */}
       <span className="mt-auto truncate text-[11px] text-gray-400">
-        {getCategoryLabel(challenge.category)} · {remainingLabel}
+        {categoryLabel ? `${categoryLabel} · ${remainingLabel}` : ''}
       </span>
     </li>
   );
@@ -229,15 +210,30 @@ export default function HomeTodayRecordSection({
   isAuthLoading,
 }: HomeTodayRecordSectionProps): React.ReactElement {
   const router = useRouter();
-  const ongoing = challenges.filter(
-    (challenge) =>
-      !isChallengeEndedOrArchived(challenge.endDate, challenge.participantCnt)
-  );
-  const { items, doneCount, pendingCount, isLoading, allResolved } =
-    useTodayRecords(ongoing);
+  // 서버(GET /challenges/my/today)가 진행 중 챌린지만 내려준다. 사이드바
+  // 전체 목록은 카드 보조 정보(카테고리·기간·목표유형) 조인에만 쓴다.
+  const { items, doneCount, pendingCount, isLoading } =
+    useTodayRecords(challenges);
 
-  // 참여 중인 진행 챌린지가 없을 때 — 탐색으로 유도한다.
-  if (!isAuthLoading && ongoing.length === 0) {
+  // 인증/사이드바 또는 today 쿼리 로딩 중 — 개수를 모르므로 2행을 예약한다.
+  if (isAuthLoading || isLoading) {
+    return (
+      <section className="w-full">
+        <SectionHeader
+          title="오늘의 기록"
+          className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
+        />
+        <ul className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <SkeletonCard key={index} />
+          ))}
+        </ul>
+      </section>
+    );
+  }
+
+  // 진행 중 챌린지가 없을 때 — 탐색으로 유도한다.
+  if (items.length === 0) {
     return (
       <section className="w-full">
         <SectionHeader
@@ -262,30 +258,11 @@ export default function HomeTodayRecordSection({
     );
   }
 
-  // 인증/사이드바 로딩 중 — 진행 챌린지 수를 아직 모르므로 2행을 예약한다.
-  if (isAuthLoading) {
-    return (
-      <section className="w-full">
-        <SectionHeader
-          title="오늘의 기록"
-          className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
-        />
-        <ul className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
-          {Array.from({ length: 2 }).map((_, index) => (
-            <SkeletonCard key={index} />
-          ))}
-        </ul>
-      </section>
-    );
-  }
-
-  // 확정 후에만 미작성 우선으로 정렬(로딩 중엔 사이드바 순서 유지).
-  const ordered = allResolved
-    ? [...items].sort(
-        (left, right) => Number(left.writtenToday) - Number(right.writtenToday)
-      )
-    : items;
-  const allDone = allResolved && pendingCount === 0 && ongoing.length > 0;
+  // 미작성 우선으로 정렬.
+  const ordered = [...items].sort(
+    (left, right) => Number(left.writtenToday) - Number(right.writtenToday)
+  );
+  const allDone = pendingCount === 0;
 
   return (
     <section className="w-full">
@@ -293,11 +270,9 @@ export default function HomeTodayRecordSection({
         className="[&_h2]:!text-2xl [&_h2]:!tracking-tight"
         title="오늘의 기록"
         subtitle={
-          isLoading
-            ? undefined
-            : allDone
-              ? '오늘 기록을 모두 마쳤어요'
-              : `오늘 ${pendingCount}개 챌린지가 기다리고 있어요`
+          allDone
+            ? '오늘 기록을 모두 마쳤어요'
+            : `오늘 ${pendingCount}개 챌린지가 기다리고 있어요`
         }
         actionLabel="전체보기 →"
         onActionClick={() => router.push('/mypage/challenge')}
@@ -326,9 +301,7 @@ export default function HomeTodayRecordSection({
             key={item.challenge.challengeId}
             challenge={item.challenge}
             writtenToday={item.writtenToday}
-            isStatusLoading={item.isLoading}
             goals={item.goals}
-            goalsLoading={item.goalsLoading}
           />
         ))}
       </ul>

--- a/src/app.feature/home/consts/homeQueryKeys.ts
+++ b/src/app.feature/home/consts/homeQueryKeys.ts
@@ -1,0 +1,5 @@
+export const HOME_QUERY_KEYS = {
+  all: ['home'] as const,
+  todayChallenges: () =>
+    [...HOME_QUERY_KEYS.all, 'today-challenges'] as const,
+};

--- a/src/app.feature/home/hooks/useTodayRecords.ts
+++ b/src/app.feature/home/hooks/useTodayRecords.ts
@@ -1,89 +1,75 @@
 'use client';
 
-import { challengeBoardApi } from '@feature/challenge/board/api/challengeBoardApi';
-import { CHALLENGE_QUERY_KEYS } from '@feature/challenge/board/consts/queryKeys';
-import { challengeDetailApi } from '@feature/challenge/detail/api/challengeDetailApi';
 import type { SidebarChallenge } from '@feature/member/type/member';
-import { formatDateISO } from '@module/utils/date';
-import { useQueries } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
+
+import { homeApi } from '../api/homeApi';
+import { HOME_QUERY_KEYS } from '../consts/homeQueryKeys';
+import type { MyTodayChallenge } from '../type/todayChallenge';
 
 export interface TodayRecordItem {
   challenge: SidebarChallenge;
-  /** 오늘 이 챌린지에 일지를 작성했는지 (해당 쿼리 확정 후에만 유효) */
+  /** 오늘(KST) 이 챌린지에 일지를 작성했는지 */
   writtenToday: boolean;
-  /** 이 챌린지의 check-write 쿼리가 아직 로딩 중인지 */
-  isLoading: boolean;
   /** 이 챌린지의 목표 목록 (FIXED=공통, FLEXIBLE=내 목표) */
   goals: string[];
-  /** 목표(상세) 쿼리가 아직 로딩 중인지 — 스켈레톤 유지용 */
-  goalsLoading: boolean;
 }
 
 export interface TodayRecordsResult {
-  /** 입력 순서를 보존한 항목들 */
+  /** 진행 중 챌린지(서버 판정) — 표시 순서 = 응답 순서 */
   items: TodayRecordItem[];
-  /** 오늘 작성 완료한 챌린지 수 (확정된 것만) */
+  /** 오늘 작성 완료한 챌린지 수 */
   doneCount: number;
-  /** 오늘 미작성 챌린지 수 (확정된 것만) */
+  /** 오늘 미작성 챌린지 수 */
   pendingCount: number;
-  /** 하나라도 로딩 중 */
+  /** today 쿼리가 아직 로딩 중인지 */
   isLoading: boolean;
-  /** 모든 check-write 쿼리가 확정됨 */
-  allResolved: boolean;
 }
 
-// 진행 중 챌린지별로 "오늘 일지 작성 여부"와 "목표 목록"을 판정한다.
-// 사이드바 데이터에는 per-challenge 작성 플래그도 목표도 없어 두 벌의
-// 병렬 쿼리를 챌린지 수만큼 돌린다.
-//  - check-write(3일 내 작성 날짜 목록): 오늘 날짜 포함 여부로 미작성/완료.
-//  - detail(챌린지 상세): challengeGoals 로 목표 목록. FIXED 는 공통 목표,
-//    FLEXIBLE 은 서버가 내 목표를 내려준다(일지 작성 체크리스트와 동일 필드).
-// 두 쿼리 모두 상세 화면과 동일 키 팩토리를 공유하므로 캐시가 겹친다
-// (상세/일지 작성 진입 시 재요청 없음).
+// 새 API에 없는 카드 보조 정보(카테고리·기간·목표유형)는 사이드바에 조인해
+// 채운다. 사이드바에 없는 항목(정상 케이스엔 없음)은 보조 정보를 생략한 최소
+// 카드로 렌더한다.
+function fallbackChallenge(today: MyTodayChallenge): SidebarChallenge {
+  return {
+    challengeId: today.challengeId,
+    title: today.title,
+    category: '',
+    startDate: '',
+    endDate: '',
+    maxParticipantCnt: 0,
+    goalType: '',
+    participationType: '',
+    participantCnt: 0,
+    likeInfo: { likedByMe: false, likeCnt: 0 },
+  };
+}
+
+// 진행 중 챌린지의 "오늘 작성 여부 + 목표 목록"을 단일 API로 조회한다.
+// 서버가 진행 중 챌린지만 내려주므로(없으면 []), 이 목록이 표시 대상 기준이다.
+// 예전엔 챌린지마다 check-write + 상세를 각각 호출해 2N 요청이 났다.
 export function useTodayRecords(
-  challenges: SidebarChallenge[]
+  sidebarChallenges: SidebarChallenge[]
 ): TodayRecordsResult {
-  const results = useQueries({
-    queries: challenges.map((challenge) => ({
-      queryKey: CHALLENGE_QUERY_KEYS.checkWrite(challenge.challengeId),
-      queryFn: () =>
-        challengeBoardApi.getChallengeCheckWriteDates(challenge.challengeId),
-      enabled: Boolean(challenge.challengeId),
-    })),
-  });
-  const detailResults = useQueries({
-    queries: challenges.map((challenge) => ({
-      queryKey: CHALLENGE_QUERY_KEYS.detail(challenge.challengeId),
-      queryFn: () =>
-        challengeDetailApi.getChallengeDetail(challenge.challengeId),
-      enabled: Boolean(challenge.challengeId),
-    })),
+  const { data, isLoading } = useQuery({
+    queryKey: HOME_QUERY_KEYS.todayChallenges(),
+    queryFn: homeApi.getMyTodayChallenges,
   });
 
   return useMemo(() => {
-    const today = formatDateISO(new Date());
-    const items: TodayRecordItem[] = challenges.map((challenge, index) => {
-      const result = results[index];
-      const detailResult = detailResults[index];
-      const dates = result?.data ?? [];
-      const goals =
-        detailResult?.data?.challengeGoals.map((goal) => goal.content) ?? [];
-      return {
-        challenge,
-        writtenToday: dates.includes(today),
-        isLoading: result?.isLoading ?? false,
-        goals,
-        goalsLoading: detailResult?.isLoading ?? false,
-      };
-    });
-    const resolved = items.filter((item) => !item.isLoading);
+    const byId = new Map(
+      sidebarChallenges.map((challenge) => [challenge.challengeId, challenge])
+    );
+    const items: TodayRecordItem[] = (data ?? []).map((today) => ({
+      challenge: byId.get(today.challengeId) ?? fallbackChallenge(today),
+      writtenToday: today.todayWritten,
+      goals: today.goals.map((goal) => goal.content),
+    }));
     return {
       items,
-      doneCount: resolved.filter((item) => item.writtenToday).length,
-      pendingCount: resolved.filter((item) => !item.writtenToday).length,
-      isLoading: results.some((result) => result.isLoading),
-      allResolved: results.every((result) => !result.isLoading),
+      doneCount: items.filter((item) => item.writtenToday).length,
+      pendingCount: items.filter((item) => !item.writtenToday).length,
+      isLoading,
     };
-  }, [challenges, results, detailResults]);
+  }, [data, sidebarChallenges, isLoading]);
 }

--- a/src/app.feature/home/type/todayChallenge.ts
+++ b/src/app.feature/home/type/todayChallenge.ts
@@ -1,0 +1,13 @@
+export interface MyTodayChallengeGoal {
+  challengeGoalId: number;
+  content: string;
+}
+
+// GET /challenges/my/today 응답 원소. 진행 중 챌린지의 오늘(KST) 작성 여부와
+// 목표 목록만 담는다(카테고리·기간 등은 사이드바에서 보완).
+export interface MyTodayChallenge {
+  challengeId: number;
+  title: string;
+  todayWritten: boolean;
+  goals: MyTodayChallengeGoal[];
+}


### PR DESCRIPTION
## 배경
홈 "오늘의 기록"은 진행 중 챌린지마다 `check-write` + 챌린지 `상세`를
각각 호출해 **2N 요청**이 발생했다. 서버에 신규 엔드포인트
`GET /challenges/my/today` 가 배포되어 이를 **단일 요청 1건**으로 대체한다.

## 변경
- `home/api/homeApi.ts`, `home/type/todayChallenge.ts`,
  `home/consts/homeQueryKeys.ts` 추가
- `useTodayRecords`: `useQueries`(2N) → `useQuery`(1) + 사이드바
  `challengeList` 에 `challengeId` 로 조인
  - 카테고리·기간·목표유형은 새 API에 없어 사이드바 데이터로 보완
    (추가 요청 없음). 사이드바에 없는 항목은 보조 정보만 생략한 최소 카드로 렌더
- 일지 작성(`useCreateDiary`) 시 `HOME_QUERY_KEYS.todayChallenges()`
  무효화 추가 → 완료 상태 즉시 갱신
- `HomeTodayRecordSection`: 단일 쿼리 기준으로 로딩/빈 상태 정리,
  per-card 스켈레톤 분기 제거

## 요청 수
- Before: `2N` (N = 진행 중 챌린지 수)
- After: `1`

## 동작 유지
미작성 우선 강조 · 완료 체크 · 목표 최대 3개+N개 더 · 기록하기 동선 ·
전부 완료 시 축하+탐색 유도 · 2열→1열 반응형 · 레이아웃 시프트 방지 ·
비로그인 CTA(HomeScreen) 모두 유지.

## 검증
tsc · lint · vitest(120) · knip · build 모두 통과.
브라우저 확인은 하지 않았고 사용자 확인에 맡깁니다.