### PR TITLE
fix: 비로그인 상태 인증 에러(AUTH-002) 토스트 노출 차단

### DIFF
--- a/src/app.feature/diary/board/hooks/useDiaryQueries.ts
+++ b/src/app.feature/diary/board/hooks/useDiaryQueries.ts
@@ -1,3 +1,4 @@
+import { authStorage } from '@module/utils/auth';
 import {
   InfiniteData,
   useInfiniteQuery,
@@ -81,6 +82,8 @@ export function useMyDiaries(
   return useQuery({
     queryKey: DIARY_QUERY_KEYS.myDiaries({ size }),
     queryFn: () => diaryBoardApi.getMyDiaries({ size }),
+    // 인증 필수 API — 세션이 있을 때만 조회한다(로그아웃 상태 AUTH-002 방지).
+    enabled: authStorage.hasTokens(),
   });
 }
 

--- a/src/app.feature/home/hooks/useTodayRecords.ts
+++ b/src/app.feature/home/hooks/useTodayRecords.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import type { SidebarChallenge } from '@feature/member/type/member';
+import { authStorage } from '@module/utils/auth';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -54,6 +55,9 @@ export function useTodayRecords(
   const { data, isLoading } = useQuery({
     queryKey: HOME_QUERY_KEYS.todayChallenges(),
     queryFn: homeApi.getMyTodayChallenges,
+    // 인증 필수 API — 로그아웃/stale 힌트 상태에서 실행돼 AUTH-002 를 유발하지
+    // 않도록 세션이 있을 때만 조회한다.
+    enabled: authStorage.hasTokens(),
   });
 
   return useMemo(() => {

--- a/src/app.module/api/error.test.ts
+++ b/src/app.module/api/error.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { isInvalidRefreshTokenError } from './error';
+import { isAuthPrincipalError, isInvalidRefreshTokenError } from './error';
 
 const axiosErrorWithCode = (code: string): unknown => ({
   isAxiosError: true,
   response: { status: 401, data: { code } },
+});
+
+// AUTH-001/AUTH-002 는 서버가 400 으로 내려주므로 상태 코드를 400 으로 둔다.
+const axiosBadRequestWithCode = (code: string): unknown => ({
+  isAxiosError: true,
+  response: { status: 400, data: { code } },
 });
 
 describe('isInvalidRefreshTokenError', () => {
@@ -19,5 +25,20 @@ describe('isInvalidRefreshTokenError', () => {
       false
     );
     expect(isInvalidRefreshTokenError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('isAuthPrincipalError', () => {
+  // 익명/무효 principal 로 인증 필수 API 를 호출한 400 응답. 세션 힌트가 stale 한
+  // 상태이므로 토스트 대신 조용히 세션을 정리해야 한다.
+  it.each(['AUTH-001', 'AUTH-002'])('treats %s as principal error', (code) => {
+    expect(isAuthPrincipalError(axiosBadRequestWithCode(code))).toBe(true);
+  });
+
+  it('ignores other codes and non-axios errors', () => {
+    expect(isAuthPrincipalError(axiosBadRequestWithCode('AUTH-006'))).toBe(
+      false
+    );
+    expect(isAuthPrincipalError(new Error('boom'))).toBe(false);
   });
 });

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -87,6 +87,14 @@ const getResponseCode = (payload: unknown): string | null => {
 //     남은 access 쿠키를 보고 힌트를 재발급해 강제 로그아웃이 되돌려진다.
 const INVALID_REFRESH_TOKEN_CODES = new Set(['AUTH-006', 'AUTH-012']);
 
+// 인증 주체(principal) 자체가 무효인 코드. 익명/무효 세션으로 인증 필수
+// 엔드포인트를 호출하면 서버가 401 이 아니라 400 으로 내려주므로 상태 코드만으론
+// 걸러지지 않는다. 클라 세션 힌트(hasTokens)가 stale 해서 로그아웃 사용자가
+// 인증 쿼리를 실행한 상황이라, 401 과 동일하게 조용히 세션 정리 대상으로 본다.
+//   - AUTH-001: 인증 정보 없음
+//   - AUTH-002: 잘못된 시큐리티 프린시플(INVALID_AUTH_PRINCIPAL)
+const INVALID_AUTH_PRINCIPAL_CODES = new Set(['AUTH-001', 'AUTH-002']);
+
 // 백엔드 도메인 에러 코드(예: CHALLENGE_022)를 응답 본문에서 추출한다.
 // 상태 코드만으로 구분할 수 없는 분기 처리에 사용한다.
 export const getApiErrorCode = (error: unknown): string | null => {
@@ -114,6 +122,14 @@ export const isInvalidRefreshTokenError = (error: unknown): boolean => {
   }
   const code = getResponseCode(error.response?.data);
   return code !== null && INVALID_REFRESH_TOKEN_CODES.has(code);
+};
+
+export const isAuthPrincipalError = (error: unknown): boolean => {
+  if (!isAxiosErrorLike(error)) {
+    return false;
+  }
+  const code = getResponseCode(error.response?.data);
+  return code !== null && INVALID_AUTH_PRINCIPAL_CODES.has(code);
 };
 
 export const normalizeApiError = (error: unknown): NormalizedApiError => {

--- a/src/app.module/api/errorNotify.ts
+++ b/src/app.module/api/errorNotify.ts
@@ -6,6 +6,7 @@ import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
 
 import { API_BASE_URL } from './config';
 import {
+  isAuthPrincipalError,
   isForbiddenError,
   isInvalidRefreshTokenError,
   isRedirectError,
@@ -64,11 +65,16 @@ export const handleAuthError = (error: unknown): void => {
   // 무한 반복된다. 반대로 5xx·429·408·네트워크/타임아웃(일시적)에는 세션을
   // 유지하고 다음 요청에서 재시도하게 둔다 — 백엔드 순단으로 로그인 사용자를
   // 일괄 로그아웃시키지 않기 위함.
+  // AUTH-001/AUTH-002: 세션 힌트(hasTokens)가 stale 해서 로그아웃 사용자가
+  // 인증 쿼리를 실행한 경우. 서버가 400 으로 내려 401 경로를 안 타므로 여기서
+  // 힌트를 정리하지 않으면 hasTokens() 가 계속 true 라 같은 요청이 반복된다.
   const invalidRefresh = isInvalidRefreshTokenError(error);
+  const invalidPrincipal = isAuthPrincipalError(error);
   if (
     !isUnauthorizedError(error) &&
     !isForbiddenError(error) &&
-    !invalidRefresh
+    !invalidRefresh &&
+    !invalidPrincipal
   ) {
     return;
   }
@@ -111,10 +117,17 @@ export const notifyApiError = (error: unknown): void => {
     return;
   }
 
-  // refresh token 자체가 무효(AUTH-006)면, 같은 에러를 토스트로 반복 노출하는
-  // 대신 조용히 로그아웃 정리한다. (handleUnauthorized=false 인 publicApiClient
-  // 의 /auth/token 호출이 이 경로로 들어온다.)
-  if (isInvalidRefreshTokenError(error)) {
+  // 인증 계열 에러는 토스트로 노출하지 않고 조용히 처리한다. 비로그인/세션 만료는
+  // 사용자에게 "잘못된 시큐리티 프린시플" 같은 원문 에러를 보여줄 게 아니라,
+  // 세션 힌트를 정리하고 (보호 경로면) 로그인으로 유도해야 한다.
+  //   - 401: 토큰 없음/만료
+  //   - AUTH-001/AUTH-002: 익명/무효 principal 로 인증 필수 API 호출(400)
+  //   - AUTH-006/AUTH-012: refresh token 무효
+  if (
+    isUnauthorizedError(error) ||
+    isAuthPrincipalError(error) ||
+    isInvalidRefreshTokenError(error)
+  ) {
     handleAuthError(error);
     return;
   }


### PR DESCRIPTION
## 문제

비로그인/세션 만료 사용자가 홈(`/`)·마이페이지 진입 시 **"잘못된 시큐리티 프린시플"(400 AUTH-002)** 등 인증 에러가 토스트로 그대로 노출됨.

## 원인

- `authStorage.hasTokens()` 가 90일 hint 쿠키/`localStorage` 플래그에만 의존 → HttpOnly 토큰이 만료된 뒤에도 **stale 하게 `true`** 반환.
- 그 상태에서 `useSidebar(enabled: hasTokens)` 등 인증 필수 쿼리가 **익명으로 실행** → 서버가 401 이 아닌 **400 AUTH-002** 반환.
- 400 이라 인터셉터의 401 refresh/로그아웃 경로를 안 타 → hint 가 정리되지 않아 매 진입마다 재발.
- 전역 `QueryCache.onError` → `notifyApiError` 가 AUTH-006/012·302 외 **모든 에러를 토스트** → AUTH-002 원문 노출.

## 수정

- `error.ts`: `AUTH-001`/`AUTH-002` 를 `isAuthPrincipalError` 로 분류.
- `errorNotify.ts`: **401/AUTH-001/AUTH-002/무효 refresh 는 토스트 대신 `handleAuthError`** 로 조용히 세션 정리(+보호 경로면 로그인 유도). AUTH-002 수신 시 stale hint 를 정리해 **인증 쿼리 반복 실행 루프 차단**.
- `useMyDiaries`/`useTodayRecords`: 게이팅 없던 인증 필수 쿼리에 `enabled: authStorage.hasTokens()` 추가.

## 검증

`tsc --noEmit` · `pnpm lint` · `pnpm test`(147 passed) · `pnpm knip` · `pnpm build` 모두 통과. 브라우저 확인은 하지 않음(사용자 확인 예정).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented diary and today’s records requests from running when you’re signed out.
  * Improved handling of invalid or missing authentication, including cases where the server reports a different error status.
  * Automatically clears invalid session information and redirects appropriately when authentication can no longer be used.
  * Reduced unnecessary error notifications for expected authentication-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->