### PR TITLE
feat: 카테고리 9종 개편 반영 (MUSIC·STUDY·LEISURE·ECONOMY 제거)

### DIFF
--- a/src/app.constants/categories.tsx
+++ b/src/app.constants/categories.tsx
@@ -9,43 +9,39 @@ export const CATEGORY_OPTIONS: ReadonlyArray<{
   { value: 'DEV', label: '개발', iconName: 'Code2' },
   { value: 'EXERCISE', label: '운동', iconName: 'Dumbbell' },
   { value: 'BOOK', label: '독서', iconName: 'BookOpen' },
-  { value: 'MUSIC', label: '음악', iconName: 'Bell' },
-  { value: 'STUDY', label: '공부', iconName: 'PencilLine' },
-  { value: 'LEISURE', label: '여가생활', iconName: 'Plane' },
-  { value: 'ECONOMY', label: '경제', iconName: 'Trophy' },
+  { value: 'DIET', label: '식단', iconName: 'Salad' },
+  { value: 'HEALTH', label: '건강', iconName: 'Heart' },
+  { value: 'HOBBY', label: '취미', iconName: 'Palette' },
+  { value: 'LANGUAGE', label: '어학', iconName: 'Flag' },
+  { value: 'SELF_DEV', label: '자기계발', iconName: 'Target' },
+  { value: 'ETC', label: '기타', iconName: 'Pin' },
 ];
 
 // 카테고리별 stripe/hero accent 색. 같은 보드/일지 화면에 여러 카테고리가
-// 동시에 노출되므로 색이 겹치면 구분이 어렵다. 색상환을 7등분해 각 카테고리에
-// 고유 hue 를 배정한다. (extras: 레거시 카테고리, 필요 시에만 사용)
+// 동시에 노출되므로 색이 겹치면 구분이 어렵다. 각 카테고리에 고유 hue 를
+// 배정한다. (ALL 은 '전체' 필터 전용 sentinel — 서버 카테고리가 아니다)
 const CATEGORY_STRIPE_TONES: Record<string, string> = {
   ALL: '#ff7043',
   DEV: '#7c3aed', // violet
-  STUDY: '#6366f1', // indigo
-  MUSIC: '#2563eb', // blue
-  ECONOMY: '#0d9488', // teal
-  BOOK: '#16a34a', // green
-  LEISURE: '#f59e0b', // amber
   EXERCISE: '#ef4444', // red
+  BOOK: '#16a34a', // green
+  DIET: '#f59e0b', // amber
   HEALTH: '#10b981', // emerald
   HOBBY: '#ec4899', // pink
-  OTHER: '#6b7280', // gray
+  LANGUAGE: '#2563eb', // blue
+  SELF_DEV: '#6366f1', // indigo
+  ETC: '#6b7280', // gray
 };
 
 const DEFAULT_STRIPE_TONE = '#6b7280';
 
