### PR TITLE
fix: OG 크롤러 미들웨어 예외 처리 — 링크 프리뷰 이미지 복구

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ NEXT_PUBLIC_REFRESH_TOKEN_COOKIE_NAME=devRefreshToken
 # image host example (if image objects are stored separately)
 # NEXT_PUBLIC_ODOS_IMAGE_URL=https://your-image-bucket.example.com/
 
+# 절대 URL 생성용 사이트 오리진. og:image/twitter:image 는 도메인 포함 절대
+# URL 이어야 하므로 필수. 오타(예: dev,1day1streak.com 처럼 . 대신 ,)가 나면
+# 크롤러가 이미지를 못 읽어 링크 프리뷰가 깨진다. 배포 환경별로 정확히 설정.
+NEXT_PUBLIC_WEB_URL=https://your-site.example.com
+
 # Kakao JS SDK app key (카카오 개발자 콘솔 > 앱 > JavaScript 키)
 # 챌린지 공유의 카카오톡 버튼에 사용. 미설정 시 버튼은 안내 토스트만 표시.
 NEXT_PUBLIC_KAKAO_JS_KEY=your-kakao-javascript-key

--- a/src/app.module/middleware/auth.ts
+++ b/src/app.module/middleware/auth.ts
@@ -32,6 +32,18 @@ export interface AuthCheckResult {
   cookieHeader?: string;
 }
 
+// 링크 프리뷰(OG) 크롤러. 인증 쿠키가 없어 항상 게이트에 걸리므로, 공개
+// 상세(list-redirect)에 한해 통과시켜 generateMetadata 가 실행되고 og 태그가
+// 실린 200 HTML 을 받게 한다. 307 로 튕기면 리다이렉트를 따라가지 않는
+// 스크레이퍼(카카오톡 등)는 상세 OG 를 아예 못 읽는다. 민감 경로
+// (login-redirect: 마이페이지/작성/편집)는 통과시키지 않는다.
+const OG_CRAWLER_UA =
+  /facebookexternalhit|Facebot|Twitterbot|Slackbot|Discordbot|TelegramBot|LinkedInBot|WhatsApp|redditbot|Pinterest|kakaotalk-scrap|KAKAOTALK|Line/i;
+
+function isOgCrawler(req: NextRequest): boolean {
+  return OG_CRAWLER_UA.test(req.headers.get('user-agent') ?? '');
+}
+
 function matchRoute(pathname: string): ProtectedRoute | null {
   return PROTECTED_ROUTES.find(({ pattern }) => pattern.test(pathname)) ?? null;
 }
@@ -169,6 +181,11 @@ export async function authMiddleware(
     hintCookies.length > 0 ? { setCookies: hintCookies } : {};
 
   if (!matched) {
+    return passThrough;
+  }
+
+  // OG 크롤러는 공개 상세를 렌더시켜 generateMetadata 로 og 태그를 싣는다.
+  if (matched.type === 'list-redirect' && isOgCrawler(req)) {
     return passThrough;
   }
 


### PR DESCRIPTION
## 문제 (실측)
`https://dev.1day1streak.com/diary/74` 를 디스코드·카카오톡에 붙여도 OG 이미지가 안 뜸. #189 배포 이후 상태. 실제 요청으로 3가지 원인 확인.

### 1) [결정적] Vercel dev 환경변수 오타 — **이 PR 밖(운영 조치 필요)**
`NEXT_PUBLIC_WEB_URL=https://dev,1day1streak.com` — 점(`.`) 대신 **쉼표(`,`)**.
→ 모든 og:image URL 이 `https://dev,1day1streak.com/api/og` 로 생성돼 DNS 해석 실패(`status 000`) → **이미지가 아예 안 뜸.**
`/api/og` 자체는 정상(`200 image/png 60KB`). 코드엔 하드코딩된 도메인 없음(로컬 빌드는 정확한 URL 생성 확인). → **Vercel dev 환경변수를 `dev.1day1streak.com` 으로 수정 필요.**

### 2) [이 PR에서 수정] 미들웨어가 크롤러를 307 로 튕김
`/diary/[id]`·`/challenge/[id]` 는 `list-redirect` 보호 경로 → 쿠키 없는 크롤러는 refresh 실패 → **307 `/diary?loginRequired=true`**. `generateMetadata`(#189) 실행 안 됨. 리다이렉트 미추종 스크레이퍼(카카오톡)는 상세 OG 를 못 읽음.

### 3) [서버 조치 필요, 이 PR 밖] 비인증 API GET 이 400
`curl https://dev.api.1day1streak.com/diaries/74` → `400 AUTH-002`.
→ `fetchPublicResource` 가 null → `generateMetadata` 가 `{}` → 기본 OG 로만 폴백(일지 제목·썸네일 OG 불가). 공개 일지의 비인증 GET 을 서버가 허용해야 상세 OG 가 나감.

## 변경
- `auth.ts`: 공개 상세(`list-redirect`)에 한해 OG 크롤러 UA 통과 → 200 HTML 에 og 태그. 민감 경로(`login-redirect`)는 기존 게이트 유지.
- `.env.example`: `NEXT_PUBLIC_WEB_URL` 문서화(쉼표 오타 경고 주석).

## 검증 (로컬 `next build && next start`)
| 요청 | 결과 |
|---|---|
| Discordbot UA `/diary/74` | **200**, og 태그 포함 (기존 307) |
| 일반 UA `/diary/74` | **307** → `/diary?loginRequired=true` (사람 게이트 유지) |
| 로컬 og:image | `https://1day1streak.com/api/og` (정상 URL — 쉼표는 Vercel env 문제 확정) |

tsc · lint(0 errors) · vitest(125) · knip · build 모두 통과.

## 배포 후 남는 조치
- **[운영]** Vercel dev `NEXT_PUBLIC_WEB_URL` 쉼표→점 수정 (1번, 이미지 복구의 결정타)
- **[서버]** 공개 일지 비인증 GET 허용 (3번, 상세 OG용) — 별도 지시 대기