### PR TITLE
fix: 탐색 공식/추천 챌린지 카드 비로그인 상세 진입 허용 (#200 후속)

### DIFF
--- a/src/app.feature/explore/screen/ExploreScreen.tsx
+++ b/src/app.feature/explore/screen/ExploreScreen.tsx
@@ -101,9 +101,7 @@ export default function ExploreScreen(): React.ReactElement {
             isLoading={isOfficialLoading}
             isError={isOfficialError}
             errorMessage={officialErrorMessage}
-            isLoggedIn={isLoggedIn}
             onMoreClick={handleMoreChallenges}
-            onRequireLogin={handleRequireLogin}
             title="공식 챌린지"
             subtitle="1D1S가 엄선한 챌린지에 참여해보세요"
             emptyTitle="아직 공식 챌린지가 없어요!"
@@ -115,9 +113,7 @@ export default function ExploreScreen(): React.ReactElement {
             isLoading={isChallengesLoading}
             isError={isChallengesError}
             errorMessage={challengesErrorMessage}
-            isLoggedIn={isLoggedIn}
             onMoreClick={handleMoreChallenges}
-            onRequireLogin={handleRequireLogin}
           />
 
           <HomeRandomDiariesSection

--- a/src/app.feature/home/components/HomeRandomChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeRandomChallengesSection.tsx
@@ -23,10 +23,7 @@ interface HomeRandomChallengesSectionProps {
   isLoading: boolean;
   isError: boolean;
   errorMessage: string | null;
-  /** 로그인 시 카드가 상세 Link(prefetch)로, 비로그인 시 로그인 유도로 동작 */
-  isLoggedIn: boolean;
   onMoreClick(): void;
-  onRequireLogin(): void;
   // 아래는 탐색(/explore)에서 공식 챌린지 섹션으로 재사용하기 위한 표시 옵션.
   title?: string;
   subtitle?: string;
@@ -40,9 +37,7 @@ export default function HomeRandomChallengesSection({
   isLoading,
   isError,
   errorMessage,
-  isLoggedIn,
   onMoreClick,
-  onRequireLogin,
   title = '오늘 시작해볼 챌린지',
   subtitle = '함께 도전할 친구를 찾아보세요',
   emptyTitle = '표시할 챌린지가 없어요',
@@ -147,12 +142,7 @@ export default function HomeRandomChallengesSection({
                   isEnded={ended}
                   isPhotoRequired={challenge.photoRequired}
                   participants={challenge.randomParticipants}
-                  href={
-                    isLoggedIn
-                      ? `/challenge/${challenge.challengeId}`
-                      : undefined
-                  }
-                  onClick={onRequireLogin}
+                  href={`/challenge/${challenge.challengeId}`}
                 />
               </div>
             );


### PR DESCRIPTION
## 문제 (증거 기반)

dev.1day1streak.com 에서 **비로그인 상태로 탐색(/explore)의 챌린지 리스트(공식·추천) 카드를 누르면** 로그인 유도 다이얼로그가 뜬다. PR #199/#200 머지 후에도 재현.

### 재현·근본 원인 확인
- **미들웨어**: 게스트 UA로 `curl -I https://dev.1day1streak.com/challenge/58` → **HTTP 200** (리다이렉트 없음). 챌린지 상세는 이미 비로그인 열람 허용됨(`middleware/auth.ts`에서 명시적 제외).
- **배포된 번들 실측**: dev 배포 청크 `2o9c40xm1ppyx.js` 에 아래가 그대로 존재.
  ```
  href: l ? `/challenge/${e.challengeId}` : void 0, onClick: o
  ```
  `l`=isLoggedIn → 비로그인 시 `href=undefined` + `onClick=onRequireLogin` 으로 빠짐.
- **원인**: #200 은 `ChallengeBoardScreen`(`/challenge` 보드)의 게이트만 제거했고, **동일 패턴이 `HomeRandomChallengesSection` 에 남아 있었다.** 이 컴포넌트는 `/explore` 의 "공식 챌린지" + 추천 챌린지 리스트로 쓰인다(사용자가 말한 "챌린지 리스트").

## 수정
- `HomeRandomChallengesSection` 챌린지 카드는 항상 `/challenge/{id}` 로 링크(상세는 비로그인 열람 가능).
- 더 이상 쓰이지 않는 `isLoggedIn`·`onRequireLogin` prop 제거 + 탐색 호출부 정리.
- 일지 섹션(`HomeRandomDiariesSection`)은 상세가 여전히 보호 경로이므로 게이트 유지.

## 검증
- `tsc --noEmit` 0 errors / `eslint` 0 errors / `vitest` 144 passed / `knip` clean / `next build` 성공.
- 배포 후 게스트 진입 curl 재검증 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Challenge cards can now be opened directly from the Explore screen.
  * Added navigation to the full challenge list through the “more” action.
  * Challenge sections are accessible without login-gating prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->