### PR TITLE
fix: 홈 팝업 그냥 닫기를 세션 동안 유지

### DIFF
--- a/src/app.feature/home/components/HomePopup.tsx
+++ b/src/app.feature/home/components/HomePopup.tsx
@@ -18,6 +18,8 @@ import { useActivePopups } from '../hooks/usePopupQueries';
 import {
   dismissPopupKeys,
   getDismissedPopupKeys,
+  getSessionDismissedPopupKeys,
+  sessionDismissPopupKeys,
 } from '../utils/popupDismissal';
 
 const SLIDE_INTERVAL_MS = 3_000;
@@ -33,8 +35,15 @@ export default function HomePopup({
   const router = useRouter();
   const { data: popups = [] } = useActivePopups(enabled);
 
-  // 쿠키에 등록된(=다시 보지 않기) key 는 마운트 시 1회만 읽는다.
-  const [dismissedKeys] = useState(() => new Set(getDismissedPopupKeys()));
+  // 차단 대상 key 는 마운트 시 1회만 읽는다.
+  // 쿠키(다시 보지 않기, 영구) + sessionStorage(그냥 닫기, 세션 한정).
+  const [dismissedKeys] = useState(
+    () =>
+      new Set([
+        ...getDismissedPopupKeys(),
+        ...getSessionDismissedPopupKeys(),
+      ])
+  );
   const [closed, setClosed] = useState(false);
   const [index, setIndex] = useState(0);
 
@@ -62,7 +71,12 @@ export default function HomePopup({
   const safeIndex = index % count;
   const current = visiblePopups[safeIndex];
 
-  const close = (): void => setClosed(true);
+  // 닫을 때(그냥 닫기·CTA·다시 보지 않기 공통) 현재 노출된 전체 팝업 key 를
+  // 세션 차단 목록에 기록해 같은 세션에서 재진입해도 다시 뜨지 않게 한다.
+  const close = (): void => {
+    sessionDismissPopupKeys(visiblePopups.map((popup) => popup.popupKey));
+    setClosed(true);
+  };
 
   // "다시 보지 않기": 현재 노출된 모든 팝업 key 를 쿠키에 등록 후 닫는다.
   const handleDismiss = (): void => {

--- a/src/app.feature/home/utils/popupDismissal.test.ts
+++ b/src/app.feature/home/utils/popupDismissal.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  getSessionDismissedPopupKeys,
+  sessionDismissPopupKeys,
+} from './popupDismissal';
+
+afterEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe('session popup dismissal', () => {
+  it('빈 세션에서는 차단 key 가 없다', () => {
+    expect(getSessionDismissedPopupKeys()).toEqual([]);
+  });
+
+  it('기록한 key 를 되읽는다', () => {
+    sessionDismissPopupKeys(['a', 'b']);
+    expect(getSessionDismissedPopupKeys().sort()).toEqual(['a', 'b']);
+  });
+
+  it('여러 번 기록해도 중복 없이 합쳐진다', () => {
+    sessionDismissPopupKeys(['a']);
+    sessionDismissPopupKeys(['a', 'b']);
+    expect(getSessionDismissedPopupKeys().sort()).toEqual(['a', 'b']);
+  });
+
+  it('손상된 값이면 빈 배열로 복구한다', () => {
+    window.sessionStorage.setItem('1d1s:sessionDismissedPopups', '{bad');
+    expect(getSessionDismissedPopupKeys()).toEqual([]);
+  });
+
+  it('배열이 아닌 JSON 이면 빈 배열을 반환한다', () => {
+    window.sessionStorage.setItem('1d1s:sessionDismissedPopups', '"x"');
+    expect(getSessionDismissedPopupKeys()).toEqual([]);
+  });
+});

--- a/src/app.feature/home/utils/popupDismissal.ts
+++ b/src/app.feature/home/utils/popupDismissal.ts
@@ -33,3 +33,43 @@ export function dismissPopupKeys(keys: string[]): void {
       window.location.protocol === 'https:',
   });
 }
+
+// 그냥 닫기로 이번 세션 동안만 차단할 팝업 key 목록을 담는 sessionStorage.
+// 탭/브라우저를 닫으면 사라지므로 다음 세션엔 다시 노출된다.
+const SESSION_DISMISSED_POPUPS_KEY = '1d1s:sessionDismissedPopups';
+
+export function getSessionDismissedPopupKeys(): string[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_DISMISSED_POPUPS_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((key): key is string => typeof key === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+// 현재 노출된 모든 팝업 key 를 세션 차단 목록에 합쳐 기록한다.
+export function sessionDismissPopupKeys(keys: string[]): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const merged = Array.from(
+    new Set([...getSessionDismissedPopupKeys(), ...keys])
+  );
+  try {
+    window.sessionStorage.setItem(
+      SESSION_DISMISSED_POPUPS_KEY,
+      JSON.stringify(merged)
+    );
+  } catch {
+    // sessionStorage 접근 불가(프라이빗 모드 등)면 조용히 무시한다.
+  }
+}


### PR DESCRIPTION
## 문제
팝업을 **그냥 닫기**(다시 보지 않기 미체크)로 닫아도, 다른 탭에 갔다가 홈으로 돌아오면 팝업이 다시 노출됨.

원인: 닫힘 상태(`closed`)가 컴포넌트 로컬 state라 홈 재진입 시 리마운트되며 초기화되고, 필터링은 쿠키(다시 보지 않기)만 반영했음.

## 변경
- `popupDismissal.ts`에 **sessionStorage 기반 세션 한정 차단** 유틸 추가
  - `getSessionDismissedPopupKeys()` / `sessionDismissPopupKeys()`
  - `window` 가드로 SSR 안전, JSON 파싱/접근 실패 시 조용히 빈 배열 복구
- `HomePopup`
  - 마운트 시 차단 대상 = **쿠키(365일, 영구) + 세션** 목록을 함께 필터링
  - 닫기(그냥 닫기·CTA·다시 보지 않기 공통) 시 현재 노출된 **전체** 팝업 key를 세션 목록에 기록 → 같은 세션에서 탭 전환·라우트 이동·홈 재진입에도 다시 뜨지 않음
  - 브라우저/탭을 새로 열면(sessionStorage 소멸) 다시 노출됨 — 의도된 동작
- 여러 팝업 동시 노출 시, 닫으면 기존 "다시 보지 않기"와 동일하게 **노출된 전체**를 일괄 차단(정책 일치)
- 기존 "다시 보지 않기" 쿠키(365일) 로직은 **변경 없이 유지**

## 검증
- tsc `--noEmit` ✅ / `pnpm lint` (0 errors) ✅ / `pnpm test` (130 passed) ✅ / `pnpm knip` ✅ / `pnpm build` ✅
- 세션 차단 유틸 단위 테스트 5건 추가
- ⚠️ 브라우저 실동작(탭 전환·재진입)은 직접 돌려보지 않음 — 정적 검증 + 단위 테스트까지 수행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Popup dismissals now persist for the current browser session when closed through standard close controls.
  * “Don’t show again” selections continue to persist beyond the current session.

* **Bug Fixes**
  * Improved popup dismissal handling across cookies and session storage.
  * Added safeguards for invalid or unavailable session storage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->