### PR TITLE
fix: 공식 챌린지만 전용 OG 유지, 실패하는 비인증 fetch 제거

### DIFF
--- a/src/app.module/metadata/seo.ts
+++ b/src/app.module/metadata/seo.ts
@@ -35,21 +35,6 @@ export function toAbsoluteUrl(path: string): string {
   }
 }
 
-// 마크다운/HTML 태그를 제거하고 미리보기용으로 한 줄 요약을 만든다.
-export function toMetaDescription(
-  raw: string | null | undefined,
-  fallback = SITE_DESCRIPTION
-): string {
-  const text = (raw ?? '')
-    .replace(/<[^>]*>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (!text) {
-    return fallback;
-  }
-  return text.length > 120 ? `${text.slice(0, 119)}…` : text;
-}
-
 interface ResourceMetadataInput {
   title: string;
   description: string;
@@ -95,22 +80,35 @@ export function buildResourceMetadata({
   };
 }
 
-// generateMetadata 전용 비인증 GET. 공개 리소스만 응답하며, 인증 필요(401)·
-// 삭제(404)·네트워크 오류는 모두 null 로 폴백해 메타를 기본값으로 되돌린다.
-export async function fetchPublicResource<T>(path: string): Promise<T | null> {
+export interface OfficialChallengeMeta {
+  challengeId: number;
+  title: string;
+  thumbnailImage?: string | null;
+}
+
+// 공식 챌린지만 비인증 조회가 열려 있다(/challenges/offset?challengeType=
+// OFFICIAL). 개별 /challenges/{id} 는 비인증 400(AUTH-002)이라 목록에서 id 로
+// 찾는다. 공식 챌린지는 큐레이션 대상이라 수가 적어 한 페이지(size=100)면
+// 충분하다. ponytail: 100개 초과 시에만 페이지네이션 추가.
+export async function fetchOfficialChallenge(
+  id: string
+): Promise<OfficialChallengeMeta | null> {
   if (!API_BASE_URL) {
     return null;
   }
   try {
-    const res = await fetch(`${API_BASE_URL}${path}`, {
-      headers: { accept: 'application/json' },
-      next: { revalidate: 300 },
-    });
+    const res = await fetch(
+      `${API_BASE_URL}/challenges/offset?challengeType=OFFICIAL&size=100`,
+      { headers: { accept: 'application/json' }, next: { revalidate: 300 } }
+    );
     if (!res.ok) {
       return null;
     }
-    const body = (await res.json()) as { data?: T };
-    return body.data ?? null;
+    const body = (await res.json()) as {
+      data?: { items?: OfficialChallengeMeta[] };
+    };
+    const items = body.data?.items ?? [];
+    return items.find((item) => String(item.challengeId) === id) ?? null;
   } catch {
     return null;
   }

--- a/src/app/challenge/[id]/page.tsx
+++ b/src/app/challenge/[id]/page.tsx
@@ -1,11 +1,10 @@
 import { ChallengeDetailSkeleton } from '@component/skeletons/ChallengeDetailSkeleton';
-import { ChallengeDetailResponse } from '@feature/challenge/board/type/challenge';
 import { ChallengeDetailScreen } from '@feature/challenge/detail/screen/ChallengeDetailScreen';
 import {
   buildResourceMetadata,
-  fetchPublicResource,
+  fetchOfficialChallenge,
+  SITE_DESCRIPTION,
   SITE_TITLE,
-  toMetaDescription,
 } from '@module/metadata/seo';
 import type { Metadata } from 'next';
 import React, { Suspense } from 'react';
@@ -15,26 +14,25 @@ interface ChallengeDetailProps {
 }
 
 /**
- * 공개(PUBLIC)·공식(OFFICIAL) 챌린지만 상세 메타를 채운다. 비공개(PRIVATE)·
- * 삭제·인증 필요·조회 실패는 빈 객체를 반환해 루트 기본 메타(기본 OG)로
- * 폴백한다. 썸네일이 있으면 OG 이미지로 쓰고 없으면 기본 이미지로 폴백.
+ * 공식(OFFICIAL) 챌린지만 전용 OG 를 채운다. 개별 챌린지 상세는 비인증 조회가
+ * 막혀 있어(400 AUTH-002) 목록(/challenges/offset?challengeType=OFFICIAL)에서
+ * id 로 찾는다. 일반(비공식)·비공개·조회 실패는 빈 객체를 반환해 루트 기본
+ * 메타(기본 OG)로 폴백한다. 배너/썸네일이 있으면 OG 이미지로, 없으면 기본
+ * 이미지. 목록엔 설명이 없어 사이트 설명을 쓴다.
  */
 export async function generateMetadata({
   params,
 }: ChallengeDetailProps): Promise<Metadata> {
   const { id } = await params;
-  const detail = await fetchPublicResource<ChallengeDetailResponse>(
-    `/challenges/${id}`
-  );
-  const summary = detail?.challengeSummary;
-  if (!summary || summary.challengeType === 'PRIVATE' || summary.deleted) {
+  const official = await fetchOfficialChallenge(id);
+  if (!official) {
     return {};
   }
 
   return buildResourceMetadata({
-    title: `${summary.title} | ${SITE_TITLE}`,
-    description: toMetaDescription(detail.challengeDetail.description),
-    imageUrl: summary.thumbnailImage,
+    title: `${official.title} | ${SITE_TITLE}`,
+    description: SITE_DESCRIPTION,
+    imageUrl: official.thumbnailImage,
   });
 }
 

--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -1,38 +1,12 @@
-import { DiaryDetail } from '@feature/diary/board/type/diary';
 import { DiaryDetailScreen } from '@feature/diary/detail/screen/DiaryDetailScreen';
-import {
-  buildResourceMetadata,
-  fetchPublicResource,
-  SITE_TITLE,
-  toMetaDescription,
-} from '@module/metadata/seo';
-import type { Metadata } from 'next';
 import React from 'react';
 
 interface DiaryDetailProps {
   params: Promise<{ id: string }>;
 }
 
-/**
- * 공개(isPublic) 일지만 상세 메타를 채운다. 비공개·삭제·인증 필요·조회 실패는
- * 빈 객체를 반환해 루트 기본 메타(기본 OG)로 폴백한다. 썸네일(없으면 첫
- * 이미지)이 있으면 OG 이미지로 쓰고 없으면 기본 이미지로 폴백.
- */
-export async function generateMetadata({
-  params,
-}: DiaryDetailProps): Promise<Metadata> {
-  const { id } = await params;
-  const diary = await fetchPublicResource<DiaryDetail>(`/diaries/${id}`);
-  if (!diary || !diary.isPublic) {
-    return {};
-  }
-
-  return buildResourceMetadata({
-    title: `${diary.title} | ${SITE_TITLE}`,
-    description: toMetaDescription(diary.content),
-    imageUrl: diary.thumbnailUrl ?? diary.imgUrl?.[0] ?? null,
-  });
-}
+// 일지 상세는 비인증 조회가 막혀 있어(400 AUTH-002) 개별 메타를 채울 수 없다.
+// generateMetadata 를 두지 않고 루트 레이아웃의 기본 OG 를 그대로 상속한다.
 
 /**
  * 상세 데이터는 클라이언트 React Query(useDiaryDetail)로 이관했다.


### PR DESCRIPTION
## 배경

서버가 비인증 GET을 막고 있어(`/diaries/{id}`·`/challenges/{id}` → 400 `AUTH-002`) 일지·일반 챌린지 상세의 개별 메타를 채울 수 없다. 서버는 열지 않기로 확정됨. 실패가 뻔한 fetch·폴백 구조를 걷어내고 정책을 단순화한다.

## 비인증 조회 실측 (dev API)

| 엔드포인트 | 결과 |
| --- | --- |
| `/challenges/offset?challengeType=OFFICIAL` | ✅ 200 (items: title·thumbnailImage 포함) |
| `/challenges/offset?challengeType=PUBLIC` | ✅ 200 |
| `/challenges/{id}` | ❌ 400 `AUTH-002` |
| `/diaries/{id}` | ❌ 400 `AUTH-002` |

개별 상세는 막혀 있지만 **offset 목록은 비인증으로 열려 있음** → 공식 챌린지는 목록에서 id로 찾아 메타를 채운다.

## 새 OG 정책

1. **기본: 모든 페이지 기본 OG** (일지 상세 포함). 개별 fetch→실패→폴백 구조 제거.
2. **공식 챌린지만 전용 OG**: `/challenges/offset?challengeType=OFFICIAL`에서 id로 찾아 제목·썸네일(있으면 og:image, 없으면 기본 이미지). 목록엔 설명이 없어 사이트 설명 사용.
3. **일반(비공식) 챌린지·일지**: 기본 OG.

## 변경

- `diary/[id]/page.tsx`: `generateMetadata` 제거 → 루트 레이아웃 기본 OG 상속
- `challenge/[id]/page.tsx`: 공식 챌린지만 `fetchOfficialChallenge`로 전용 OG, 나머지는 `{}` 폴백
- `seo.ts`: 죽은 `fetchPublicResource`·`toMetaDescription` 제거, `fetchOfficialChallenge` 추가
- `twitter:card summary_large_image`·절대 URL·미들웨어 OG 크롤러 통과는 유지

## 검증

tsc ✅ / lint ✅ (0 errors) / vitest ✅ 125 / knip ✅ / build ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SEO metadata support for official challenge pages, including titles and thumbnail images.
  * Official challenge metadata is retrieved when available and safely omitted when unavailable.

* **Bug Fixes**
  * Prevented private, deleted, or unavailable challenge details from appearing in page metadata.
  * Diary detail pages now consistently inherit default social preview metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->