### PR TITLE
fix: 챌린지 카드 썸네일 배지 좁은 폭에서 겹침·줄바꿈 깨짐 수정

### DIFF
--- a/src/app.component/cards/ChallengeCard.tsx
+++ b/src/app.component/cards/ChallengeCard.tsx
@@ -261,29 +261,31 @@ function ChallengeCard({
             className={cn(
               // pointer-events-none: stretched-link 위의 장식 배지가 클릭
               // 데드존이 되지 않도록 포인터 이벤트를 통과시킨다.
-              'pointer-events-none absolute top-2 right-2 z-10 flex',
-              'items-center gap-1'
+              // left-2 로 폭을 제한하고 flex-wrap+justify-end 로 좁은 카드에서
+              // 배지가 겹치지 않고 우측 정렬을 유지한 채 다음 줄로 넘어가게 한다.
+              'pointer-events-none absolute top-2 right-2 left-2 z-10 flex',
+              'flex-wrap items-center justify-end gap-1'
             )}
           >
             {isPhotoRequired ? (
               <span
                 aria-label="인증샷 필수"
                 className={cn(
-                  'inline-flex items-center gap-1 rounded-full',
+                  'inline-flex shrink-0 items-center gap-1 rounded-full',
                   'bg-main-800 px-2 py-1 text-[10px] font-bold text-white',
-                  'shadow-sm'
+                  'whitespace-nowrap shadow-sm'
                 )}
               >
-                <Camera className="h-3 w-3" />
+                <Camera className="h-3 w-3 shrink-0" />
                 인증샷
               </span>
             ) : null}
             {goalLabel ? (
               <span
                 className={cn(
-                  'inline-flex items-center rounded-full bg-white/95',
+                  'inline-flex shrink-0 items-center rounded-full bg-white/95',
                   'px-2 py-1 text-[10px] font-bold text-gray-700',
-                  'shadow-sm'
+                  'whitespace-nowrap shadow-sm'
                 )}
               >
                 {goalLabel}
@@ -291,8 +293,8 @@ function ChallengeCard({
             ) : null}
             <span
               className={cn(
-                'inline-flex items-center rounded-full px-2.5 py-1',
-                'text-[11px] font-bold shadow-sm',
+                'inline-flex shrink-0 items-center rounded-full px-2.5 py-1',
+                'text-[11px] font-bold whitespace-nowrap shadow-sm',
                 isGroup ? 'bg-main-800 text-white' : 'bg-white text-gray-900'
               )}
             >


### PR DESCRIPTION
## 문제
챌린지 카드 썸네일 위 배지(인증샷 / 고정 목표 / 단체)가 **카드 폭이 좁아지면 서로 겹치고 배지 안 텍스트가 "고정 목 표", "단 체"처럼 줄바꿈되어 깨진다.** (태블릿 4열 그리드에서 재현)

### 원인
배지 컨테이너가 `absolute top-2 right-2 flex items-center gap-1` — **폭 제한과 wrap 이 없다.** 배지 행이 카드 너비를 넘으면 flex 기본 `shrink:1` 로 각 배지가 축소되고, 그 안의 텍스트가 강제 줄바꿈된다.

## 수정
- 컨테이너: `left-2` 로 폭을 제한하고 `flex-wrap items-center justify-end` — 넘칠 때 겹치지 않고 **우측 정렬을 유지한 채 다음 줄로 wrap.**
- 각 배지: `shrink-0`(축소 금지) + `whitespace-nowrap`(내부 줄바꿈 금지). Camera 아이콘에도 `shrink-0`.
- DS 컴포넌트/토큰·색·굵기 그대로. 배지 3개 이상도 견고. 모바일 1열·태블릿 다열·데스크톱 공통.

## 검증
- `tsc` 0 · `eslint` 0 errors · `vitest` 144 passed · `knip` clean · `next build` 성공.
- (프로젝트 정책상 브라우저 프리뷰 미사용 — 정적 클래스 검토로 확인, 배포 후 실제 확인 예정.)