### PR TITLE
feat: 사용 가이드 페이지 추가 및 배너·설정 진입점 연결

### DIFF
--- a/src/app.constants/consts/homeData.ts
+++ b/src/app.constants/consts/homeData.ts
@@ -11,12 +11,12 @@ export interface HomeMainBanner {
 
 export const HOME_MAIN_BANNERS: HomeMainBanner[] = [
   {
-    id: 'popular-challenge',
-    kind: 'HOT',
-    title: '7월 챌린지 시즌\n오픈!',
-    subtitle: '함께 도전할 챌린저를 찾아보세요',
+    id: 'usage-guide',
+    kind: 'TIP',
+    title: '1D1S가\n처음이라면',
+    subtitle: '5단계로 시작하는 사용 가이드 보기',
     gradient: 'linear-gradient(135deg, #ff8a65 0%, #ff5722 100%)',
-    href: '/challenge',
+    href: '/guide',
   },
   {
     id: 'community-diary',

--- a/src/app.feature/guide/components/GuidePhoneMock.tsx
+++ b/src/app.feature/guide/components/GuidePhoneMock.tsx
@@ -1,0 +1,413 @@
+import { cn } from '@module/utils/cn';
+import { Camera, Heart, MessageCircle, Search } from 'lucide-react';
+import React from 'react';
+
+import type { GuideMockKey } from '../consts/guideData';
+
+/** 목업을 담는 미니 폰 프레임 (순수 프레젠테이션) */
+function GuidePhone({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div
+      className={cn(
+        'w-[236px] shrink-0 rounded-[26px] border border-gray-200',
+        'bg-white p-2 shadow-[0_12px_30px_rgba(0,0,0,0.1)]'
+      )}
+    >
+      <div className="overflow-hidden rounded-[19px] bg-gray-50">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/** 미니 진행률 링 */
+function MiniRing({
+  pct,
+  size = 22,
+  stroke = 3,
+}: {
+  pct: number;
+  size?: number;
+  stroke?: number;
+}): React.ReactElement {
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  return (
+    <span
+      className="relative inline-flex items-center justify-center"
+      style={{ width: size, height: size }}
+    >
+      <svg width={size} height={size} className="-rotate-90">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          className="stroke-gray-100"
+          strokeWidth={stroke}
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          className="stroke-main-800"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={c}
+          strokeDashoffset={c * (1 - pct / 100)}
+        />
+      </svg>
+      <span className="text-main-800 absolute text-[8px] font-extrabold">
+        {pct}
+      </span>
+    </span>
+  );
+}
+
+const TONE: Record<string, string> = {
+  orange: 'bg-main-300',
+  mint: 'bg-mint-200',
+  blue: 'bg-blue-200',
+};
+
+function MockBrowse(): React.ReactElement {
+  const items = [
+    { t: '아침 30분 러닝 크루', c: '운동', tone: 'orange', s: '8/10명', on: true },
+    { t: '하루 한 권 책 읽기', c: '독서', tone: 'mint', s: '12/20명' },
+    { t: '물 2L 마시기', c: '건강', tone: 'blue', s: '1/1명' },
+  ];
+  return (
+    <div className="p-3">
+      <div
+        className={cn(
+          'mb-3 flex items-center gap-1.5 rounded-full border',
+          'border-gray-200 bg-white px-3 py-[7px]'
+        )}
+      >
+        <Search className="h-3 w-3 text-gray-400" />
+        <span className="text-[10.5px] font-semibold text-gray-400">
+          챌린지 검색
+        </span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {items.map((it) => (
+          <div
+            key={it.t}
+            className={cn(
+              'flex gap-2 rounded-[12px] border bg-white p-2',
+              it.on
+                ? 'border-main-800 shadow-[0_3px_12px_rgba(255,89,0,0.14)]'
+                : 'border-gray-200'
+            )}
+          >
+            <span
+              className={cn(
+                'h-[42px] w-[42px] shrink-0 rounded-[9px]',
+                TONE[it.tone]
+              )}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[11px] font-extrabold text-gray-900">
+                {it.t}
+              </div>
+              <div className="mt-[3px] text-[9px] font-semibold text-gray-400">
+                {it.c} · {it.s}
+              </div>
+            </div>
+            <span
+              className={cn(
+                'self-center rounded-full px-2.5 py-[5px]',
+                'text-[9.5px] font-extrabold whitespace-nowrap',
+                it.on
+                  ? 'bg-main-800 text-white'
+                  : 'bg-gray-100 text-gray-500'
+              )}
+            >
+              {it.on ? '참여' : '보기'}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MockCreateField({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}): React.ReactElement {
+  return (
+    <div className="mb-[9px]">
+      <div className="mb-1 text-[9px] font-bold text-gray-500">{label}</div>
+      <div
+        className={cn(
+          'rounded-[9px] border bg-white px-2.5 py-2',
+          'text-[10.5px] font-bold',
+          accent
+            ? 'border-main-800 text-main-800'
+            : 'border-gray-200 text-gray-800'
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function MockCreate(): React.ReactElement {
+  return (
+    <div className="p-[13px]">
+      <div className="mb-3 text-[11.5px] font-extrabold text-gray-900">
+        새 챌린지 만들기
+      </div>
+      <MockCreateField label="챌린지 이름" value="아침 30분 러닝 크루" accent />
+      <MockCreateField label="기간" value="2026.07.01 ~ 07.31" />
+      <div className="mb-[9px]">
+        <div className="mb-1 text-[9px] font-bold text-gray-500">참여 방식</div>
+        <div className="flex gap-1">
+          <span
+            className={cn(
+              'bg-main-800 flex-1 rounded-[8px] py-1.5 text-center',
+              'text-[9.5px] font-extrabold text-white'
+            )}
+          >
+            단체
+          </span>
+          <span
+            className={cn(
+              'flex-1 rounded-[8px] bg-gray-100 py-1.5 text-center',
+              'text-[9.5px] font-bold text-gray-500'
+            )}
+          >
+            개인
+          </span>
+        </div>
+      </div>
+      <div
+        className={cn(
+          'mb-3 flex items-center justify-between rounded-[9px] border',
+          'border-main-300 bg-main-100 px-2.5 py-2'
+        )}
+      >
+        <span className="text-[10px] font-bold text-gray-700">
+          사진 인증 필수
+        </span>
+        <span className="bg-main-800 relative h-[15px] w-[26px] rounded-full">
+          <span className="absolute top-[2px] right-[2px] h-[11px] w-[11px] rounded-full bg-white" />
+        </span>
+      </div>
+      <div
+        className={cn(
+          'bg-main-800 rounded-[10px] py-2.5 text-center',
+          'text-[11px] font-extrabold text-white'
+        )}
+      >
+        만들기
+      </div>
+    </div>
+  );
+}
+
+function MockDiary(): React.ReactElement {
+  return (
+    <div className="p-[13px]">
+      <div className="mb-3 text-[11.5px] font-extrabold text-gray-900">
+        오늘의 일지
+      </div>
+      <div className="bg-main-300 relative mb-2.5 h-[78px] overflow-hidden rounded-[11px]">
+        <span className="absolute top-2 left-2 inline-flex items-center gap-1 rounded-full bg-white/90 px-2 py-1">
+          <Camera className="text-main-800 h-3 w-3" />
+          <span className="text-main-800 text-[9px] font-extrabold">
+            사진 인증
+          </span>
+        </span>
+        <span
+          className={cn(
+            'absolute right-[7px] bottom-[7px] inline-flex items-center',
+            'gap-1.5 rounded-full bg-white/95 py-[3px] pr-2 pl-1'
+          )}
+        >
+          <MiniRing pct={100} />
+          <span className="text-main-800 text-[9px] font-extrabold">
+            달성 100%
+          </span>
+        </span>
+      </div>
+      <div
+        className={cn(
+          'mb-2 rounded-[10px] border border-gray-200 bg-white',
+          'px-2.5 py-[9px] text-[10.5px] font-bold text-gray-800'
+        )}
+      >
+        오늘도 한강 5km 완주!
+      </div>
+      <div
+        className={cn(
+          'mb-3 rounded-[10px] border border-gray-200 bg-white px-2.5',
+          'py-[9px] text-[9.5px] leading-relaxed text-gray-500'
+        )}
+      >
+        날이 선선해서 페이스가 잘 나왔다. 내일도 이 시간에!
+      </div>
+      <div
+        className={cn(
+          'bg-main-800 rounded-[10px] py-2.5 text-center',
+          'text-[11px] font-extrabold text-white'
+        )}
+      >
+        기록 저장
+      </div>
+    </div>
+  );
+}
+
+function MockTogether(): React.ReactElement {
+  const rows = [
+    { r: 1, n: '새벽러너', s: 10, tone: 'orange', medal: 'bg-[#FCD34D]' },
+    { r: 2, n: '러닝왕', s: 8, tone: 'blue', medal: 'bg-gray-300' },
+    { r: 3, n: '달리는곰', s: 7, tone: 'mint', medal: 'bg-[#E2A56E]' },
+  ];
+  return (
+    <div className="p-[13px]">
+      <div className="mb-3 text-[11.5px] font-extrabold text-gray-900">
+        이번 주 리더보드
+      </div>
+      <div className="mb-3 flex flex-col gap-[7px]">
+        {rows.map((m) => (
+          <div
+            key={m.r}
+            className={cn(
+              'flex items-center gap-2 rounded-[10px] border',
+              'border-gray-100 bg-white px-2.5 py-[7px]'
+            )}
+          >
+            <span
+              className={cn(
+                'flex h-[18px] w-[18px] items-center justify-center',
+                'rounded-full text-[9px] font-extrabold text-white',
+                m.medal
+              )}
+            >
+              {m.r}
+            </span>
+            <span
+              className={cn(
+                'h-6 w-6 shrink-0 rounded-full',
+                TONE[m.tone]
+              )}
+            />
+            <span className="flex-1 text-[10.5px] font-extrabold text-gray-900">
+              {m.n}
+            </span>
+            <span className="text-[9px] font-bold text-gray-400">
+              {m.s}일 연속
+            </span>
+          </div>
+        ))}
+      </div>
+      <div
+        className={cn(
+          'flex items-center gap-2 rounded-[10px] border',
+          'border-main-300 bg-main-100 px-2.5 py-[9px]'
+        )}
+      >
+        <span className="text-main-800 inline-flex items-center gap-1 text-[10px] font-extrabold">
+          <Heart className="h-3 w-3" />
+          24
+        </span>
+        <span className="inline-flex items-center gap-1 text-[10px] font-extrabold text-gray-500">
+          <MessageCircle className="h-3 w-3 text-gray-400" />3
+        </span>
+        <span
+          className={cn(
+            'border-main-800 ml-auto rounded-full border bg-white',
+            'text-main-800 px-2 py-1 text-[9px] font-extrabold'
+          )}
+        >
+          콕 찌르기
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function MockStats(): React.ReactElement {
+  const bars = [1, 2, 0, 3, 2, 4, 1, 2, 3, 5];
+  const max = Math.max(...bars);
+  const peak = bars.indexOf(max);
+  return (
+    <div className="p-[13px]">
+      <div className="mb-3 grid grid-cols-2 gap-[7px]">
+        {[
+          ['참여율', '72%'],
+          ['목표 완료', '68%'],
+        ].map(([l, v]) => (
+          <div
+            key={l}
+            className="rounded-[10px] border border-gray-200 bg-white px-2.5 py-[9px]"
+          >
+            <div className="text-[8.5px] font-bold text-gray-500">{l}</div>
+            <div className="mt-0.5 text-[18px] font-extrabold tracking-tight text-gray-900">
+              {v}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="rounded-[11px] border border-gray-200 bg-white p-[11px]">
+        <div className="mb-2 text-[9.5px] font-extrabold text-gray-700">
+          날짜별 일지 추이
+        </div>
+        <div className="grid h-[62px] grid-cols-10 items-end gap-1">
+          {bars.map((c, i) => (
+            <div key={i} className="flex h-full items-end">
+              <div
+                className={cn(
+                  'w-full rounded-[4px]',
+                  c === 0
+                    ? 'bg-gray-100'
+                    : i === peak
+                      ? 'bg-main-800'
+                      : 'bg-main-300'
+                )}
+                style={{
+                  height: `${Math.max((c / max) * 100, c > 0 ? 12 : 5)}%`,
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const MOCKS: Record<GuideMockKey, () => React.ReactElement> = {
+  browse: MockBrowse,
+  create: MockCreate,
+  diary: MockDiary,
+  together: MockTogether,
+  stats: MockStats,
+};
+
+export function GuidePhoneMock({
+  mock,
+}: {
+  mock: GuideMockKey;
+}): React.ReactElement {
+  const Mock = MOCKS[mock];
+  return (
+    <GuidePhone>
+      <Mock />
+    </GuidePhone>
+  );
+}

--- a/src/app.feature/guide/consts/guideData.ts
+++ b/src/app.feature/guide/consts/guideData.ts
@@ -1,0 +1,113 @@
+import {
+  CalendarDays,
+  Camera,
+  Flag,
+  Flame,
+  Heart,
+  type LucideIcon,
+  Plus,
+  Search,
+  Sparkles,
+  Users,
+} from 'lucide-react';
+
+export type GuideMockKey =
+  | 'browse'
+  | 'create'
+  | 'diary'
+  | 'together'
+  | 'stats';
+
+export interface GuideStep {
+  n: string;
+  icon: LucideIcon;
+  kicker: string;
+  title: string;
+  body: string;
+  mock: GuideMockKey;
+}
+
+interface GuideItem {
+  icon: LucideIcon;
+  title: string;
+  desc: string;
+}
+
+export const GUIDE_SUMMARY: GuideItem[] = [
+  {
+    icon: Flag,
+    title: '참여 또는 생성',
+    desc: '챌린지를 찾아 참여하거나 직접 만들어요.',
+  },
+  {
+    icon: CalendarDays,
+    title: '매일 일지 기록',
+    desc: '하루하루 달성률과 사진으로 남겨요.',
+  },
+  {
+    icon: Sparkles,
+    title: '함께, 그리고 통계',
+    desc: '동료와 응원하고 성장을 확인해요.',
+  },
+];
+
+export const GUIDE_STEPS: GuideStep[] = [
+  {
+    n: '01',
+    icon: Search,
+    kicker: '둘러보기',
+    title: '마음에 드는 챌린지에 참여하기',
+    body: '운동·독서·건강·학습 등 다양한 챌린지를 둘러보고, 혼자 하는 개인 챌린지든 여럿이 함께하는 단체 챌린지든 마음에 드는 걸 골라 참여하세요.',
+    mock: 'browse',
+  },
+  {
+    n: '02',
+    icon: Plus,
+    kicker: '만들기',
+    title: '나만의 챌린지 만들기',
+    body: '원하는 챌린지가 없다면 직접 만들어요. 이름·기간·목표를 정하고, 개인/단체와 사진 인증 여부만 설정하면 끝. 친구를 초대해 함께 도전할 수도 있어요.',
+    mock: 'create',
+  },
+  {
+    n: '03',
+    icon: CalendarDays,
+    kicker: '기록하기',
+    title: '매일 일지로 하루를 기록하기',
+    body: '1D1S의 핵심이에요. 챌린지마다 매일 일지를 남기며 오늘의 달성률을 체크하고, 사진과 짧은 글로 하루를 기록하세요. 기록이 쌓일수록 연속 스트릭이 이어집니다.',
+    mock: 'diary',
+  },
+  {
+    n: '04',
+    icon: Users,
+    kicker: '함께하기',
+    title: '동료들과 함께 성장하기',
+    body: '같은 챌린지 참여자들의 일지에 좋아요와 댓글을 남기고, 뜸한 동료는 콕 찌르기로 응원하세요. 리더보드에서 서로의 연속 기록을 확인하며 자극받을 수 있어요.',
+    mock: 'together',
+  },
+  {
+    n: '05',
+    icon: Sparkles,
+    kicker: '돌아보기',
+    title: '통계로 성장을 확인하기',
+    body: '참여율, 목표 완료율, 날짜별 일지 추이를 한눈에. 내가 얼마나 꾸준했는지 데이터로 돌아보고, 다음 챌린지의 동기로 삼으세요.',
+    mock: 'stats',
+  },
+];
+
+export const GUIDE_TIPS: GuideItem[] = [
+  {
+    icon: Flame,
+    title: '스트릭을 지켜요',
+    desc: '하루도 빠지지 않고 기록하면 연속 스트릭이 이어집니다. 짧게라도 매일 남기는 게 비결.',
+  },
+  {
+    icon: Camera,
+    title: '사진으로 인증해요',
+    desc: '사진 인증 챌린지는 오늘의 활동을 담은 한 장이면 충분해요.',
+  },
+  {
+    icon: Heart,
+    title: '서로 응원해요',
+    desc: '동료의 일지에 반응을 남기면 나도 힘이 나요. 콕 찌르기로 서로를 챙겨보세요.',
+  },
+];

--- a/src/app.feature/guide/screen/GuideScreen.tsx
+++ b/src/app.feature/guide/screen/GuideScreen.tsx
@@ -1,0 +1,320 @@
+import { Text } from '@1d1s/design-system';
+import { GuidePhoneMock } from '@feature/guide/components/GuidePhoneMock';
+import {
+  GUIDE_STEPS,
+  GUIDE_SUMMARY,
+  GUIDE_TIPS,
+  type GuideStep,
+} from '@feature/guide/consts/guideData';
+import { cn } from '@module/utils/cn';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import React from 'react';
+
+function GuideStepBlock({
+  step,
+  index,
+}: {
+  step: GuideStep;
+  index: number;
+}): React.ReactElement {
+  const StepIcon = step.icon;
+  const flip = index % 2 === 1;
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-8',
+        'lg:flex-row lg:gap-12',
+        flip ? 'lg:flex-row-reverse' : ''
+      )}
+    >
+      <div className="w-full max-w-[420px] min-w-0 lg:flex-1">
+        <div className="mb-4 flex items-center gap-3">
+          <span
+            className={cn(
+              'flex h-11 w-11 shrink-0 items-center justify-center',
+              'bg-main-800 rounded-[13px] shadow-[0_6px_16px_rgba(255,89,0,0.28)]'
+            )}
+          >
+            <StepIcon className="h-5 w-5 text-white" strokeWidth={2} />
+          </span>
+          <div>
+            <Text
+              size="caption1"
+              weight="extrabold"
+              className="text-main-800 block"
+            >
+              STEP {step.n}
+            </Text>
+            <Text
+              size="caption1"
+              weight="semibold"
+              className="block text-gray-400"
+            >
+              {step.kicker}
+            </Text>
+          </div>
+        </div>
+        <Text
+          as="h3"
+          size="heading2"
+          weight="extrabold"
+          className="mb-3 block break-keep text-gray-900"
+        >
+          {step.title}
+        </Text>
+        <Text
+          as="p"
+          size="body2"
+          weight="regular"
+          className="block leading-relaxed break-keep text-gray-600"
+        >
+          {step.body}
+        </Text>
+      </div>
+      <div className="shrink-0">
+        <GuidePhoneMock mock={step.mock} />
+      </div>
+    </div>
+  );
+}
+
+export default function GuideScreen(): React.ReactElement {
+  return (
+    <div className="min-h-screen w-full">
+      {/* 모바일 sticky 헤더 — 사용 가이드. 네비 탭이 있는 최상위 화면이므로
+          홈/챌린지/일지처럼 뒤로가기 없이 타이틀만 노출한다. */}
+      <div
+        className={cn(
+          'sticky top-0 z-20 flex items-center justify-between',
+          'gap-3 border-b border-gray-100',
+          'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
+          'backdrop-blur lg:hidden'
+        )}
+      >
+        <Text
+          as="p"
+          size="heading1"
+          weight="extrabold"
+          className="tracking-[-0.5px] text-gray-900"
+        >
+          사용 가이드
+        </Text>
+      </div>
+
+      <div className="mx-auto w-full max-w-[960px] px-5 lg:px-6">
+        {/* 히어로 */}
+        <header
+          className={cn(
+            'animate-pop-in -mx-5 mb-2 px-5 pt-14 pb-16 text-center lg:-mx-6',
+            'lg:px-6 lg:pt-20 lg:pb-20',
+            'bg-[linear-gradient(160deg,var(--main-100)_0%,var(--gray-50)_70%)]'
+          )}
+        >
+          <span
+            className={cn(
+              'bg-main-800 mb-5 inline-block rounded-full px-3.5 py-1.5',
+              'text-[12.5px] font-extrabold tracking-wide text-white'
+            )}
+          >
+            1 Day 1 Streak
+          </span>
+          <Text
+            as="h1"
+            size="display1"
+            weight="extrabold"
+            className="mx-auto mb-4 block break-keep text-gray-900"
+          >
+            작은 기록이 쌓여
+            <br />
+            <span className="text-main-800">꾸준함</span>이 됩니다
+          </Text>
+          <Text
+            as="p"
+            size="body1"
+            weight="regular"
+            className="mx-auto block max-w-[520px] leading-relaxed break-keep text-gray-600"
+          >
+            1D1S는 챌린지에 참여하고 매일 일지를 남기며 나의 도전을 기록하는
+            서비스예요. 아래로 스크롤하며 사용법을 익혀보세요.
+          </Text>
+        </header>
+
+        {/* 3줄 요약 */}
+        <section className="animate-pop-in -mt-9">
+          <div className="grid gap-3.5 sm:grid-cols-3">
+            {GUIDE_SUMMARY.map((c) => {
+              const CardIcon = c.icon;
+              return (
+                <div
+                  key={c.title}
+                  className={cn(
+                    'rounded-2 border border-gray-200 bg-white p-5',
+                    'shadow-[0_2px_10px_rgba(0,0,0,0.04)]'
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'mb-3 flex h-9 w-9 items-center justify-center',
+                      'bg-main-100 rounded-[11px]'
+                    )}
+                  >
+                    <CardIcon className="text-main-800 h-[19px] w-[19px]" />
+                  </span>
+                  <Text
+                    size="body1"
+                    weight="extrabold"
+                    className="mb-1 block text-gray-900"
+                  >
+                    {c.title}
+                  </Text>
+                  <Text
+                    size="caption2"
+                    weight="regular"
+                    className="block leading-relaxed break-keep text-gray-500"
+                  >
+                    {c.desc}
+                  </Text>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* 스텝 */}
+        <section className="pt-14 pb-6">
+          <div className="animate-pop-in mb-14 text-center">
+            <Text
+              size="caption1"
+              weight="extrabold"
+              className="text-main-800 mb-2 block tracking-wide"
+            >
+              HOW IT WORKS
+            </Text>
+            <Text
+              as="h2"
+              size="heading1"
+              weight="extrabold"
+              className="block tracking-tight text-gray-900"
+            >
+              5단계로 시작하기
+            </Text>
+          </div>
+          <div className="flex flex-col gap-16 lg:gap-20">
+            {GUIDE_STEPS.map((step, i) => (
+              <div key={step.n} className="animate-pop-in">
+                <GuideStepBlock step={step} index={i} />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 팁 */}
+        <section
+          className={cn(
+            'animate-pop-in -mx-5 mt-16 border-y border-gray-200 bg-white',
+            'px-5 py-16 lg:-mx-6 lg:px-6'
+          )}
+        >
+          <Text
+            as="h2"
+            size="heading1"
+            weight="extrabold"
+            className="mb-9 block text-center tracking-tight text-gray-900"
+          >
+            더 잘 활용하는 팁
+          </Text>
+          <div className="grid gap-4.5 sm:grid-cols-3">
+            {GUIDE_TIPS.map((t) => {
+              const TipIcon = t.icon;
+              return (
+                <div
+                  key={t.title}
+                  className={cn(
+                    'rounded-2 flex h-full gap-3.5 border border-gray-100',
+                    'bg-gray-50 p-5'
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'flex h-10 w-10 shrink-0 items-center justify-center',
+                      'rounded-[11px] border border-gray-200 bg-white'
+                    )}
+                  >
+                    <TipIcon className="text-main-800 h-[19px] w-[19px]" />
+                  </span>
+                  <div>
+                    <Text
+                      size="body1"
+                      weight="extrabold"
+                      className="mb-1.5 block text-gray-900"
+                    >
+                      {t.title}
+                    </Text>
+                    <Text
+                      size="caption2"
+                      weight="regular"
+                      className="block leading-relaxed break-keep text-gray-500"
+                    >
+                      {t.desc}
+                    </Text>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* 클로징 CTA */}
+        <section className="animate-pop-in pt-20 pb-24 text-center">
+          <div
+            className={cn(
+              'rounded-4 px-8 py-14 text-white',
+              'shadow-[0_20px_48px_rgba(255,89,0,0.24)]',
+              'bg-[linear-gradient(135deg,var(--main-600)_0%,var(--main-800)_100%)]'
+            )}
+          >
+            <Text
+              as="h2"
+              size="heading1"
+              weight="extrabold"
+              className="mb-3.5 block break-keep text-white"
+            >
+              오늘의 첫 기록,
+              <br />
+              지금 시작해볼까요?
+            </Text>
+            <Text
+              as="p"
+              size="body2"
+              weight="regular"
+              className="mx-auto mb-7 block max-w-[420px] leading-relaxed break-keep text-white/90"
+            >
+              마음에 드는 챌린지를 찾고, 오늘 하루를 기록하는 것부터. 꾸준함은
+              그렇게 시작돼요.
+            </Text>
+            <Link
+              href="/challenge"
+              className={cn(
+                'inline-flex items-center gap-2 rounded-full bg-white',
+                'text-main-800 px-7 py-3.5 text-[15.5px] font-extrabold',
+                'shadow-[0_6px_18px_rgba(0,0,0,0.12)]',
+                'transition hover:brightness-95'
+              )}
+            >
+              챌린지 둘러보기
+              <ArrowRight className="h-[17px] w-[17px]" strokeWidth={2.4} />
+            </Link>
+          </div>
+          <Text
+            size="caption2"
+            weight="regular"
+            className="mt-10 block text-gray-400"
+          >
+            1 Day 1 Streak — 매일의 기록이 만드는 변화
+          </Text>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/member/settings/screen/SettingsScreen.tsx
+++ b/src/app.feature/member/settings/screen/SettingsScreen.tsx
@@ -8,7 +8,14 @@ import { ConfirmDialog } from '@feature/member/settings/components/ConfirmDialog
 import { notifyApiError } from '@module/api/errorNotify';
 import { toast } from '@module/providers/toast';
 import { cn } from '@module/utils/cn';
-import { Bell, ChevronRight, LogOut, User } from 'lucide-react';
+import {
+  Bell,
+  BookOpen,
+  ChevronRight,
+  HelpCircle,
+  LogOut,
+  User,
+} from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import React, { useState } from 'react';
 
@@ -131,6 +138,26 @@ export default function SettingsScreen(): React.ReactElement {
             label="알림 설정"
             description="알림 수신 항목을 관리해요"
             onClick={() => router.push('/mypage/settings/notifications')}
+          />
+        </section>
+
+        <section
+          className={cn(
+            'overflow-hidden rounded-[14px] border border-gray-200 bg-white'
+          )}
+        >
+          <SettingsRow
+            icon={<BookOpen className="h-5 w-5" />}
+            label="사용 가이드"
+            description="1D1S 사용법을 5단계로 확인해요"
+            onClick={() => router.push('/guide')}
+          />
+          <div className="h-px w-full bg-gray-100" />
+          <SettingsRow
+            icon={<HelpCircle className="h-5 w-5" />}
+            label="문의하기"
+            description="궁금한 점·불편한 점을 알려주세요"
+            onClick={() => router.push('/inquiry')}
           />
         </section>
 

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -1,0 +1,10 @@
+import GuideScreen from '@feature/guide/screen/GuideScreen';
+import React from 'react';
+
+export const metadata = {
+  title: '사용 가이드 | 1Day 1Streak',
+};
+
+export default function GuidePage(): React.ReactElement {
+  return <GuideScreen />;
+}


### PR DESCRIPTION
## 요약
1D1S 사용 가이드 페이지(`/guide`)를 신설하고, 홈·탐색 배너와 마이페이지 설정에서 진입점을 연결합니다. 디자인 시안(claude.ai/design "1D1S 사용 가이드")을 프로젝트 DS 토큰·컴포넌트로 이식했습니다.

## 변경 사항
- **`/guide` 라우트 신설** — 히어로 → 3줄 요약 → 5단계 안내(좌우 교차 + 미니 폰 목업) → 활용 팁 → 클로징 CTA.
  - 최상위 화면이라 챌린지·일지 보드와 **동일한 뒤로가기 없는 헤더** 정책. 데스크톱은 글로벌 `AppTopNav`, 모바일은 sticky 타이틀 헤더(뒤로가기 없음).
  - **비로그인 열람 가능** — 미들웨어 보호 라우트에 미포함, `○ (Static)` 정적 프리렌더.
  - 서버 컴포넌트로 구현(진입 애니메이션은 기존 `animate-pop-in` CSS 재사용, JS/클라이언트 컴포넌트 불필요). DS `Text`·토큰 클래스 우선, 아이콘은 `lucide-react`.
- **배너 캐러셀 첫 슬라이드 → `/guide`** — `HomeWarmBanner`(홈·탐색 공용) 첫 슬라이드를 가이드 배너로 교체. 슬라이드 수 유지로 레이아웃 시프트 없음.
- **마이페이지 설정** — "사용 가이드"(`/guide`)·"문의하기"(기존 `/inquiry`) 바로가기 추가.

## 검증
- ✅ `tsc --noEmit` · ✅ `eslint` · ✅ `knip` · ✅ `vitest` (125/125) · ✅ `next build`
- `/guide` = `○ (Static)` 확인.
- ⚠️ 브라우저 렌더 확인은 하지 않았습니다(프로젝트 정책상 로컬 브라우저 확인은 리뷰어가 진행). 반응형(모바일/데스크톱)·다크 여부는 육안 확인 필요.

## 반응형/접근성
- 모바일 1열 → `sm` 3열(요약·팁), 스텝은 모바일 세로 → `lg` 좌우 교차.
- 문서 내 단일 `h1`(히어로), 섹션은 `h2`/스텝 `h3`으로 위계 구성.