### PR TITLE
fix: 가이드·문의 헤더를 디자인시스템 MobileHeader로 통일

### DIFF
--- a/src/app.feature/guide/components/GuideMobileHeader.tsx
+++ b/src/app.feature/guide/components/GuideMobileHeader.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { MobileHeader } from '@1d1s/design-system';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+/**
+ * 사용 가이드(모바일) 헤더.
+ * 마이페이지 설정에서 진입하는 서브페이지이므로 다른 서브페이지와 동일하게
+ * DS `MobileHeader`(뒤로가기 + 타이틀)를 사용한다. RSC인 GuideScreen을 그대로
+ * 두기 위해 router.back 을 쓰는 이 헤더만 client 리프로 분리한다.
+ */
+export function GuideMobileHeader(): React.ReactElement {
+  const router = useRouter();
+  return <MobileHeader title="사용 가이드" onBack={() => router.back()} />;
+}

--- a/src/app.feature/guide/screen/GuideScreen.tsx
+++ b/src/app.feature/guide/screen/GuideScreen.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@1d1s/design-system';
+import { GuideMobileHeader } from '@feature/guide/components/GuideMobileHeader';
 import { GuidePhoneMock } from '@feature/guide/components/GuidePhoneMock';
 import {
   GUIDE_STEPS,
@@ -82,25 +83,9 @@ function GuideStepBlock({
 export default function GuideScreen(): React.ReactElement {
   return (
     <div className="min-h-screen w-full">
-      {/* 모바일 sticky 헤더 — 사용 가이드. 네비 탭이 있는 최상위 화면이므로
-          홈/챌린지/일지처럼 뒤로가기 없이 타이틀만 노출한다. */}
-      <div
-        className={cn(
-          'sticky top-0 z-20 flex items-center justify-between',
-          'gap-3 border-b border-gray-100',
-          'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
-          'backdrop-blur lg:hidden'
-        )}
-      >
-        <Text
-          as="p"
-          size="heading1"
-          weight="extrabold"
-          className="tracking-[-0.5px] text-gray-900"
-        >
-          사용 가이드
-        </Text>
-      </div>
+      {/* 모바일 헤더 — 설정에서 진입하는 서브페이지이므로 다른 서브페이지와
+          동일하게 DS MobileHeader(뒤로가기)를 사용한다. */}
+      <GuideMobileHeader />
 
       <div className="mx-auto w-full max-w-[960px] px-5 lg:px-6">
         {/* 히어로 */}

--- a/src/app.feature/inquiry/screen/InquiryScreen.tsx
+++ b/src/app.feature/inquiry/screen/InquiryScreen.tsx
@@ -8,154 +8,101 @@ import {
   Button,
   Text,
 } from '@1d1s/design-system';
+import { SubPageShell } from '@component/layout/SubPageShell';
 import { INQUIRY_FAQ_ITEMS } from '@constants/consts/inquiryData';
 import { cn } from '@module/utils/cn';
-import { ArrowLeft, ExternalLink, Mail } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { ExternalLink, Mail } from 'lucide-react';
 import React from 'react';
 
 const INQUIRY_FORM_URL = 'https://forms.gle/yxgnTJdYViRmb2zR6';
 
 export function InquiryScreen(): React.ReactElement {
-  const router = useRouter();
-
   return (
-    <div className="min-h-screen w-full pt-14 lg:pt-0">
-      <div
-        className={cn(
-          'fixed top-0 right-0 left-0 z-30 flex h-14 items-center gap-3',
-          'border-b border-gray-100 bg-white/95 px-4 backdrop-blur',
-          'lg:hidden'
-        )}
-      >
-        <button
-          type="button"
-          aria-label="뒤로가기"
-          onClick={() => router.back()}
-          className={cn(
-            'flex h-8 w-8 items-center justify-center rounded-lg',
-            'text-gray-700 transition-colors hover:bg-gray-100'
-          )}
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <Text
-          size="body1"
-          weight="extrabold"
-          className="flex-1 tracking-[-0.3px] text-gray-900"
-        >
-          문의하기
-        </Text>
-      </div>
+    <SubPageShell
+      title="문의하기"
+      description="궁금한 점이 있으시면 언제든지 문의해주세요."
+    >
+      <div className="flex flex-col gap-3">
+        <section className="rounded-4 border border-gray-200 bg-white">
+          <div className="border-b border-gray-100 px-5 py-4">
+            <Text size="body1" weight="bold" className="text-gray-500">
+              자주 묻는 질문
+            </Text>
+          </div>
 
-      <section className="mx-auto w-full max-w-[980px] p-4 lg:p-6">
-        <div className="hidden border-b border-gray-200 pb-5 lg:block">
-          <Text
-            size="pageTitle"
-            weight="extrabold"
-            className="tracking-tight text-gray-900"
+          <Accordion
+            type="single"
+            collapsible
+            className="divide-y divide-gray-100"
           >
-            문의하기
-          </Text>
-          <Text
-            size="body2"
-            weight="regular"
-            className="mt-2 block text-gray-500"
-          >
-            궁금한 점이 있으시면 언제든지 문의해주세요.
-          </Text>
-        </div>
-
-        <div className="mt-6 flex flex-col gap-3">
-          <section className="rounded-4 border border-gray-200 bg-white">
-            <div className="border-b border-gray-100 px-5 py-4">
-              <Text size="body1" weight="bold" className="text-gray-500">
-                자주 묻는 질문
-              </Text>
-            </div>
-
-            <Accordion
-              type="single"
-              collapsible
-              className="divide-y divide-gray-100"
-            >
-              {INQUIRY_FAQ_ITEMS.map((item) => (
-                <AccordionItem
-                  key={item.id}
-                  value={item.id}
-                  className="border-0 px-5"
-                >
-                  <AccordionTrigger className="py-4 hover:no-underline">
-                    <Text
-                      size="body1"
-                      weight="medium"
-                      className="text-left text-gray-800"
-                    >
-                      {item.question}
-                    </Text>
-                  </AccordionTrigger>
-                  <AccordionContent className="pb-4">
-                    <Text
-                      size="body2"
-                      weight="regular"
-                      className="text-gray-500"
-                    >
-                      {item.answer}
-                    </Text>
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
-          </section>
-
-          <section className="rounded-4 border border-gray-200 bg-white">
-            <div className="border-b border-gray-100 px-5 py-4">
-              <Text size="body1" weight="bold" className="text-gray-500">
-                1:1 문의
-              </Text>
-            </div>
-
-            <div className="flex flex-col gap-4 px-5 py-5">
-              <div className="flex items-start gap-3">
-                <span
-                  className={cn(
-                    'flex h-10 w-10 shrink-0 items-center justify-center',
-                    'bg-main-50 text-main-800 rounded-full'
-                  )}
-                  aria-hidden
-                >
-                  <Mail className="h-5 w-5" />
-                </span>
-                <div className="flex flex-col gap-1">
-                  <Text size="body1" weight="bold" className="text-gray-900">
-                    무엇을 도와드릴까요?
-                  </Text>
-                  <Text
-                    size="caption1"
-                    weight="regular"
-                    className="text-gray-500"
-                  >
-                    문제가 발생하거나 추가됐으면 하는 기능이 있다면 아래 버튼을
-                    통해 문의를 남겨주세요.
-                  </Text>
-                </div>
-              </div>
-
-              <a
-                href={INQUIRY_FORM_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="w-full"
+            {INQUIRY_FAQ_ITEMS.map((item) => (
+              <AccordionItem
+                key={item.id}
+                value={item.id}
+                className="border-0 px-5"
               >
-                <Button variant="primary" size="md" className="w-full">
-                  문의 남기기
-                  <ExternalLink className="h-4 w-4" />
-                </Button>
-              </a>
+                <AccordionTrigger className="py-4 hover:no-underline">
+                  <Text
+                    size="body1"
+                    weight="medium"
+                    className="text-left text-gray-800"
+                  >
+                    {item.question}
+                  </Text>
+                </AccordionTrigger>
+                <AccordionContent className="pb-4">
+                  <Text size="body2" weight="regular" className="text-gray-500">
+                    {item.answer}
+                  </Text>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </section>
+
+        <section className="rounded-4 border border-gray-200 bg-white">
+          <div className="border-b border-gray-100 px-5 py-4">
+            <Text size="body1" weight="bold" className="text-gray-500">
+              1:1 문의
+            </Text>
+          </div>
+
+          <div className="flex flex-col gap-4 px-5 py-5">
+            <div className="flex items-start gap-3">
+              <span
+                className={cn(
+                  'flex h-10 w-10 shrink-0 items-center justify-center',
+                  'bg-main-50 text-main-800 rounded-full'
+                )}
+                aria-hidden
+              >
+                <Mail className="h-5 w-5" />
+              </span>
+              <div className="flex flex-col gap-1">
+                <Text size="body1" weight="bold" className="text-gray-900">
+                  무엇을 도와드릴까요?
+                </Text>
+                <Text size="caption1" weight="regular" className="text-gray-500">
+                  문제가 발생하거나 추가됐으면 하는 기능이 있다면 아래 버튼을
+                  통해 문의를 남겨주세요.
+                </Text>
+              </div>
             </div>
-          </section>
-        </div>
-      </section>
-    </div>
+
+            <a
+              href={INQUIRY_FORM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full"
+            >
+              <Button variant="primary" size="md" className="w-full">
+                문의 남기기
+                <ExternalLink className="h-4 w-4" />
+              </Button>
+            </a>
+          </div>
+        </section>
+      </div>
+    </SubPageShell>
   );
 }


### PR DESCRIPTION
## 배경

`/guide`(사용 가이드)와 `/inquiry`(문의하기)는 둘 다 **마이페이지 설정에서 진입하는 서브페이지**인데, 다른 서브페이지(친구·알림·설정 등)가 쓰는 공통 헤더와 다르게 각자 자체 헤더를 구현하고 있었다.

- **inquiry**: `fixed` + `ArrowLeft` 자체 헤더 → `SubPageShell`을 그대로 재구현한 코드였음
- **guide**: 뒤로가기 없는 자체 `sticky` 헤더 → "최상위 탭 화면" 주석과 달리 실제로는 설정에서 push되는 서브페이지(바텀네비도 노출 안 됨)

## 변경

두 화면 모두 다른 서브페이지와 동일하게 **DS `MobileHeader`(뒤로가기 + 타이틀)** 를 쓰도록 통일.

| 화면 | Before | After |
| --- | --- | --- |
| `/inquiry` | 자체 `fixed` 헤더 + 자체 데스크톱 헤더 | `SubPageShell` (내부적으로 DS `MobileHeader`) |
| `/guide` | 자체 `sticky` 헤더(뒤로가기 없음) | DS `MobileHeader`(뒤로가기) via `GuideMobileHeader` client 리프 |

- guide는 랜딩성 풀블리드 히어로 레이아웃(고유 `max-w-[960px]` 컨테이너, 데스크톱 전용 헤더 없음)을 가져 `SubPageShell`에 넣으면 레이아웃이 깨진다. 그래서 본문은 그대로 두고 **모바일 헤더만** DS `MobileHeader`로 교체. RSC인 `GuideScreen`을 유지하기 위해 `router.back`을 쓰는 부분만 `GuideMobileHeader` client 리프로 분리(아키텍처 불변량 #1: `'use client'`는 최하위 리프).
- 바텀네비 정책은 기존과 동일 — `/guide`·`/inquiry`는 `BOTTOM_NAV_VISIBLE_ROUTES`에 없으므로 원래부터 미노출(서브페이지 규칙 준수).

## 검증

- ✅ `tsc --noEmit` / `pnpm lint`(0 errors) / `pnpm test`(125 passed) / `pnpm knip` / `pnpm build`
- `/guide`·`/inquiry` 모두 정적 프리렌더(`○ Static`) 유지
- 브라우저 육안 확인은 하지 않음(프로젝트 정책상 사용자 확인)