### PR TITLE
fix: 챌린지 리스트에서 비로그인 상세 진입 허용 (#199 후속)

### DIFF
--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -16,7 +16,6 @@ import {
 } from '@constants/categories';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
-import { useLoginRequiredParam } from '@module/hooks/useLoginRequiredParam';
 import { cn } from '@module/utils/cn';
 import { X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -39,9 +38,8 @@ import {
 
 interface ChallengeBoardCardItemProps {
   challenge: ChallengeListItem;
-  /** 로그인 시 상세 링크. 비로그인 시 undefined + onRequireLogin 사용. */
-  href?: string;
-  onRequireLogin(): void;
+  /** 상세 링크. 상세는 비로그인도 열람 가능하므로 항상 지정된다. */
+  href: string;
 }
 
 // 카드 매핑에서 인라인 람다·파생 계산을 제거해 React.memo(ChallengeCard) 가
@@ -50,7 +48,6 @@ const ChallengeBoardCardItem = React.memo(
   ({
     challenge,
     href,
-    onRequireLogin,
   }: ChallengeBoardCardItemProps): React.ReactElement => {
     const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
     const ended = isChallengeEndedOrArchived(
@@ -86,7 +83,6 @@ const ChallengeBoardCardItem = React.memo(
         isOfficial={challenge.challengeType === 'OFFICIAL'}
         participants={challenge.randomParticipants}
         href={href}
-        onClick={onRequireLogin}
       />
     );
   }
@@ -95,7 +91,6 @@ ChallengeBoardCardItem.displayName = 'ChallengeBoardCardItem';
 
 export default function ChallengeBoardScreen(): React.ReactElement {
   const router = useRouter();
-  const { isLoginRequired, returnTo } = useLoginRequiredParam();
   const isLoggedIn = useIsLoggedIn();
 
   const [showLoginDialog, setShowLoginDialog] = useState(false);
@@ -112,18 +107,6 @@ export default function ChallengeBoardScreen(): React.ReactElement {
     'UPCOMING',
     'ONGOING',
   ]);
-
-  // 상세 → 목록 바운스 시 원래 가려던 상세 경로. 로그인 후 그리로 복귀한다.
-  const [loginReturnTo, setLoginReturnTo] = useState<string | null>(null);
-  const [prevIsLoginRequired, setPrevIsLoginRequired] = useState(false);
-  if (isLoginRequired !== prevIsLoginRequired) {
-    setPrevIsLoginRequired(isLoginRequired);
-    if (isLoginRequired && !isLoggedIn) {
-      setShowLoginDialog(true);
-      setLoginDialogDescription('챌린지 상세는 로그인 후 이용할 수 있습니다.');
-      setLoginReturnTo(returnTo);
-    }
-  }
 
   const requireAuth = useCallback(
     (description: string, action: () => void): void => {
@@ -183,12 +166,6 @@ export default function ChallengeBoardScreen(): React.ReactElement {
       router.push('/challenge/create')
     );
   }, [requireAuth, router]);
-
-  // 로그인 시 카드 자체가 Link(prefetch)로 이동하므로 비로그인 유도만 남는다.
-  const handleCardRequireLogin = useCallback((): void => {
-    setLoginDialogDescription('챌린지 상세는 로그인 후 이용할 수 있습니다.');
-    setShowLoginDialog(true);
-  }, []);
 
   // 미선택 필터는 undefined 로 넘겨 요청에서 키 자체가 빠지게 한다
   // (빈 값 전송 시 서버 enum 변환 400). status 빈 배열도 동일.
@@ -301,14 +278,8 @@ export default function ChallengeBoardScreen(): React.ReactElement {
     >
       <LoginRequiredDialog
         open={showLoginDialog}
-        onOpenChange={(open) => {
-          setShowLoginDialog(open);
-          if (!open) {
-            setLoginReturnTo(null);
-          }
-        }}
+        onOpenChange={setShowLoginDialog}
         description={loginDialogDescription}
-        returnTo={loginReturnTo}
       />
 
       <div className="mt-2 flex flex-col gap-4 lg:mt-6">
@@ -375,10 +346,7 @@ export default function ChallengeBoardScreen(): React.ReactElement {
               <ChallengeBoardCardItem
                 key={challenge.challengeId}
                 challenge={challenge}
-                href={
-                  isLoggedIn ? `/challenge/${challenge.challengeId}` : undefined
-                }
-                onRequireLogin={handleCardRequireLogin}
+                href={`/challenge/${challenge.challengeId}`}
               />
             ))}
           </div>


### PR DESCRIPTION
## 문제
비로그인 상태에서 챌린지 리스트 → 카드 클릭 시 여전히 "로그인이 필요합니다" 모달이 떴다. PR #199(비로그인 상세 열람 허용)가 서버/미들웨어 레벨에서는 반영됐지만(게스트 상세 GET 200), **리스트 쪽 클라이언트 게이트**가 남아 있었다.

## 실제 원인 (코드 라인)
`src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx`
```tsx
href={ isLoggedIn ? `/challenge/${challenge.challengeId}` : undefined }
onRequireLogin={handleCardRequireLogin}
```
`ChallengeCard`는 `href`가 있으면 `<Link>`로 이동하고, 없으면 `onClick`으로 폴백한다. 비로그인일 때 `href`를 `undefined`로 넘겨 `onClick=handleCardRequireLogin`이 로그인 모달을 띄웠다. 상세 화면·미들웨어가 아니라 **리스트 카드 클릭 핸들러가 원인**.

부수적으로, 미들웨어의 `list-redirect`에서 챌린지 상세가 제외되면서(#199) `/challenge?loginRequired=true` 바운스는 더 이상 발생하지 않는다 → 보드 화면의 `loginRequired` 바운스 처리가 죽은 코드가 되어 함께 제거.

## 수정
- 카드는 로그인 여부와 무관하게 항상 `/challenge/{id}`로 링크 → 게스트도 자유롭게 상세 진입.
- 죽은 `loginRequired` 바운스 state/effect 및 `handleCardRequireLogin` 제거.
- 로그인 유도는 **새 챌린지 만들기 등 액션 시점에만** 유지(`requireAuth` + `LoginRequiredDialog`).
- 상세 화면의 참여·좋아요 게이트는 그대로(이미 액션 시점 게이트).

## 검증
tsc(0) · lint(0 error) · vitest(144 pass) · knip(clean) · build(성공). 브라우저 실측은 미실행 — 사용자 확인 필요.