### PR TITLE
fix: 비로그인 상태 데스크톱 GNB 마이페이지 노출 차단

### DIFF
--- a/src/app.component/layout/AppTopNav.tsx
+++ b/src/app.component/layout/AppTopNav.tsx
@@ -4,7 +4,10 @@ import { Icon, StreakChip } from '@1d1s/design-system';
 import { ChallengeTrophyIcon } from '@component/ChallengeTrophyIcon';
 import { Skeleton } from '@component/Skeleton';
 import { cn } from '@module/utils/cn';
-import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
+import {
+  buildLoginUrl,
+  loginUrlFromCurrentLocation,
+} from '@module/utils/returnTo';
 import { BookOpen, Compass, User } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -85,10 +88,16 @@ export default function AppTopNav({
       <nav className="flex items-center gap-1">
         {NAV_ITEMS.map((item) => {
           const active = activeId === item.id;
+          // 로그인 필요한 최상위 메뉴(마이페이지)는 비로그인에 그대로 노출하지
+          // 않는다. 모바일 바텀 네비와 동일하게 '로그인'으로 바꾸고 로그인 후
+          // 원래 목적지(마이페이지)로 복귀하는 동선으로 유도한다.
+          const isGuestMyPage = item.id === 'mypage' && !isLoggedIn;
+          const href = isGuestMyPage ? buildLoginUrl('/mypage') : item.href;
+          const label = isGuestMyPage ? '로그인' : item.label;
           return (
             <Link
               key={item.id}
-              href={item.href}
+              href={href}
               className={cn(
                 'rounded-2 inline-flex items-center gap-1.5 transition',
                 'px-2.5 py-1.5 lg:px-3.5 lg:py-2',
@@ -101,7 +110,7 @@ export default function AppTopNav({
               {item.NavIcon ? (
                 <item.NavIcon className="h-3.5 w-3.5" aria-hidden />
               ) : null}
-              {item.label}
+              {label}
             </Link>
           );
         })}


### PR DESCRIPTION
## 문제

데스크톱 상단 GNB에서 **비로그인 상태인데도 '마이페이지'가 노출**되고, 클릭해 진입하면 인증 에러(AUTH 계열)가 발생. PR #203(인증 에러 조용히 처리) 이후에도 재현.

## 원인 (root cause)

`AppTopNav.tsx` 의 `NAV_ITEMS` 가 `isLoggedIn` 과 **무관하게 항상** 렌더됨. `isLoggedIn` prop 은 태블릿 이하 아바타/로그인 클러스터에만 쓰이고, 데스크톱 nav 항목 게이팅에는 쓰이지 않았다. 모바일 바텀 네비(`AppBottomNav`)는 이미 비로그인 시 마이 탭을 '로그인'으로 바꿔 `buildLoginUrl('/mypage')` 로 유도하고 있었으나, **데스크톱 GNB에는 동일 정책이 적용되지 않은 것**이 유일한 실질 원인.

클릭 시 발생하던 인증 에러는 위 노출 버그의 하위 증상 — 잘못 노출된 마이페이지 링크로 진입하며 인증 쿼리가 실행된 결과다.

## 확인 (변경 불필요로 판단한 지점)

- **미들웨어 보호 경로**: `/^\/mypage(\/.*)?$/` 가 `login-redirect` 로 이미 포함됨 (#199 에서 누락되지 않음). 비로그인 직접 접근은 `/login` 으로 리다이렉트됨.
- **AUTH 에러 토스트(#203)**: 배포 dev API 실측 결과 익명 `/member/my-page`·`/member/side-bar` 는 **302→/login**, `/auth/token` 은 **401 AUTH-006** 응답. apiClient 인터셉터가 리다이렉트 감지→refresh 실패→`handleAuthError` 로 조용히 세션 정리+리다이렉트하며, `QueryCache.onError` 경로도 동일하게 silent 처리됨. 토스트 누출 없음.
- **힌트 정리 반영(#203)**: `authStorage.clearTokens()` 가 `notifyAuthChange()` 로 `useHasSessionHint`(useSyncExternalStore) 구독자를 깨워 GNB 가 즉시 로그아웃 상태로 전환됨.

## 변경

- `AppTopNav` 의 마이페이지 항목: 비로그인 시 label→'로그인', href→`buildLoginUrl('/mypage')` 로 전환해 모바일 바텀 네비와 정책 일치.

## 검증

`tsc --noEmit` ✓ / `eslint` 0 errors ✓ / `vitest` 147 passed ✓ / `knip` ✓ / `next build` ✓
(브라우저 실기기 확인은 하지 않음 — 정적 검증까지 수행)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “마이페이지” navigation item for logged-out visitors.
  * Selecting it now redirects to the login page and displays “로그인” instead of the original label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->