### PR TITLE
feat: 링크 공유 OG 이미지 개선 및 챌린지·일지 상세 동적 메타

### DIFF
--- a/src/app.module/metadata/seo.ts
+++ b/src/app.module/metadata/seo.ts
@@ -1,0 +1,117 @@
+import { API_BASE_URL } from '@module/api/config';
+import type { Metadata } from 'next';
+
+export const SITE_TITLE = '1Day 1Streak';
+export const SITE_DESCRIPTION =
+  '매일 하나의 챌린지로 꾸준함을 기록하는 1Day 1Streak';
+
+// next/og 로 생성하는 기본 OG 이미지(1200×630). challenge/diary 에 썸네일이
+// 없을 때의 폴백으로도 재사용한다.
+export const DEFAULT_OG_IMAGE_PATH = '/api/og';
+export const OG_IMAGE_WIDTH = 1200;
+export const OG_IMAGE_HEIGHT = 630;
+
+function resolveSiteUrl(): URL {
+  const rawUrl =
+    process.env.NEXT_PUBLIC_WEB_URL ??
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    'http://localhost:3000';
+
+  try {
+    return new URL(rawUrl);
+  } catch {
+    return new URL('http://localhost:3000');
+  }
+}
+
+export const SITE_URL = resolveSiteUrl();
+
+// og:image / twitter:image 는 도메인 포함 절대 URL 이어야 한다(카톡·트위터).
+export function toAbsoluteUrl(path: string): string {
+  try {
+    return new URL(path, SITE_URL).toString();
+  } catch {
+    return path;
+  }
+}
+
+// 마크다운/HTML 태그를 제거하고 미리보기용으로 한 줄 요약을 만든다.
+export function toMetaDescription(
+  raw: string | null | undefined,
+  fallback = SITE_DESCRIPTION
+): string {
+  const text = (raw ?? '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!text) {
+    return fallback;
+  }
+  return text.length > 120 ? `${text.slice(0, 119)}…` : text;
+}
+
+interface ResourceMetadataInput {
+  title: string;
+  description: string;
+  // 리소스의 대표 이미지(S3 썸네일 등). 없으면 기본 OG 이미지로 폴백.
+  imageUrl?: string | null;
+}
+
+export function buildResourceMetadata({
+  title,
+  description,
+  imageUrl,
+}: ResourceMetadataInput): Metadata {
+  const isDefault = !imageUrl;
+  const absoluteImage = toAbsoluteUrl(imageUrl || DEFAULT_OG_IMAGE_PATH);
+  // 기본 이미지만 크기를 아는 값(1200×630)으로 명시한다. S3 썸네일은 크기를
+  // 알 수 없어 크롤러가 추론하도록 width/height 를 생략한다.
+  const image = isDefault
+    ? {
+        url: absoluteImage,
+        width: OG_IMAGE_WIDTH,
+        height: OG_IMAGE_HEIGHT,
+        alt: title,
+      }
+    : { url: absoluteImage, alt: title };
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      siteName: SITE_TITLE,
+      locale: 'ko_KR',
+      type: 'article',
+      images: [image],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [image],
+    },
+  };
+}
+
+// generateMetadata 전용 비인증 GET. 공개 리소스만 응답하며, 인증 필요(401)·
+// 삭제(404)·네트워크 오류는 모두 null 로 폴백해 메타를 기본값으로 되돌린다.
+export async function fetchPublicResource<T>(path: string): Promise<T | null> {
+  if (!API_BASE_URL) {
+    return null;
+  }
+  try {
+    const res = await fetch(`${API_BASE_URL}${path}`, {
+      headers: { accept: 'application/json' },
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const body = (await res.json()) as { data?: T };
+    return body.data ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,0 +1,71 @@
+import {
+  OG_IMAGE_HEIGHT,
+  OG_IMAGE_WIDTH,
+  SITE_TITLE,
+} from '@module/metadata/seo';
+import { ImageResponse } from 'next/og';
+
+// 기본 OG 이미지(1200×630)를 next/og 로 생성한다. 브랜드 오렌지(#FF7043)를
+// 더 진하게 깔고(#E64A19 그라데이션) 흰색 로고 마크 + 서비스명을 얹는다.
+// 문구는 ASCII 만 사용해 별도 폰트 로딩 없이 기본 폰트로 렌더한다.
+export function GET(): ImageResponse {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 40,
+          background:
+            'linear-gradient(135deg, #FF7A45 0%, #F4511E 55%, #D84315 100%)',
+        }}
+      >
+        <svg
+          width="150"
+          height="250"
+          viewBox="0 0 180 300"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 294.833V58.0342C0 52.9823 6.4726 50.9325 9.35613 55.0711L174.337 291.87C176.723 295.295 174.285 300 170.124 300H5.14291C2.30256 300 0 297.688 0 294.833Z"
+            fill="#ffffff"
+          />
+          <path
+            d="M180 294.833V58.0342C180 52.9823 173.527 50.9325 170.644 55.0711L5.66273 291.87C3.27673 295.295 5.71524 300 9.87598 300H174.857C177.697 300 180 297.688 180 294.833Z"
+            fill="#ffffff"
+          />
+          <path
+            d="M87.5168 1.91788L80.0992 29.865C79.8619 30.7589 79.1668 31.4573 78.2771 31.6958L50.4612 39.1483C47.9159 39.8302 47.9159 43.4591 50.4612 44.1409L78.2771 51.5935C79.1668 51.8319 79.8619 52.5303 80.0992 53.4242L87.5168 81.3713C88.1954 83.9285 91.8073 83.9285 92.4859 81.3713L99.9035 53.4242C100.141 52.5303 100.836 51.8319 101.726 51.5935L129.542 44.1409C132.087 43.4591 132.087 39.8302 129.542 39.1483L101.726 31.6958C100.836 31.4573 100.141 30.7589 99.9035 29.865L92.4859 1.91788C91.8073 -0.639294 88.1954 -0.639294 87.5168 1.91788Z"
+            fill="#ffffff"
+          />
+        </svg>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 84,
+            fontWeight: 800,
+            color: '#ffffff',
+            letterSpacing: -2,
+          }}
+        >
+          {SITE_TITLE}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 34,
+            color: 'rgba(255,255,255,0.92)',
+          }}
+        >
+          Build your streak, one day at a time.
+        </div>
+      </div>
+    ),
+    { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT }
+  );
+}

