### PR TITLE
fix: 공식 챌린지는 참여자 0명이어도 종료/아카이브로 판정하지 않음

### DIFF
--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -55,7 +55,8 @@ const ChallengeBoardCardItem = React.memo(
     const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
     const ended = isChallengeEndedOrArchived(
       challenge.endDate,
-      challenge.participantCnt
+      challenge.participantCnt,
+      challenge.challengeType
     );
     const remainingLabel = formatChallengeRemainingLabel(
       challenge.endDate,

--- a/src/app.feature/challenge/board/screen/MemberChallengeListScreen.tsx
+++ b/src/app.feature/challenge/board/screen/MemberChallengeListScreen.tsx
@@ -35,7 +35,8 @@ const MemberChallengeCardItem = React.memo(
     const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
     const ended = isChallengeEndedOrArchived(
       challenge.endDate,
-      challenge.participantCnt
+      challenge.participantCnt,
+      challenge.challengeType
     );
     const remainingLabel = formatChallengeRemainingLabel(
       challenge.endDate,

--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -48,6 +48,9 @@ export interface ChallengeSummary {
   deleted?: boolean;
   // 종료 후 2일 유예 동안 일지 작성 허용 여부(생성 시 지정).
   postEndWriteAllowed?: boolean;
+  // 공개 범위 — OFFICIAL 이면 참여자 0명이어도 종료로 판정하지 않는다.
+  // 서버가 상세 응답에 내려주지 않으면 undefined (기존 동작 유지).
+  challengeType?: ChallengeType;
   randomParticipants?: RandomParticipant[];
 }
 

--- a/src/app.feature/challenge/board/utils/challengePeriod.test.ts
+++ b/src/app.feature/challenge/board/utils/challengePeriod.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { canWriteDiaryForChallenge } from './challengePeriod';
+import {
+  canWriteDiaryForChallenge,
+  isChallengeEndedOrArchived,
+} from './challengePeriod';
 
 describe('canWriteDiaryForChallenge', () => {
   const start = '2026-07-01';
@@ -31,5 +34,27 @@ describe('canWriteDiaryForChallenge', () => {
   it('종료 + 옵션 ON + 유예 경과(+3일): 작성 불가', () => {
     const now = new Date('2026-07-13T09:00:00+09:00');
     expect(canWriteDiaryForChallenge(start, end, true, now)).toBe(false);
+  });
+});
+
+describe('isChallengeEndedOrArchived', () => {
+  const end = '2026-07-10';
+  const during = new Date('2026-07-05T09:00:00+09:00');
+  const past = new Date('2026-07-12T09:00:00+09:00');
+
+  it('일반 챌린지: 참여자 0명이면 종료(아카이브)로 판정', () => {
+    expect(isChallengeEndedOrArchived(end, 0, 'PUBLIC', during)).toBe(true);
+  });
+
+  it('공식 챌린지: 참여자 0명이어도 진행 중이면 종료 아님', () => {
+    expect(isChallengeEndedOrArchived(end, 0, 'OFFICIAL', during)).toBe(false);
+  });
+
+  it('공식 챌린지도 기간이 지나면 종료로 판정', () => {
+    expect(isChallengeEndedOrArchived(end, 0, 'OFFICIAL', past)).toBe(true);
+  });
+
+  it('challengeType 미지정(undefined): 기존 동작대로 0명이면 종료', () => {
+    expect(isChallengeEndedOrArchived(end, 0, undefined, during)).toBe(true);
   });
 });

--- a/src/app.feature/challenge/board/utils/challengePeriod.ts
+++ b/src/app.feature/challenge/board/utils/challengePeriod.ts
@@ -1,6 +1,8 @@
 import { toStartOfDay } from '@module/utils/date';
 import { add } from 'date-fns';
 
+import type { ChallengeType } from '../type/challenge';
+
 const ENDLESS_MIN_YEAR = 2090;
 
 // 종료 후 일지 작성 유예 기간(일). 서버 규칙과 동일하게 종료일 +2일까지 허용.
@@ -91,14 +93,22 @@ export function canWriteDiaryForChallenge(
 }
 
 // 참여자가 0명이면 아카이브된 챌린지로 간주해 종료 처리한다.
+// 단, 공식 챌린지(OFFICIAL)는 참여자 0명이어도 아카이브로 보지 않고
+// 종료 판정을 기간(endDate) 기준으로만 한다. 운영이 만들어둔 공식 챌린지가
+// 아직 참여자가 없다는 이유로 종료로 표시되거나 노출에서 빠지는 걸 막는다.
 export function isChallengeEndedOrArchived(
   endDate: string | null | undefined,
   participantCnt: number | null | undefined,
+  challengeType?: ChallengeType | null,
   referenceDate: Date = new Date()
 ): boolean {
-  return (
-    isChallengeEnded(endDate, referenceDate) || (participantCnt ?? 0) === 0
-  );
+  if (isChallengeEnded(endDate, referenceDate)) {
+    return true;
+  }
+  if (challengeType === 'OFFICIAL') {
+    return false;
+  }
+  return (participantCnt ?? 0) === 0;
 }
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -253,7 +253,8 @@ export function ChallengeDetailScreen({
   );
   const isChallengeAlreadyEnded = isChallengeEndedOrArchived(
     summaryEndDate,
-    summaryParticipantCnt
+    summaryParticipantCnt,
+    summary?.challengeType
   );
   // 종료됐어도 종료 후 작성 허용 옵션 + 2일 유예 이내면 일지 작성을 살린다.
   const canWriteDiary = canWriteDiaryForChallenge(

--- a/src/app.feature/diary/detail/components/DiaryConnectedChallenge.tsx
+++ b/src/app.feature/diary/detail/components/DiaryConnectedChallenge.tsx
@@ -39,7 +39,8 @@ export function DiaryConnectedChallengeCard({
       isOngoing={isChallengeOngoing(summary.startDate, summary.endDate)}
       isEnded={isChallengeEndedOrArchived(
         summary.endDate,
-        summary.participantCnt
+        summary.participantCnt,
+        summary.challengeType
       )}
       stripeTone={getCategoryStripeTone(summary.category)}
       onClick={onClick}

--- a/src/app.feature/diary/write/components/ChallengePicker.tsx
+++ b/src/app.feature/diary/write/components/ChallengePicker.tsx
@@ -110,7 +110,8 @@ export function ChallengePicker({
                   )}
                   isEnded={isChallengeEndedOrArchived(
                     challenge.endDate,
-                    challenge.participantCnt
+                    challenge.participantCnt,
+                    challenge.challengeType
                   )}
                   stripeTone={getCategoryStripeTone(challenge.category)}
                   variant="picker"

--- a/src/app.feature/diary/write/components/DiaryCreateChallengeSection.tsx
+++ b/src/app.feature/diary/write/components/DiaryCreateChallengeSection.tsx
@@ -131,7 +131,8 @@ function DiaryCreateChallengeSectionComponent({
           )}
           isEnded={isChallengeEndedOrArchived(
             selectedChallenge.endDate,
-            selectedChallenge.participantCnt
+            selectedChallenge.participantCnt,
+            selectedChallenge.challengeType
           )}
           stripeTone={getCategoryStripeTone(selectedChallenge.category)}
           onClick={openPicker}

--- a/src/app.feature/home/components/HomeRandomChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeRandomChallengesSection.tsx
@@ -110,7 +110,8 @@ export default function HomeRandomChallengesSection({
             const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
             const ended = isChallengeEndedOrArchived(
               challenge.endDate,
-              challenge.participantCnt
+              challenge.participantCnt,
+              challenge.challengeType
             );
             const remainingLabel = formatChallengeRemainingLabel(
               challenge.endDate,


### PR DESCRIPTION
## 배경
클라 유틸 `isChallengeEndedOrArchived(endDate, participantCnt)` 이
참여자 0명이면 무조건 아카이브(=종료)로 간주하고 있어, **운영이 만든 공식
챌린지가 아직 참여자가 없다는 이유만으로 "종료"로 표시되거나 노출에서
빠지는** 문제가 있었습니다.

## 규칙 변경
`isChallengeEndedOrArchived` 에 `challengeType` 인자를 추가:

- `challengeType === 'OFFICIAL'` → 참여자 0명이어도 **아카이브로 보지 않고
  기간(endDate) 기준으로만** 종료를 판정.
- 그 외(PUBLIC/PRIVATE/undefined) → 기존 규칙(0명이면 종료) 유지.

## 반영 범위
| 위치 | 데이터 타입 | 처리 |
|---|---|---|
| 탐색 공식 챌린지 섹션 / 홈 랜덤·추천 (`HomeRandomChallengesSection`) | `ChallengeListItem` | `challenge.challengeType` 전달 |
| 챌린지 보드 (`ChallengeBoardScreen`) | `ChallengeListItem` | 전달 |
| 회원 챌린지 목록 (`MemberChallengeListScreen`) | `ChallengeListItem` | 전달 |
| 일지 작성 챌린지 선택 (`ChallengePicker`, `DiaryCreateChallengeSection`) | `ChallengeListItem` | 전달 |
| 챌린지 상세 배지 (`ChallengeDetailScreen`) | `ChallengeSummary` | 타입에 `challengeType?` 추가 후 전달 |
| 일지 연결 챌린지 (`DiaryConnectedChallenge`) | `ChallengeSummary` | 동일 |

> 탐색의 "공식 챌린지" 섹션은 `HomeRandomChallengesSection` 을 재사용하므로
> 해당 컴포넌트 수정으로 함께 반영됩니다.

## ⚠️ 서버 변경 필요 (challengeType 미전달 경로)
아래 응답 타입에는 `challengeType` 필드가 **원래 없습니다**. 클라에서는
optional 로 열어 전달하도록 준비했으나, **서버가 실제로 값을 내려주기 전까지는
`undefined` → 공식 예외가 적용되지 않습니다**(무회귀, 기존 동작 유지).

- **`GET /challenges/{id}` (`ChallengeSummary`)** — 챌린지 상세 배지·일지 연결
  챌린지가 이 응답을 사용. **공식 챌린지 상세의 "종료" 배지를 완전히 고치려면
  서버가 `challengeSummary.challengeType` 을 내려줘야 합니다.**
- **마이페이지 `MyPageChallenge`** — `challengeType` 없음. 다만 이 목록은 본인이
  참여 중인 챌린지라 `participantCnt >= 1` 이라 0명 아카이브 규칙이 애초에
  발동하지 않아 실질 영향 없음(변경도 하지 않음).

## 검증
- `tsc --noEmit` ✅
- `pnpm lint` ✅ (기존 경고 4건 외 신규 없음)
- `pnpm test` ✅ 124 passed (공식 예외 케이스 4건 추가)
- `pnpm knip` ✅
- `pnpm build` ✅

브라우저 확인은 프로젝트 정책상 사용자에게 맡깁니다(직접 실행하지 않음).