+// ALL('전체')만 CATEGORY_OPTIONS 밖의 필터 전용 항목이라 별도로 둔다.
 const EXTRA_CATEGORY_LABELS: Record<string, string> = {
   ALL: '전체',
-  OTHER: '기타',
-  HEALTH: '건강',
-  HOBBY: '취미',
 };
 
 const EXTRA_CATEGORY_ICON_NAMES: Record<string, IconName> = {
   ALL: 'HamburgerMenu',
-  OTHER: 'Pin',
-  HEALTH: 'Salad',
-  HOBBY: 'Palette',
 };
 
 const CATEGORY_LABELS: Record<string, string> = CATEGORY_OPTIONS.reduce(

--- a/src/app.feature/auth/hooks/useSignUpForm.ts
+++ b/src/app.feature/auth/hooks/useSignUpForm.ts
@@ -10,10 +10,12 @@ export const TOPIC_VALUES = [
   'DEV',
   'EXERCISE',
   'BOOK',
-  'MUSIC',
-  'STUDY',
-  'LEISURE',
-  'ECONOMY',
+  'DIET',
+  'HEALTH',
+  'HOBBY',
+  'LANGUAGE',
+  'SELF_DEV',
+  'ETC',
 ] as const;
 
 export const signupFormSchema = z.object({

--- a/src/app.feature/auth/screen/step-pages/Step2.tsx
+++ b/src/app.feature/auth/screen/step-pages/Step2.tsx
@@ -20,10 +20,12 @@ const TOPIC_TONE: Record<CategoryType, string> = {
   DEV: 'bg-[#dff5b8]',
   EXERCISE: 'bg-[#ffccbc]',
   BOOK: 'bg-[#c8f4e1]',
-  MUSIC: 'bg-[#deecfb]',
-  STUDY: 'bg-[#fff3e0]',
-  LEISURE: 'bg-[#e0f2fe]',
-  ECONOMY: 'bg-[#ffe0b2]',
+  DIET: 'bg-[#fff3e0]',
+  HEALTH: 'bg-[#d7f8ea]',
+  HOBBY: 'bg-[#fde0ef]',
+  LANGUAGE: 'bg-[#deecfb]',
+  SELF_DEV: 'bg-[#e5e6fb]',
+  ETC: 'bg-[#eceef1]',
 };
 
 const MAX_SELECTABLE_TOPICS = 3;

--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -7,10 +7,12 @@ export type ChallengeCategory =
   | 'DEV'
   | 'EXERCISE'
   | 'BOOK'
-  | 'MUSIC'
-  | 'STUDY'
-  | 'LEISURE'
-  | 'ECONOMY';
+  | 'DIET'
+  | 'HEALTH'
+  | 'HOBBY'
+  | 'LANGUAGE'
+  | 'SELF_DEV'
+  | 'ETC';
 export type GoalType = 'FIXED' | 'FLEXIBLE';
 export type ParticipationType = 'INDIVIDUAL' | 'GROUP';
 // 챌린지 공개 범위 — PUBLIC: 공개, PRIVATE: 비공개(비밀번호), OFFICIAL: 공식

--- a/src/app.feature/challenge/write/components/ChallengePreviewCardView.tsx
+++ b/src/app.feature/challenge/write/components/ChallengePreviewCardView.tsx
@@ -8,10 +8,12 @@ const CATEGORY_TONE: Record<string, string> = {
   DEV: 'blue',
   EXERCISE: 'peach',
   BOOK: 'mint',
-  MUSIC: 'rose',
-  STUDY: 'cream',
-  LEISURE: 'sky',
-  ECONOMY: 'gray',
+  DIET: 'cream',
+  HEALTH: 'mint',
+  HOBBY: 'rose',
+  LANGUAGE: 'sky',
+  SELF_DEV: 'blue',
+  ETC: 'gray',
 };
 
 export interface ChallengePreviewCardViewProps {

--- a/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
+++ b/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
@@ -16,7 +16,17 @@ export const challengeCreateFormSchema = z
       .max(50, '챌린지 제목은 50자 이하로 입력해주세요.'),
     // 카테고리를 필수로 하고, 선택하지 않았을 때 에러 메시지 지정
     category: z.enum(
-      ['DEV', 'EXERCISE', 'BOOK', 'MUSIC', 'STUDY', 'LEISURE', 'ECONOMY'],
+      [
+        'DEV',
+        'EXERCISE',
+        'BOOK',
+        'DIET',
+        'HEALTH',
+        'HOBBY',
+        'LANGUAGE',
+        'SELF_DEV',
+        'ETC',
+      ],
       {
         message: '카테고리를 선택해주세요.',
       }

--- a/src/app.feature/challenge/write/hooks/useChallengeEditForm.ts
+++ b/src/app.feature/challenge/write/hooks/useChallengeEditForm.ts
@@ -20,7 +20,17 @@ export const challengeEditFormSchema = z
       .min(1, '챌린지 제목을 입력해주세요.')
       .max(50, '챌린지 제목은 50자 이하로 입력해주세요.'),
     category: z.enum(
-      ['DEV', 'EXERCISE', 'BOOK', 'MUSIC', 'STUDY', 'LEISURE', 'ECONOMY'],
+      [
+        'DEV',
+        'EXERCISE',
+        'BOOK',
+        'DIET',
+        'HEALTH',
+        'HOBBY',
+        'LANGUAGE',
+        'SELF_DEV',
+        'ETC',
+      ],
       {
         message: '카테고리를 선택해주세요.',
       }

--- a/src/app.feature/diary/write/utils/diaryFormHelpers.ts
+++ b/src/app.feature/diary/write/utils/diaryFormHelpers.ts
@@ -127,10 +127,12 @@ function normalizeChallengeCategory(category: string): ChallengeCategory {
     DEV: 'DEV',
     EXERCISE: 'EXERCISE',
     BOOK: 'BOOK',
-    MUSIC: 'MUSIC',
-    STUDY: 'STUDY',
-    LEISURE: 'LEISURE',
-    ECONOMY: 'ECONOMY',
+    DIET: 'DIET',
+    HEALTH: 'HEALTH',
+    HOBBY: 'HOBBY',
+    LANGUAGE: 'LANGUAGE',
+    SELF_DEV: 'SELF_DEV',
+    ETC: 'ETC',
   };
 
   return categoryMap[category] ?? 'DEV';

--- a/src/app.feature/guide/components/GuidePhoneMock.tsx
+++ b/src/app.feature/guide/components/GuidePhoneMock.tsx
@@ -41,13 +41,11 @@ function GuidePhone({
 const CATEGORY_HEX: Record<string, string> = {
   EXERCISE: '#ef4444',
   BOOK: '#16a34a',
-  STUDY: '#6366f1',
 };
 
 const CATEGORY_ICON: Record<string, typeof Dumbbell> = {
   EXERCISE: Dumbbell,
   BOOK: BookOpen,
-  STUDY: PencilLine,
 };
 
 /** 미니 무드 얼굴 — 일지 카드의 mood SVG 를 축소해 흉내낸 정적 아이콘 */


### PR DESCRIPTION
## 개요
서버 카테고리 재매핑 배포에 맞춰 클라이언트 카테고리를 **9종**으로 통일합니다.

**최종 Category(9종)**: `DEV`(개발) `EXERCISE`(운동) `BOOK`(독서) `DIET`(식단) `HEALTH`(건강) `HOBBY`(취미) `LANGUAGE`(어학) `SELF_DEV`(자기계발) `ETC`(기타)

**제거**: `MUSIC` `STUDY` `LEISURE` `ECONOMY` — 서버 DB에서 MUSIC/LEISURE→HOBBY, STUDY→SELF_DEV, ECONOMY→ETC 로 재매핑 완료.

## 라벨·색·아이콘
| Category | 라벨 | 아이콘(DS) | 색 |
|---|---|---|---|
| DEV | 개발 | Code2 | `#7c3aed` violet |
| EXERCISE | 운동 | Dumbbell | `#ef4444` red |
| BOOK | 독서 | BookOpen | `#16a34a` green |
| DIET | 식단 | Salad | `#f59e0b` amber |
| HEALTH | 건강 | Heart | `#10b981` emerald |
| HOBBY | 취미 | Palette | `#ec4899` pink |
| LANGUAGE | 어학 | Flag | `#2563eb` blue |
| SELF_DEV | 자기계발 | Target | `#6366f1` indigo |
| ETC | 기타 | Pin | `#6b7280` gray |

> 아이콘은 `@1d1s/design-system` 의 `IconName` 세트로 제한됨. lucide의 HeartPulse/Languages/Sprout/Shapes 등은 DS에 없어 가장 근접한 기존 아이콘(Heart/Flag/Target/Pin)으로 지정.

## 변경 파일
- `challenge/board/type/challenge.ts` — `ChallengeCategory` 유니온
- `app.constants/categories.tsx` — `CATEGORY_OPTIONS`·`CATEGORY_STRIPE_TONES` + 잉여 extras(OTHER/HEALTH/HOBBY) 정리
- `diary/write/utils/diaryFormHelpers.ts` — `normalizeChallengeCategory` 맵(누락 시 DEV 폴백 주의 → 9종 전부 매핑)
- `auth/hooks/useSignUpForm.ts` — `TOPIC_VALUES` (회원가입 관심주제, `CategoryType` 원천)
- `auth/screen/step-pages/Step2.tsx` — `TOPIC_TONE`
- `challenge/write/components/ChallengePreviewCardView.tsx` — `CATEGORY_TONE`
- `challenge/write/hooks/useChallengeCreateForm.ts` / `useChallengeEditForm.ts` — `z.enum`
- `guide/components/GuidePhoneMock.tsx` — 목업 STUDY 사문화 항목 제거

## 검증
- ✅ `tsc --noEmit`
- ✅ `pnpm lint` (0 errors)
- ✅ `pnpm test` (125 passed)
- ✅ `pnpm knip`
- ✅ `pnpm build`