### PR TITLE
feat: 회원 전화번호 입력·수정 기능 추가

### DIFF
--- a/src/app.feature/auth/hooks/useSignUpForm.ts
+++ b/src/app.feature/auth/hooks/useSignUpForm.ts
@@ -1,6 +1,7 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { nicknameSchema } from '@module/utils/nickname';
+import { phoneNumberSchema } from '@module/utils/phoneNumber';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -20,6 +21,7 @@ export const TOPIC_VALUES = [
 
 export const signupFormSchema = z.object({
   nickname: nicknameSchema,
+  phoneNumber: phoneNumberSchema,
   year: z
     .string()
     .nonempty('연도를 선택해 주세요.')
@@ -52,6 +54,7 @@ export function useSignUpForm(): ReturnType<typeof useForm<SignupFormValues>> {
     reValidateMode: 'onChange',
     defaultValues: {
       nickname: '',
+      phoneNumber: '',
       year: '',
       month: '',
       day: '',

--- a/src/app.feature/auth/screen/SignUpScreen.tsx
+++ b/src/app.feature/auth/screen/SignUpScreen.tsx
@@ -3,11 +3,16 @@
 import { ConfirmDialog, Icon, StepIndicator, Text } from '@1d1s/design-system';
 import { Form } from '@component/ui/Form';
 import { MEMBER_QUERY_KEYS } from '@feature/member/consts/queryKeys';
+import { getApiErrorCode } from '@module/api/error';
 import { notifyApiError } from '@module/api/errorNotify';
 import { putToStorage } from '@module/api/presignedUpload';
 import { toast } from '@module/providers/toast';
 import { authStorage } from '@module/utils/auth';
 import { cn } from '@module/utils/cn';
+import {
+  normalizePhoneNumber,
+  PHONE_NUMBER_DUPLICATE_MESSAGE,
+} from '@module/utils/phoneNumber';
 import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import { useQueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
@@ -80,6 +85,7 @@ export function SignUpScreen(): React.ReactElement {
 
       await authApi.completeSignUpInfo({
         nickname: values.nickname,
+        phoneNumber: normalizePhoneNumber(values.phoneNumber),
         job: values.job,
         birth,
         gender: values.gender,
@@ -98,6 +104,15 @@ export function SignUpScreen(): React.ReactElement {
       );
       router.replace(returnTo ?? '/');
     } catch (error) {
+      // 전화번호 중복(409, USER-010)은 토스트 대신 입력 단계의 필드
+      // 에러로 노출해 사용자가 바로 수정할 수 있게 한다.
+      if (getApiErrorCode(error) === 'USER-010') {
+        form.setError('phoneNumber', {
+          message: PHONE_NUMBER_DUPLICATE_MESSAGE,
+        });
+        setStep(1);
+        return;
+      }
       notifyApiError(error);
     } finally {
       setIsSubmitting(false);
@@ -122,6 +137,7 @@ export function SignUpScreen(): React.ReactElement {
   const handleNextStep = async (): Promise<void> => {
     const stepOneValid = await form.trigger([
       'nickname',
+      'phoneNumber',
       'year',
       'month',
       'day',

--- a/src/app.feature/auth/screen/step-pages/Step1.tsx
+++ b/src/app.feature/auth/screen/step-pages/Step1.tsx
@@ -23,6 +23,7 @@ import { NicknameCheckButton } from '@feature/member/components/NicknameCheckBut
 import { useCheckNickname } from '@feature/member/hooks/useMemberMutations';
 import { normalizeApiError } from '@module/api/error';
 import { NICKNAME_REGEX } from '@module/utils/nickname';
+import { formatPhoneNumber } from '@module/utils/phoneNumber';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -173,6 +174,33 @@ export function Step1({ onNext }: Step1Props): React.ReactElement {
               ) : (
                 <FormMessage />
               )}
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="phoneNumber"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <TextField
+                  label="전화번호"
+                  placeholder="010-1234-5678"
+                  inputMode="numeric"
+                  maxLength={13}
+                  helper="상품 발송 시에만 사용하고 외부에 공개하지 않아요"
+                  className="w-full"
+                  value={field.value ?? ''}
+                  onChange={(event) =>
+                    field.onChange(formatPhoneNumber(event.target.value))
+                  }
+                  onBlur={field.onBlur}
+                  name={field.name}
+                  ref={field.ref}
+                />
+              </FormControl>
+              <FormMessage />
             </FormItem>
           )}
         />

--- a/src/app.feature/auth/type/auth.ts
+++ b/src/app.feature/auth/type/auth.ts
@@ -22,6 +22,7 @@ export interface SocialLoginResponse {
 
 export interface SignUpInfoRequest {
   nickname: string;
+  phoneNumber: string;
   profileImageKey?: string;
   job: JobType;
   birth: string; // yyyy-MM-dd format

--- a/src/app.feature/member/api/memberApi.ts
+++ b/src/app.feature/member/api/memberApi.ts
@@ -73,6 +73,13 @@ export const memberApi = {
       data: { nickname },
     }),
 
+  updatePhoneNumber: async (phoneNumber: string): Promise<void> =>
+    requestData<void>(apiClient, {
+      url: '/member/phone-number',
+      method: 'PATCH',
+      data: { phoneNumber },
+    }),
+
   checkNickname: async (nickname: string): Promise<{ message?: string }> =>
     requestBody<{ message?: string }>(publicApiClient, {
       url: '/member/nickname/check',

--- a/src/app.feature/member/hooks/useMemberMutations.ts
+++ b/src/app.feature/member/hooks/useMemberMutations.ts
@@ -25,6 +25,24 @@ export function useUpdateNickname(): UseMutationResult<void, Error, string> {
   });
 }
 
+export function useUpdatePhoneNumber(): UseMutationResult<
+  void,
+  Error,
+  string
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (phoneNumber: string) =>
+      memberApi.updatePhoneNumber(phoneNumber),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: MEMBER_QUERY_KEYS.myPage(),
+      });
+    },
+  });
+}
+
 export function useCheckNickname(): UseMutationResult<
   { message?: string },
   Error,

--- a/src/app.feature/member/settings/screen/ProfileSettingsScreen.tsx
+++ b/src/app.feature/member/settings/screen/ProfileSettingsScreen.tsx
@@ -11,12 +11,19 @@ import { NicknameCheckButton } from '@feature/member/components/NicknameCheckBut
 import {
   useCheckNickname,
   useUpdateNickname,
+  useUpdatePhoneNumber,
   useUpdateProfileImage,
 } from '@feature/member/hooks/useMemberMutations';
 import { useMyPage } from '@feature/member/hooks/useMemberQueries';
-import { normalizeApiError } from '@module/api/error';
+import { getApiErrorCode, normalizeApiError } from '@module/api/error';
 import { cn } from '@module/utils/cn';
 import { validateNickname } from '@module/utils/nickname';
+import {
+  formatPhoneNumber,
+  normalizePhoneNumber,
+  PHONE_NUMBER_DUPLICATE_MESSAGE,
+  validatePhoneNumber,
+} from '@module/utils/phoneNumber';
 import Image from 'next/image';
 import React, { useState } from 'react';
 
@@ -46,6 +53,8 @@ export default function ProfileSettingsScreen(): React.ReactElement {
 
   const [editedNickname, setEditedNickname] = useState<string | undefined>();
   const [nicknameError, setNicknameError] = useState('');
+  const [editedPhone, setEditedPhone] = useState<string | undefined>();
+  const [phoneError, setPhoneError] = useState('');
   const [localProfilePreview, setLocalProfilePreview] = useState<
     string | undefined
   >();
@@ -54,8 +63,20 @@ export default function ProfileSettingsScreen(): React.ReactElement {
   const profilePreview = localProfilePreview ?? data?.profileUrl ?? '';
 
   const updateNickname = useUpdateNickname();
+  const updatePhoneNumber = useUpdatePhoneNumber();
   const updateProfileImage = useUpdateProfileImage();
   const checkNickname = useCheckNickname();
+
+  const hasPhone = Boolean(data?.phoneNumber);
+  const phoneNumber = editedPhone ?? data?.phoneNumber ?? '';
+  const isSamePhone =
+    normalizePhoneNumber(phoneNumber) ===
+    normalizePhoneNumber(data?.phoneNumber ?? '');
+  const phoneServerError = updatePhoneNumber.isError
+    ? getApiErrorCode(updatePhoneNumber.error) === 'USER-010'
+      ? PHONE_NUMBER_DUPLICATE_MESSAGE
+      : normalizeApiError(updatePhoneNumber.error).message
+    : '';
 
   const trimmedNickname = nickname.trim();
   const isSameAsCurrent = trimmedNickname === data?.nickname;
@@ -101,6 +122,25 @@ export default function ProfileSettingsScreen(): React.ReactElement {
       return;
     }
     updateNickname.mutate(trimmedNickname);
+  };
+
+  const handlePhoneChange = (value: string): void => {
+    updatePhoneNumber.reset();
+    const formatted = formatPhoneNumber(value);
+    setEditedPhone(formatted);
+    setPhoneError(formatted ? validatePhoneNumber(formatted) : '');
+  };
+
+  const handlePhoneSave = (): void => {
+    const error = validatePhoneNumber(phoneNumber);
+    if (error) {
+      setPhoneError(error);
+      return;
+    }
+    if (isSamePhone) {
+      return;
+    }
+    updatePhoneNumber.mutate(normalizePhoneNumber(phoneNumber));
   };
 
   return (
@@ -199,6 +239,63 @@ export default function ProfileSettingsScreen(): React.ReactElement {
                   ✅ 사용 가능한 닉네임이에요
                 </Text>
               ) : null}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Text size="body1" weight="medium" className="text-gray-700">
+                전화번호
+              </Text>
+              <div className="flex gap-2">
+                <TextField
+                  value={phoneNumber}
+                  onChange={(event) => handlePhoneChange(event.target.value)}
+                  placeholder="010-1234-5678"
+                  inputMode="numeric"
+                  maxLength={13}
+                  className="flex-1"
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      handlePhoneSave();
+                    }
+                  }}
+                />
+                <Button
+                  size="sm"
+                  onClick={handlePhoneSave}
+                  disabled={
+                    updatePhoneNumber.isPending ||
+                    !phoneNumber ||
+                    Boolean(phoneError) ||
+                    isSamePhone
+                  }
+                  className="shrink-0 whitespace-nowrap"
+                >
+                  {updatePhoneNumber.isPending ? '저장 중...' : '저장'}
+                </Button>
+              </div>
+              {phoneError ? (
+                <Text size="caption1" weight="regular" className="text-red-500">
+                  {phoneError}
+                </Text>
+              ) : phoneServerError ? (
+                <Text size="caption1" weight="regular" className="text-red-500">
+                  {phoneServerError}
+                </Text>
+              ) : updatePhoneNumber.isSuccess ? (
+                <Text
+                  size="caption1"
+                  weight="regular"
+                  className="text-green-600"
+                >
+                  전화번호가 저장되었습니다.
+                </Text>
+              ) : (
+                <Text size="caption1" weight="regular" className="text-gray-400">
+                  {hasPhone
+                    ? '상품 발송 시에만 사용하고 외부에 공개하지 않아요.'
+                    : '상품 발송을 위해 번호를 등록해 주세요. 외부에 공개되지 않아요.'}
+                </Text>
+              )}
             </div>
 
             {data?.provider && (

--- a/src/app.feature/member/type/member.ts
+++ b/src/app.feature/member/type/member.ts
@@ -114,6 +114,8 @@ export interface MyPageData {
   nickname: string;
   profileUrl: string;
   email: string;
+  // 미입력 회원은 응답에 키가 없다.
+  phoneNumber?: string;
   provider: 'GOOGLE' | 'KAKAO' | 'NAVER';
   streak: MyPageStreak;
   challengeList: MyPageChallenge[];

--- a/src/app.module/utils/phoneNumber.test.ts
+++ b/src/app.module/utils/phoneNumber.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatPhoneNumber,
+  normalizePhoneNumber,
+  validatePhoneNumber,
+} from './phoneNumber';
+
+describe('validatePhoneNumber', () => {
+  it.each(['010-1234-5678', '01012345678', '010-123-4567', '0111234567'])(
+    'accepts valid number %s (하이픈 유무 무관)',
+    (value) => {
+      expect(validatePhoneNumber(value)).toBe('');
+    }
+  );
+
+  it('rejects empty input with a required message', () => {
+    expect(validatePhoneNumber('')).toBe('전화번호를 입력해 주세요.');
+  });
+
+  it.each(['02-123-4567', '010-12-5678', 'abcd', '010123456789'])(
+    'rejects malformed number %s',
+    (value) => {
+      expect(validatePhoneNumber(value)).toBe('올바른 전화번호 형식이 아니에요.');
+    }
+  );
+});
+
+describe('normalizePhoneNumber', () => {
+  it('strips hyphens and non-digits', () => {
+    expect(normalizePhoneNumber('010-1234-5678')).toBe('01012345678');
+    expect(normalizePhoneNumber(' 010 1234 5678 ')).toBe('01012345678');
+  });
+});
+
+describe('formatPhoneNumber', () => {
+  it('inserts hyphens for an 11-digit number', () => {
+    expect(formatPhoneNumber('01012345678')).toBe('010-1234-5678');
+  });
+
+  it('inserts hyphens for a 10-digit number', () => {
+    expect(formatPhoneNumber('0111234567')).toBe('011-123-4567');
+  });
+
+  it('formats progressively while typing', () => {
+    expect(formatPhoneNumber('010')).toBe('010');
+    expect(formatPhoneNumber('0101')).toBe('010-1');
+    expect(formatPhoneNumber('0101234')).toBe('010-1234');
+  });
+
+  it('caps at 11 digits and ignores existing hyphens', () => {
+    expect(formatPhoneNumber('010-1234-5678999')).toBe('010-1234-5678');
+  });
+});

--- a/src/app.module/utils/phoneNumber.ts
+++ b/src/app.module/utils/phoneNumber.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+// 서버와 동일한 검증 규칙. 하이픈 유무는 무관하다.
+export const PHONE_NUMBER_REGEX = /^01[016-9]-?\d{3,4}-?\d{4}$/;
+export const PHONE_NUMBER_REQUIRED_MESSAGE = '전화번호를 입력해 주세요.';
+export const PHONE_NUMBER_PATTERN_MESSAGE = '올바른 전화번호 형식이 아니에요.';
+// 서버 409(USER-010) 응답과 동일한 문구.
+export const PHONE_NUMBER_DUPLICATE_MESSAGE =
+  '이미 등록된 휴대폰 번호입니다.';
+
+export const phoneNumberSchema = z
+  .string()
+  .trim()
+  .min(1, PHONE_NUMBER_REQUIRED_MESSAGE)
+  .regex(PHONE_NUMBER_REGEX, PHONE_NUMBER_PATTERN_MESSAGE);
+
+/**
+ * phoneNumberSchema 를 단일 출처로 사용해 첫 번째 오류 메시지를 반환한다.
+ * 유효하면 빈 문자열.
+ */
+export function validatePhoneNumber(value: string): string {
+  const result = phoneNumberSchema.safeParse(value);
+  return result.success ? '' : result.error.issues[0].message;
+}
+
+/** 하이픈 등 숫자 외 문자를 제거한 순수 숫자 문자열(API 전송용). */
+export function normalizePhoneNumber(value: string): string {
+  return value.replace(/\D/g, '');
+}
+
+/**
+ * 입력 편의를 위한 자동 하이픈 포맷팅. 숫자만 남긴 뒤 최대 11자리로 자르고
+ * 010-1234-5678(11자리) / 010-123-4567(10자리) 형태로 구분자를 넣는다.
+ */
+export function formatPhoneNumber(value: string): string {
+  const digits = normalizePhoneNumber(value).slice(0, 11);
+  if (digits.length < 4) {
+    return digits;
+  }
+  if (digits.length < 8) {
+    return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  }
+  if (digits.length === 11) {
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  }
+  // 8~10자리: 3-중간-4 로 구분.
+  const head = digits.slice(0, 3);
+  const tail = digits.slice(-4);
+  const mid = digits.slice(3, -4);
+  return `${head}-${mid}-${tail}`;
+}


### PR DESCRIPTION
## 개요
상품 발송용 휴대폰 번호를 가입/프로필에서 관리하도록 클라이언트를 서버 계약에 연동합니다. (서버는 dev 배포 완료)

## 변경 사항
### 가입 (`PUT /signup/info`)
- 스텝1에 전화번호 입력 필드 추가(필수)
- `zod` 형식 검증(`^01[016-9]-?\d{3,4}-?\d{4}$`) + 입력 시 자동 하이픈 포맷팅
- 요청 바디에 `phoneNumber` 포함(숫자만 정규화하여 전송)

### 프로필 설정 (`PATCH /member/phone-number`)
- 전화번호 항목 추가 — 미입력 회원은 등록 유도 안내, 기존 번호는 수정
- 성공 시 마이페이지 캐시 무효화
- `GET /member/my-page` 응답 `phoneNumber`(옵셔널) 타입 반영

### 공통
- 서버 **409 `USER-010`** 응답을 토스트가 아닌 **필드 에러**로 노출 ("이미 등록된 휴대폰 번호입니다.")
- 형식/포맷/정규화 유틸(`phoneNumber.ts`) 및 단위 테스트 추가

## 안내 문구
상품 발송 맥락에 맞춰 과하지 않게 한 줄로 안내("상품 발송 시에만 사용하고 외부에 공개하지 않아요").

## 검증
- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `vitest` ✅ (144 passed, phoneNumber 14 케이스 포함)
- `knip` ✅
- `next build` ✅

브라우저 동작 확인은 하지 않았습니다(프로젝트 정책상 사용자가 직접 확인).