--- a/src/app/challenge/[id]/page.tsx
+++ b/src/app/challenge/[id]/page.tsx
@@ -1,9 +1,41 @@
 import { ChallengeDetailSkeleton } from '@component/skeletons/ChallengeDetailSkeleton';
+import { ChallengeDetailResponse } from '@feature/challenge/board/type/challenge';
 import { ChallengeDetailScreen } from '@feature/challenge/detail/screen/ChallengeDetailScreen';
+import {
+  buildResourceMetadata,
+  fetchPublicResource,
+  SITE_TITLE,
+  toMetaDescription,
+} from '@module/metadata/seo';
+import type { Metadata } from 'next';
 import React, { Suspense } from 'react';
 
 interface ChallengeDetailProps {
   params: Promise<{ id: string }>;
+}
+
+/**
+ * 공개(PUBLIC)·공식(OFFICIAL) 챌린지만 상세 메타를 채운다. 비공개(PRIVATE)·
+ * 삭제·인증 필요·조회 실패는 빈 객체를 반환해 루트 기본 메타(기본 OG)로
+ * 폴백한다. 썸네일이 있으면 OG 이미지로 쓰고 없으면 기본 이미지로 폴백.
+ */
+export async function generateMetadata({
+  params,
+}: ChallengeDetailProps): Promise<Metadata> {
+  const { id } = await params;
+  const detail = await fetchPublicResource<ChallengeDetailResponse>(
+    `/challenges/${id}`
+  );
+  const summary = detail?.challengeSummary;
+  if (!summary || summary.challengeType === 'PRIVATE' || summary.deleted) {
+    return {};
+  }
+
+  return buildResourceMetadata({
+    title: `${summary.title} | ${SITE_TITLE}`,
+    description: toMetaDescription(detail.challengeDetail.description),
+    imageUrl: summary.thumbnailImage,
+  });
 }
 
 /**

--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -1,8 +1,37 @@
+import { DiaryDetail } from '@feature/diary/board/type/diary';
 import { DiaryDetailScreen } from '@feature/diary/detail/screen/DiaryDetailScreen';
+import {
+  buildResourceMetadata,
+  fetchPublicResource,
+  SITE_TITLE,
+  toMetaDescription,
+} from '@module/metadata/seo';
+import type { Metadata } from 'next';
 import React from 'react';
 
 interface DiaryDetailProps {
   params: Promise<{ id: string }>;
+}
+
+/**
+ * 공개(isPublic) 일지만 상세 메타를 채운다. 비공개·삭제·인증 필요·조회 실패는
+ * 빈 객체를 반환해 루트 기본 메타(기본 OG)로 폴백한다. 썸네일(없으면 첫
+ * 이미지)이 있으면 OG 이미지로 쓰고 없으면 기본 이미지로 폴백.
+ */
+export async function generateMetadata({
+  params,
+}: DiaryDetailProps): Promise<Metadata> {
+  const { id } = await params;
+  const diary = await fetchPublicResource<DiaryDetail>(`/diaries/${id}`);
+  if (!diary || !diary.isPublic) {
+    return {};
+  }
+
+  return buildResourceMetadata({
+    title: `${diary.title} | ${SITE_TITLE}`,
+    description: toMetaDescription(diary.content),
+    imageUrl: diary.thumbnailUrl ?? diary.imgUrl?.[0] ?? null,
+  });
 }
 
 /**

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,15 @@ import '@/app.styles/globals.css';
 
 import AppLayoutShell from '@component/layout/AppLayoutShell';
 import ScrollToTop from '@component/layout/ScrollToTop';
+import {
+  DEFAULT_OG_IMAGE_PATH,
+  OG_IMAGE_HEIGHT,
+  OG_IMAGE_WIDTH,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_URL,
+  toAbsoluteUrl,
+} from '@module/metadata/seo';
 import { AppProviders } from '@module/providers';
 import { cn } from '@module/utils/cn';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -10,23 +19,7 @@ import type { Metadata, Viewport } from 'next';
 
 import { pretendard } from '@/app.lib/font';
 
-function resolveSiteUrl(): URL {
-  const rawUrl =
-    process.env.NEXT_PUBLIC_WEB_URL ??
-    process.env.NEXT_PUBLIC_SITE_URL ??
-    'http://localhost:3000';
-
-  try {
-    return new URL(rawUrl);
-  } catch {
-    return new URL('http://localhost:3000');
-  }
-}
-
-const SITE_URL = resolveSiteUrl();
-const SITE_TITLE = '1Day 1Streak';
-const SITE_DESCRIPTION = '매일 하나의 챌린지로 꾸준함을 기록하는 1Day 1Streak';
-const OG_IMAGE_PATH = '/images/open-graph.png';
+const OG_IMAGE_URL = toAbsoluteUrl(DEFAULT_OG_IMAGE_PATH);
 
 export const metadata: Metadata = {
   metadataBase: SITE_URL,
@@ -52,9 +45,9 @@ export const metadata: Metadata = {
     type: 'website',
     images: [
       {
-        url: OG_IMAGE_PATH,
-        width: 1200,
-        height: 630,
+        url: OG_IMAGE_URL,
+        width: OG_IMAGE_WIDTH,
+        height: OG_IMAGE_HEIGHT,
         alt: SITE_TITLE,
       },
     ],
@@ -65,9 +58,9 @@ export const metadata: Metadata = {
     description: SITE_DESCRIPTION,
     images: [
       {
-        url: OG_IMAGE_PATH,
-        width: 1200,
-        height: 630,
+        url: OG_IMAGE_URL,
+        width: OG_IMAGE_WIDTH,
+        height: OG_IMAGE_HEIGHT,
         alt: SITE_TITLE,
       },
     ],


### PR DESCRIPTION
## 요약

디스코드·트위터·카톡 등 링크 공유 시 미리보기(OG) 이미지를 개선하고, 챌린지/일지 상세에 리소스별 동적 메타를 추가한다.

## 변경 내용

### 1) 기본 OG 이미지 리뉴얼 — `next/og`
- 기존: 옅은 핑크 배경의 정적 PNG(`/images/open-graph.png`)로 색감이 흐림.
- 변경: `GET /api/og` 에서 `ImageResponse` 로 1200×630 동적 생성. 브랜드 오렌지를 더 진한 그라데이션(`#FF7A45 → #F4511E → #D84315`)으로 깔고 흰색 로고 마크 + `1Day 1Streak` 워드마크 + 태그라인.
- 정적 파일 대신 `next/og` 선택 이유: 로컬에 래스터라이저(sharp/resvg/imagemagick)가 없어 고품질 PNG를 만들 수 없고, `next/og` 는 이미 설치되어 있어 추가 의존성이 없다. 문구는 ASCII 만 써서 별도 폰트 로딩 없이 렌더.

### 2) 공용 SEO 모듈 `src/app.module/metadata/seo.ts`
- SITE 상수, 절대 URL 변환(`toAbsoluteUrl`), 메타 설명 정제(`toMetaDescription`), 리소스 메타 빌더(`buildResourceMetadata`), 비인증 공개 리소스 fetch(`fetchPublicResource`)를 모아 root layout·상세 페이지가 공유.

### 3) 챌린지 상세 `generateMetadata`
- 서버에서 `GET /challenges/{id}` 비인증 조회 → 제목·소개·썸네일을 `openGraph.images` + `twitter(summary_large_image)` 에 반영. 썸네일 없으면 기본 이미지.
- **비공개(PRIVATE)·삭제·조회 실패**는 빈 메타 반환 → 루트 기본 메타로 폴백.

### 4) 일지 상세 `generateMetadata`
- `GET /diaries/{id}` 조회 → 제목·내용·썸네일(없으면 첫 이미지) 반영.
- **비공개 일지(`isPublic=false`)·삭제·조회 실패**는 빈 메타로 폴백.

### 5) OG 메타 규격
- `twitter:card = summary_large_image`, `og:image` 는 도메인 포함 절대 URL, 기본 이미지엔 `og:image:width/height`(1200×630) 명시. S3 썸네일은 크기를 알 수 없어 width/height 생략(크롤러 추론).

## 폴백 동작
접근 불가 리소스(비공개·삭제·인증 필요·네트워크 오류)는 모두 빈 객체를 반환해 루트 기본 메타(기본 OG)로 안전하게 폴백 — 정보 노출·렌더 에러 없음.

## 검증
- ✅ `tsc --noEmit` / `pnpm lint` / `pnpm test`(124) / `pnpm knip` / `pnpm build`
- ✅ `/api/og` 렌더 결과 시각 확인(글리프 정상, 토푸 없음)
- 브라우저 실측(크롤러 미리보기)은 배포 후 확인 필요.