### PR TITLE
fix: 공식 챌린지 상세/일지 연결 종료 배지 판정 확정 (challengeType 필수화)

### DIFF
--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -49,8 +49,8 @@ export interface ChallengeSummary {
   // 종료 후 2일 유예 동안 일지 작성 허용 여부(생성 시 지정).
   postEndWriteAllowed?: boolean;
   // 공개 범위 — OFFICIAL 이면 참여자 0명이어도 종료로 판정하지 않는다.
-  // 서버가 상세 응답에 내려주지 않으면 undefined (기존 동작 유지).
-  challengeType?: ChallengeType;
+  // 서버가 상세 응답(challengeSummary)에 항상 내려주므로 필수.
+  challengeType: ChallengeType;
   randomParticipants?: RandomParticipant[];
 }
 

--- a/src/app.feature/diary/detail/utils/diaryViewData.test.ts
+++ b/src/app.feature/diary/detail/utils/diaryViewData.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { ChallengeDetailResponse } from '../../../challenge/board/type/challenge';
 import type { DiaryDetail } from '../../board/type/diary';
 import type { DiaryComment } from '../type/comment';
 import {
@@ -159,5 +160,32 @@ describe('mapDiaryToViewData', () => {
     expect(view.connectedChallengeTitle).toBe('아침 러닝');
     expect(view.achievementPercent).toBe(40);
     expect(view.contentImageUrls).toEqual(['https://cdn.example.com/a.jpg']);
+  });
+
+  it('carries challengeType from challengeSummary so the badge can read it', () => {
+    const diary = {
+      id: 8,
+      challenge: null,
+      author: null,
+      title: '일지',
+      content: '<p>내용</p>',
+      imgUrl: null,
+      thumbnailUrl: null,
+      likeInfo: { likedByMe: false, likeCnt: 0 },
+      diaryInfo: { feeling: 'NONE', achievementRate: 0 },
+    } as unknown as DiaryDetail;
+    const challengeDetailData = {
+      challengeSummary: {
+        challengeId: 5,
+        title: '공식 챌린지',
+        participantCnt: 0,
+        challengeType: 'OFFICIAL',
+      },
+    } as unknown as ChallengeDetailResponse;
+
+    const view = mapDiaryToViewData(diary, challengeDetailData);
+
+    // 공식 챌린지 배지가 challengeType 을 읽어 0명이어도 종료로 보지 않게 한다.
+    expect(view.connectedChallengeSummary?.challengeType).toBe('OFFICIAL');
   });
 });


### PR DESCRIPTION
## 배경
#187 에서 `isChallengeEndedOrArchived` 에 `challengeType` 예외를 추가해 공식(OFFICIAL) 챌린지는 참여자 0명이어도 종료로 판정하지 않도록 했다. 다만 `ChallengeSummary.challengeType` 을 optional 로 열어둬, 챌린지 상세 종료 배지·일지 연결 챌린지 배지가 공식 여부를 확실히 읽는다는 보장이 타입 레벨에 없었다.

## 변경
- `ChallengeSummary.challengeType` 을 optional → **필수**로 정리. 서버가 `GET /challenges/{id}` 응답의 `challengeSummary.challengeType` 를 항상 내려주므로 실제 응답 계약을 타입에 반영한다.
- 상세 화면(`ChallengeDetailScreen`)과 일지 연결 챌린지 카드(`DiaryConnectedChallengeCard`)는 이미 `summary.challengeType` 을 `isChallengeEndedOrArchived` 로 넘기고 있어, 타입 필수화로 누락 없이 전달됨이 컴파일 타임에 보장된다.
- `diaryViewData`: `connectedChallengeSummary` 가 `challengeSummary.challengeType` 를 그대로 전달하는지 테스트 추가.

## 결과
공식 챌린지는 참여자 0명이어도 상세/일지 연결 배지에서 "종료"로 표시되지 않는다.

## 검증
- tsc / lint / vitest(125) / knip / build 통과
- 브라우저 확인은 하지 않음(정적 검증까지)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diary detail handling so challenge badges display the correct challenge type, including when the challenge itself is unavailable.

* **Tests**
  * Added coverage for challenge detail data and challenge type preservation in diary views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->