### PR TITLE
feat: 챌린지 상세 비로그인 열람 허용 + OG 썸네일 반영

### DIFF
--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -206,6 +206,18 @@ export function ChallengeDetailScreen({
     useState(false);
   // 비공개 챌린지가 자유 목표로 확인돼 목표 입력이 필요한지.
   const [passwordNeedsGoals, setPasswordNeedsGoals] = useState(false);
+  // 비로그인 사용자가 로그인 필요 액션(참여·좋아요 등)을 누르면 로그인 유도.
+  const [showLoginPrompt, setShowLoginPrompt] = useState(false);
+
+  // 로그인 필요 액션 게이트. 비로그인이면 로그인 유도 다이얼로그를 띄우고
+  // false 를 반환한다(호출부는 즉시 return).
+  const requireLogin = (): boolean => {
+    if (isLoggedIn) {
+      return true;
+    }
+    setShowLoginPrompt(true);
+    return false;
+  };
 
   const summary = data?.challengeSummary;
   const detail = data?.challengeDetail;
@@ -310,6 +322,9 @@ export function ChallengeDetailScreen({
   });
 
   const handleJoinChallenge = (): void => {
+    if (!requireLogin()) {
+      return;
+    }
     if (isChallengeAlreadyEnded) {
       toast.error('종료된 챌린지는 참여 신청을 보낼 수 없습니다.');
       return;
@@ -351,6 +366,9 @@ export function ChallengeDetailScreen({
   };
 
   const handleToggleLike = (): void => {
+    if (!requireLogin()) {
+      return;
+    }
     if (!summary) {
       return;
     }
@@ -431,19 +449,6 @@ export function ChallengeDetailScreen({
   // 비공개 챌린지(403)는 비밀번호 검증 모달로 유도한다.
   const isPrivateChallengeLocked =
     isError && normalizeApiError(error).status === 403;
-
-  if (!isLoggedIn) {
-    return (
-      <LoginRequiredDialog
-        open
-        onOpenChange={() => {}}
-        title="간편 가입 후에 둘러보세요!"
-        description="챌린지 상세는 로그인 후 이용할 수 있습니다."
-        required
-        onClose={() => router.push('/challenge')}
-      />
-    );
-  }
 
   if (showSkeleton) {
     return <ChallengeDetailSkeleton />;
@@ -584,6 +589,12 @@ export function ChallengeDetailScreen({
         )}
       >
         <ChallengeGoalModals editors={goalEditors} />
+        <LoginRequiredDialog
+          open={showLoginPrompt}
+          onOpenChange={setShowLoginPrompt}
+          title="로그인이 필요해요"
+          description="이 기능은 로그인 후 이용할 수 있어요."
+        />
         <AlertDialog
           open={showCreateUnavailableDialog}
           onOpenChange={setShowCreateUnavailableDialog}

--- a/src/app.module/metadata/seo.ts
+++ b/src/app.module/metadata/seo.ts
@@ -80,35 +80,45 @@ export function buildResourceMetadata({
   };
 }
 
-export interface OfficialChallengeMeta {
-  challengeId: number;
+export interface PublicChallengeMeta {
   title: string;
+  description?: string | null;
   thumbnailImage?: string | null;
 }
 
-// 공식 챌린지만 비인증 조회가 열려 있다(/challenges/offset?challengeType=
-// OFFICIAL). 개별 /challenges/{id} 는 비인증 400(AUTH-002)이라 목록에서 id 로
-// 찾는다. 공식 챌린지는 큐레이션 대상이라 수가 적어 한 페이지(size=100)면
-// 충분하다. ponytail: 100개 초과 시에만 페이지네이션 추가.
-export async function fetchOfficialChallenge(
+// 챌린지 상세는 비인증 GET /challenges/{id} 가 열려 있어(dev tip 248a99d~)
+// 게스트 응답으로 제목·설명·썸네일을 그대로 OG 에 채운다. 비공개(403)·예약 전
+// 공식(404)·네트워크 오류는 null 을 반환해 루트 기본 OG 로 폴백한다(정보
+// 노출 없음).
+export async function fetchPublicChallengeMeta(
   id: string
-): Promise<OfficialChallengeMeta | null> {
+): Promise<PublicChallengeMeta | null> {
   if (!API_BASE_URL) {
     return null;
   }
   try {
-    const res = await fetch(
-      `${API_BASE_URL}/challenges/offset?challengeType=OFFICIAL&size=100`,
-      { headers: { accept: 'application/json' }, next: { revalidate: 300 } }
-    );
+    const res = await fetch(`${API_BASE_URL}/challenges/${id}`, {
+      headers: { accept: 'application/json' },
+      next: { revalidate: 300 },
+    });
     if (!res.ok) {
       return null;
     }
     const body = (await res.json()) as {
-      data?: { items?: OfficialChallengeMeta[] };
+      data?: {
+        challengeSummary?: { title?: string; thumbnailImage?: string | null };
+        challengeDetail?: { description?: string | null };
+      };
     };
-    const items = body.data?.items ?? [];
-    return items.find((item) => String(item.challengeId) === id) ?? null;
+    const title = body.data?.challengeSummary?.title;
+    if (!title) {
+      return null;
+    }
+    return {
+      title,
+      description: body.data?.challengeDetail?.description,
+      thumbnailImage: body.data?.challengeSummary?.thumbnailImage,
+    };
   } catch {
     return null;
   }

--- a/src/app.module/middleware/auth.ts
+++ b/src/app.module/middleware/auth.ts
@@ -13,11 +13,8 @@ type ProtectedRoute =
   | { pattern: RegExp; type: 'login-redirect' };
 
 const PROTECTED_ROUTES: ProtectedRoute[] = [
-  {
-    pattern: /^\/challenge\/\d+\/?$/,
-    type: 'list-redirect',
-    fallback: '/challenge',
-  },
+  // 챌린지 상세(/challenge/{id})는 비인증 공개 조회가 열려 있어 보호 대상에서
+  // 제외한다. 비공개(403)·예약 전(404)은 상세 화면이 클라이언트에서 처리한다.
   { pattern: /^\/diary\/\d+\/?$/, type: 'list-redirect', fallback: '/diary' },
 
   { pattern: /^\/challenge\/\d+\/edit\/?$/, type: 'login-redirect' },

--- a/src/app/challenge/[id]/page.tsx
+++ b/src/app/challenge/[id]/page.tsx
@@ -2,7 +2,7 @@ import { ChallengeDetailSkeleton } from '@component/skeletons/ChallengeDetailSke
 import { ChallengeDetailScreen } from '@feature/challenge/detail/screen/ChallengeDetailScreen';
 import {
   buildResourceMetadata,
-  fetchOfficialChallenge,
+  fetchPublicChallengeMeta,
   SITE_DESCRIPTION,
   SITE_TITLE,
 } from '@module/metadata/seo';
@@ -14,25 +14,24 @@ interface ChallengeDetailProps {
 }
 
 /**
- * 공식(OFFICIAL) 챌린지만 전용 OG 를 채운다. 개별 챌린지 상세는 비인증 조회가
- * 막혀 있어(400 AUTH-002) 목록(/challenges/offset?challengeType=OFFICIAL)에서
- * id 로 찾는다. 일반(비공식)·비공개·조회 실패는 빈 객체를 반환해 루트 기본
- * 메타(기본 OG)로 폴백한다. 배너/썸네일이 있으면 OG 이미지로, 없으면 기본
- * 이미지. 목록엔 설명이 없어 사이트 설명을 쓴다.
+ * 챌린지 상세는 비인증 GET /challenges/{id} 로 제목·설명·썸네일을 채운다.
+ * 조회 실패(비공개 403·예약 전 공식 404·네트워크)는 빈 객체를 반환해 루트
+ * 기본 메타(기본 OG)로 폴백한다(정보 노출 없음). 썸네일이 있으면 og:image 로,
+ * 없으면 기본 OG 이미지.
  */
 export async function generateMetadata({
   params,
 }: ChallengeDetailProps): Promise<Metadata> {
   const { id } = await params;
-  const official = await fetchOfficialChallenge(id);
-  if (!official) {
+  const challenge = await fetchPublicChallengeMeta(id);
+  if (!challenge) {
     return {};
   }
 
   return buildResourceMetadata({
-    title: `${official.title} | ${SITE_TITLE}`,
-    description: SITE_DESCRIPTION,
-    imageUrl: official.thumbnailImage,
+    title: `${challenge.title} | ${SITE_TITLE}`,
+    description: challenge.description?.trim() || SITE_DESCRIPTION,
+    imageUrl: challenge.thumbnailImage,
   });
 }
 


### PR DESCRIPTION
## 요약
챌린지 상세를 비로그인도 열람 가능하게 클라이언트를 대응하고, OG(링크 프리뷰)를 챌린지 썸네일로 전환합니다. 서버는 dev(tip 248a99d)에서 이미 비인증 `GET /challenges/{id}`·`/statistics` 를 허용하도록 배포됨.

## 변경 내용
1. **하드 게이트 제거** — `ChallengeDetailScreen` 의 `LoginRequiredDialog required` 전체 차단 제거. 비로그인도 소개·통계·일지·참여자 탭 열람 가능.
2. **액션 시점 로그인 유도** — 참여하기·좋아요 등 로그인 필요 액션은 비로그인 클릭 시 `requireLogin()` 게이트로 로그인 유도 다이얼로그를 띄움(버튼은 보이되 누르면 유도). 기존 `LoginRequiredDialog`/`loginUrlFromCurrentLocation()` 동선 재사용.
3. **쿼리 enabled 게이팅** — 게스트 응답은 `myStatus=NONE` 이라 내 참여 상태 의존 쿼리(작성일 조회·대기 승인)는 기존 조건으로 이미 비활성. 사이드바 쿼리도 토큰/힌트 없으면 비활성이라 401/403 누수 없음.
4. **OG** — `generateMetadata` 를 비인증 `GET /challenges/{id}` 조회로 전환 → 제목·설명·**썸네일**을 og:image 로. 공식 목록(`/challenges/offset`) 우회 로직(`fetchOfficialChallenge`) 제거. 비공개(403)·예약 전(404)은 조회 실패 → 기본 OG 폴백(정보 노출 없음).
5. **미들웨어** — 챌린지 상세를 보호 경로에서 제외. 일반 비로그인 사용자도 상세 접근 시 로그인으로 리다이렉트되지 않음. 다른 보호 경로 정책은 유지.

비공개(403)는 기존 비밀번호 다이얼로그, 예약 전(404)은 기존 에러 화면으로 자연스럽게 폴백됩니다.

## 검증
- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test` ✅ (144 passed)
- `pnpm knip` ✅ (dead code 정리 확인)
- `pnpm build` ✅