### PR TITLE
release: 챌린지 상세 게스트 개방 + 비로그인 UX 개선 승격 (develop → main)

### DIFF
--- a/src/app.component/cards/ChallengeCard.tsx
+++ b/src/app.component/cards/ChallengeCard.tsx
@@ -261,29 +261,31 @@ function ChallengeCard({
             className={cn(
               // pointer-events-none: stretched-link 위의 장식 배지가 클릭
               // 데드존이 되지 않도록 포인터 이벤트를 통과시킨다.
-              'pointer-events-none absolute top-2 right-2 z-10 flex',
-              'items-center gap-1'
+              // left-2 로 폭을 제한하고 flex-wrap+justify-end 로 좁은 카드에서
+              // 배지가 겹치지 않고 우측 정렬을 유지한 채 다음 줄로 넘어가게 한다.
+              'pointer-events-none absolute top-2 right-2 left-2 z-10 flex',
+              'flex-wrap items-center justify-end gap-1'
             )}
           >
             {isPhotoRequired ? (
               <span
                 aria-label="인증샷 필수"
                 className={cn(
-                  'inline-flex items-center gap-1 rounded-full',
+                  'inline-flex shrink-0 items-center gap-1 rounded-full',
                   'bg-main-800 px-2 py-1 text-[10px] font-bold text-white',
-                  'shadow-sm'
+                  'whitespace-nowrap shadow-sm'
                 )}
               >
-                <Camera className="h-3 w-3" />
+                <Camera className="h-3 w-3 shrink-0" />
                 인증샷
               </span>
             ) : null}
             {goalLabel ? (
               <span
                 className={cn(
-                  'inline-flex items-center rounded-full bg-white/95',
+                  'inline-flex shrink-0 items-center rounded-full bg-white/95',
                   'px-2 py-1 text-[10px] font-bold text-gray-700',
-                  'shadow-sm'
+                  'whitespace-nowrap shadow-sm'
                 )}
               >
                 {goalLabel}
@@ -291,8 +293,8 @@ function ChallengeCard({
             ) : null}
             <span
               className={cn(
-                'inline-flex items-center rounded-full px-2.5 py-1',
-                'text-[11px] font-bold shadow-sm',
+                'inline-flex shrink-0 items-center rounded-full px-2.5 py-1',
+                'text-[11px] font-bold whitespace-nowrap shadow-sm',
                 isGroup ? 'bg-main-800 text-white' : 'bg-white text-gray-900'
               )}
             >

--- a/src/app.component/layout/AppTopNav.tsx
+++ b/src/app.component/layout/AppTopNav.tsx
@@ -4,7 +4,10 @@ import { Icon, StreakChip } from '@1d1s/design-system';
 import { ChallengeTrophyIcon } from '@component/ChallengeTrophyIcon';
 import { Skeleton } from '@component/Skeleton';
 import { cn } from '@module/utils/cn';
-import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
+import {
+  buildLoginUrl,
+  loginUrlFromCurrentLocation,
+} from '@module/utils/returnTo';
 import { BookOpen, Compass, User } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -85,10 +88,16 @@ export default function AppTopNav({
       <nav className="flex items-center gap-1">
         {NAV_ITEMS.map((item) => {
           const active = activeId === item.id;
+          // 로그인 필요한 최상위 메뉴(마이페이지)는 비로그인에 그대로 노출하지
+          // 않는다. 모바일 바텀 네비와 동일하게 '로그인'으로 바꾸고 로그인 후
+          // 원래 목적지(마이페이지)로 복귀하는 동선으로 유도한다.
+          const isGuestMyPage = item.id === 'mypage' && !isLoggedIn;
+          const href = isGuestMyPage ? buildLoginUrl('/mypage') : item.href;
+          const label = isGuestMyPage ? '로그인' : item.label;
           return (
             <Link
               key={item.id}
-              href={item.href}
+              href={href}
               className={cn(
                 'rounded-2 inline-flex items-center gap-1.5 transition',
                 'px-2.5 py-1.5 lg:px-3.5 lg:py-2',
@@ -101,7 +110,7 @@ export default function AppTopNav({
               {item.NavIcon ? (
                 <item.NavIcon className="h-3.5 w-3.5" aria-hidden />
               ) : null}
-              {item.label}
+              {label}
             </Link>
           );
         })}

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -16,7 +16,6 @@ import {
 } from '@constants/categories';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
-import { useLoginRequiredParam } from '@module/hooks/useLoginRequiredParam';
 import { cn } from '@module/utils/cn';
 import { X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -39,9 +38,8 @@ import {
 
 interface ChallengeBoardCardItemProps {
   challenge: ChallengeListItem;
-  /** 로그인 시 상세 링크. 비로그인 시 undefined + onRequireLogin 사용. */
-  href?: string;
-  onRequireLogin(): void;
+  /** 상세 링크. 상세는 비로그인도 열람 가능하므로 항상 지정된다. */
+  href: string;
 }
 
 // 카드 매핑에서 인라인 람다·파생 계산을 제거해 React.memo(ChallengeCard) 가
@@ -50,7 +48,6 @@ const ChallengeBoardCardItem = React.memo(
   ({
     challenge,
     href,
-    onRequireLogin,
   }: ChallengeBoardCardItemProps): React.ReactElement => {
     const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
     const ended = isChallengeEndedOrArchived(
@@ -86,7 +83,6 @@ const ChallengeBoardCardItem = React.memo(
         isOfficial={challenge.challengeType === 'OFFICIAL'}
         participants={challenge.randomParticipants}
         href={href}
-        onClick={onRequireLogin}
       />
     );
   }
@@ -95,7 +91,6 @@ ChallengeBoardCardItem.displayName = 'ChallengeBoardCardItem';
 
 export default function ChallengeBoardScreen(): React.ReactElement {
   const router = useRouter();
-  const { isLoginRequired, returnTo } = useLoginRequiredParam();
   const isLoggedIn = useIsLoggedIn();
 
   const [showLoginDialog, setShowLoginDialog] = useState(false);
@@ -112,18 +107,6 @@ export default function ChallengeBoardScreen(): React.ReactElement {
     'UPCOMING',
     'ONGOING',
   ]);
-
-  // 상세 → 목록 바운스 시 원래 가려던 상세 경로. 로그인 후 그리로 복귀한다.
-  const [loginReturnTo, setLoginReturnTo] = useState<string | null>(null);
-  const [prevIsLoginRequired, setPrevIsLoginRequired] = useState(false);
-  if (isLoginRequired !== prevIsLoginRequired) {
-    setPrevIsLoginRequired(isLoginRequired);
-    if (isLoginRequired && !isLoggedIn) {
-      setShowLoginDialog(true);
-      setLoginDialogDescription('챌린지 상세는 로그인 후 이용할 수 있습니다.');
-      setLoginReturnTo(returnTo);
-    }
-  }
 
   const requireAuth = useCallback(
     (description: string, action: () => void): void => {
@@ -183,12 +166,6 @@ export default function ChallengeBoardScreen(): React.ReactElement {
       router.push('/challenge/create')
     );
   }, [requireAuth, router]);
-
-  // 로그인 시 카드 자체가 Link(prefetch)로 이동하므로 비로그인 유도만 남는다.
-  const handleCardRequireLogin = useCallback((): void => {
-    setLoginDialogDescription('챌린지 상세는 로그인 후 이용할 수 있습니다.');
-    setShowLoginDialog(true);
-  }, []);
 
   // 미선택 필터는 undefined 로 넘겨 요청에서 키 자체가 빠지게 한다
   // (빈 값 전송 시 서버 enum 변환 400). status 빈 배열도 동일.
@@ -301,14 +278,8 @@ export default function ChallengeBoardScreen(): React.ReactElement {
     >
       <LoginRequiredDialog
         open={showLoginDialog}
-        onOpenChange={(open) => {
-          setShowLoginDialog(open);
-          if (!open) {
-            setLoginReturnTo(null);
-          }
-        }}
+        onOpenChange={setShowLoginDialog}
         description={loginDialogDescription}
-        returnTo={loginReturnTo}
       />
 
       <div className="mt-2 flex flex-col gap-4 lg:mt-6">
@@ -375,10 +346,7 @@ export default function ChallengeBoardScreen(): React.ReactElement {
               <ChallengeBoardCardItem
                 key={challenge.challengeId}
                 challenge={challenge}
-                href={
-                  isLoggedIn ? `/challenge/${challenge.challengeId}` : undefined
-                }
-                onRequireLogin={handleCardRequireLogin}
+                href={`/challenge/${challenge.challengeId}`}
               />
             ))}
           </div>

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -206,6 +206,18 @@ export function ChallengeDetailScreen({
     useState(false);
   // 비공개 챌린지가 자유 목표로 확인돼 목표 입력이 필요한지.
   const [passwordNeedsGoals, setPasswordNeedsGoals] = useState(false);
+  // 비로그인 사용자가 로그인 필요 액션(참여·좋아요 등)을 누르면 로그인 유도.
+  const [showLoginPrompt, setShowLoginPrompt] = useState(false);
+
+  // 로그인 필요 액션 게이트. 비로그인이면 로그인 유도 다이얼로그를 띄우고
+  // false 를 반환한다(호출부는 즉시 return).
+  const requireLogin = (): boolean => {
+    if (isLoggedIn) {
+      return true;
+    }
+    setShowLoginPrompt(true);
+    return false;
+  };
 
   const summary = data?.challengeSummary;
   const detail = data?.challengeDetail;
@@ -310,6 +322,9 @@ export function ChallengeDetailScreen({
   });
 
   const handleJoinChallenge = (): void => {
+    if (!requireLogin()) {
+      return;
+    }
     if (isChallengeAlreadyEnded) {
       toast.error('종료된 챌린지는 참여 신청을 보낼 수 없습니다.');
       return;
@@ -351,6 +366,9 @@ export function ChallengeDetailScreen({
   };
 
   const handleToggleLike = (): void => {
+    if (!requireLogin()) {
+      return;
+    }
     if (!summary) {
       return;
     }
@@ -431,19 +449,6 @@ export function ChallengeDetailScreen({
   // 비공개 챌린지(403)는 비밀번호 검증 모달로 유도한다.
   const isPrivateChallengeLocked =
     isError && normalizeApiError(error).status === 403;
-
-  if (!isLoggedIn) {
-    return (
-      <LoginRequiredDialog
-        open
-        onOpenChange={() => {}}
-        title="간편 가입 후에 둘러보세요!"
-        description="챌린지 상세는 로그인 후 이용할 수 있습니다."
-        required
-        onClose={() => router.push('/challenge')}
-      />
-    );
-  }
 
   if (showSkeleton) {
     return <ChallengeDetailSkeleton />;
@@ -584,6 +589,12 @@ export function ChallengeDetailScreen({
         )}
       >
         <ChallengeGoalModals editors={goalEditors} />
+        <LoginRequiredDialog
+          open={showLoginPrompt}
+          onOpenChange={setShowLoginPrompt}
+          title="로그인이 필요해요"
+          description="이 기능은 로그인 후 이용할 수 있어요."
+        />
         <AlertDialog
           open={showCreateUnavailableDialog}
           onOpenChange={setShowCreateUnavailableDialog}

--- a/src/app.feature/diary/board/hooks/useDiaryQueries.ts
+++ b/src/app.feature/diary/board/hooks/useDiaryQueries.ts
@@ -1,3 +1,4 @@
+import { authStorage } from '@module/utils/auth';
 import {
   InfiniteData,
   useInfiniteQuery,
@@ -81,6 +82,8 @@ export function useMyDiaries(
   return useQuery({
     queryKey: DIARY_QUERY_KEYS.myDiaries({ size }),
     queryFn: () => diaryBoardApi.getMyDiaries({ size }),
+    // 인증 필수 API — 세션이 있을 때만 조회한다(로그아웃 상태 AUTH-002 방지).
+    enabled: authStorage.hasTokens(),
   });
 }
 

--- a/src/app.feature/explore/screen/ExploreScreen.tsx
+++ b/src/app.feature/explore/screen/ExploreScreen.tsx
@@ -101,9 +101,7 @@ export default function ExploreScreen(): React.ReactElement {
             isLoading={isOfficialLoading}
             isError={isOfficialError}
             errorMessage={officialErrorMessage}
-            isLoggedIn={isLoggedIn}
             onMoreClick={handleMoreChallenges}
-            onRequireLogin={handleRequireLogin}
             title="공식 챌린지"
             subtitle="1D1S가 엄선한 챌린지에 참여해보세요"
             emptyTitle="아직 공식 챌린지가 없어요!"
@@ -115,9 +113,7 @@ export default function ExploreScreen(): React.ReactElement {
             isLoading={isChallengesLoading}
             isError={isChallengesError}
             errorMessage={challengesErrorMessage}
-            isLoggedIn={isLoggedIn}
             onMoreClick={handleMoreChallenges}
-            onRequireLogin={handleRequireLogin}
           />
 
           <HomeRandomDiariesSection

--- a/src/app.feature/home/components/HomeRandomChallengesSection.tsx
+++ b/src/app.feature/home/components/HomeRandomChallengesSection.tsx
@@ -23,10 +23,7 @@ interface HomeRandomChallengesSectionProps {
   isLoading: boolean;
   isError: boolean;
   errorMessage: string | null;
-  /** 로그인 시 카드가 상세 Link(prefetch)로, 비로그인 시 로그인 유도로 동작 */
-  isLoggedIn: boolean;
   onMoreClick(): void;
-  onRequireLogin(): void;
   // 아래는 탐색(/explore)에서 공식 챌린지 섹션으로 재사용하기 위한 표시 옵션.
   title?: string;
   subtitle?: string;
@@ -40,9 +37,7 @@ export default function HomeRandomChallengesSection({
   isLoading,
   isError,
   errorMessage,
-  isLoggedIn,
   onMoreClick,
-  onRequireLogin,
   title = '오늘 시작해볼 챌린지',
   subtitle = '함께 도전할 친구를 찾아보세요',
   emptyTitle = '표시할 챌린지가 없어요',
@@ -147,12 +142,7 @@ export default function HomeRandomChallengesSection({
                   isEnded={ended}
                   isPhotoRequired={challenge.photoRequired}
                   participants={challenge.randomParticipants}
-                  href={
-                    isLoggedIn
-                      ? `/challenge/${challenge.challengeId}`
-                      : undefined
-                  }
-                  onClick={onRequireLogin}
+                  href={`/challenge/${challenge.challengeId}`}
                 />
               </div>
             );

--- a/src/app.feature/home/hooks/useTodayRecords.ts
+++ b/src/app.feature/home/hooks/useTodayRecords.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import type { SidebarChallenge } from '@feature/member/type/member';
+import { authStorage } from '@module/utils/auth';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -54,6 +55,9 @@ export function useTodayRecords(
   const { data, isLoading } = useQuery({
     queryKey: HOME_QUERY_KEYS.todayChallenges(),
     queryFn: homeApi.getMyTodayChallenges,
+    // 인증 필수 API — 로그아웃/stale 힌트 상태에서 실행돼 AUTH-002 를 유발하지
+    // 않도록 세션이 있을 때만 조회한다.
+    enabled: authStorage.hasTokens(),
   });
 
   return useMemo(() => {

--- a/src/app.module/api/error.test.ts
+++ b/src/app.module/api/error.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { isInvalidRefreshTokenError } from './error';
+import { isAuthPrincipalError, isInvalidRefreshTokenError } from './error';
 
 const axiosErrorWithCode = (code: string): unknown => ({
   isAxiosError: true,
   response: { status: 401, data: { code } },
+});
+
+// AUTH-001/AUTH-002 는 서버가 400 으로 내려주므로 상태 코드를 400 으로 둔다.
+const axiosBadRequestWithCode = (code: string): unknown => ({
+  isAxiosError: true,
+  response: { status: 400, data: { code } },
 });
 
 describe('isInvalidRefreshTokenError', () => {
@@ -19,5 +25,20 @@ describe('isInvalidRefreshTokenError', () => {
       false
     );
     expect(isInvalidRefreshTokenError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('isAuthPrincipalError', () => {
+  // 익명/무효 principal 로 인증 필수 API 를 호출한 400 응답. 세션 힌트가 stale 한
+  // 상태이므로 토스트 대신 조용히 세션을 정리해야 한다.
+  it.each(['AUTH-001', 'AUTH-002'])('treats %s as principal error', (code) => {
+    expect(isAuthPrincipalError(axiosBadRequestWithCode(code))).toBe(true);
+  });
+
+  it('ignores other codes and non-axios errors', () => {
+    expect(isAuthPrincipalError(axiosBadRequestWithCode('AUTH-006'))).toBe(
+      false
+    );
+    expect(isAuthPrincipalError(new Error('boom'))).toBe(false);
   });
 });

--- a/src/app.module/api/error.ts
+++ b/src/app.module/api/error.ts
@@ -87,6 +87,14 @@ const getResponseCode = (payload: unknown): string | null => {
 //     남은 access 쿠키를 보고 힌트를 재발급해 강제 로그아웃이 되돌려진다.
 const INVALID_REFRESH_TOKEN_CODES = new Set(['AUTH-006', 'AUTH-012']);
 
+// 인증 주체(principal) 자체가 무효인 코드. 익명/무효 세션으로 인증 필수
+// 엔드포인트를 호출하면 서버가 401 이 아니라 400 으로 내려주므로 상태 코드만으론
+// 걸러지지 않는다. 클라 세션 힌트(hasTokens)가 stale 해서 로그아웃 사용자가
+// 인증 쿼리를 실행한 상황이라, 401 과 동일하게 조용히 세션 정리 대상으로 본다.
+//   - AUTH-001: 인증 정보 없음
+//   - AUTH-002: 잘못된 시큐리티 프린시플(INVALID_AUTH_PRINCIPAL)
+const INVALID_AUTH_PRINCIPAL_CODES = new Set(['AUTH-001', 'AUTH-002']);
+
 // 백엔드 도메인 에러 코드(예: CHALLENGE_022)를 응답 본문에서 추출한다.
 // 상태 코드만으로 구분할 수 없는 분기 처리에 사용한다.
 export const getApiErrorCode = (error: unknown): string | null => {
@@ -114,6 +122,14 @@ export const isInvalidRefreshTokenError = (error: unknown): boolean => {
   }
   const code = getResponseCode(error.response?.data);
   return code !== null && INVALID_REFRESH_TOKEN_CODES.has(code);
+};
+
+export const isAuthPrincipalError = (error: unknown): boolean => {
+  if (!isAxiosErrorLike(error)) {
+    return false;
+  }
+  const code = getResponseCode(error.response?.data);
+  return code !== null && INVALID_AUTH_PRINCIPAL_CODES.has(code);
 };
 
 export const normalizeApiError = (error: unknown): NormalizedApiError => {

--- a/src/app.module/api/errorNotify.ts
+++ b/src/app.module/api/errorNotify.ts
@@ -6,6 +6,7 @@ import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
 
 import { API_BASE_URL } from './config';
 import {
+  isAuthPrincipalError,
   isForbiddenError,
   isInvalidRefreshTokenError,
   isRedirectError,
@@ -64,11 +65,16 @@ export const handleAuthError = (error: unknown): void => {
   // 무한 반복된다. 반대로 5xx·429·408·네트워크/타임아웃(일시적)에는 세션을
   // 유지하고 다음 요청에서 재시도하게 둔다 — 백엔드 순단으로 로그인 사용자를
   // 일괄 로그아웃시키지 않기 위함.
+  // AUTH-001/AUTH-002: 세션 힌트(hasTokens)가 stale 해서 로그아웃 사용자가
+  // 인증 쿼리를 실행한 경우. 서버가 400 으로 내려 401 경로를 안 타므로 여기서
+  // 힌트를 정리하지 않으면 hasTokens() 가 계속 true 라 같은 요청이 반복된다.
   const invalidRefresh = isInvalidRefreshTokenError(error);
+  const invalidPrincipal = isAuthPrincipalError(error);
   if (
     !isUnauthorizedError(error) &&
     !isForbiddenError(error) &&
-    !invalidRefresh
+    !invalidRefresh &&
+    !invalidPrincipal
   ) {
     return;
   }
@@ -111,10 +117,17 @@ export const notifyApiError = (error: unknown): void => {
     return;
   }
 
-  // refresh token 자체가 무효(AUTH-006)면, 같은 에러를 토스트로 반복 노출하는
-  // 대신 조용히 로그아웃 정리한다. (handleUnauthorized=false 인 publicApiClient
-  // 의 /auth/token 호출이 이 경로로 들어온다.)
-  if (isInvalidRefreshTokenError(error)) {
+  // 인증 계열 에러는 토스트로 노출하지 않고 조용히 처리한다. 비로그인/세션 만료는
+  // 사용자에게 "잘못된 시큐리티 프린시플" 같은 원문 에러를 보여줄 게 아니라,
+  // 세션 힌트를 정리하고 (보호 경로면) 로그인으로 유도해야 한다.
+  //   - 401: 토큰 없음/만료
+  //   - AUTH-001/AUTH-002: 익명/무효 principal 로 인증 필수 API 호출(400)
+  //   - AUTH-006/AUTH-012: refresh token 무효
+  if (
+    isUnauthorizedError(error) ||
+    isAuthPrincipalError(error) ||
+    isInvalidRefreshTokenError(error)
+  ) {
     handleAuthError(error);
     return;
   }

--- a/src/app.module/metadata/seo.ts
+++ b/src/app.module/metadata/seo.ts
@@ -80,35 +80,45 @@ export function buildResourceMetadata({
   };
 }
 
-export interface OfficialChallengeMeta {
-  challengeId: number;
+export interface PublicChallengeMeta {
   title: string;
+  description?: string | null;
   thumbnailImage?: string | null;
 }
 
-// 공식 챌린지만 비인증 조회가 열려 있다(/challenges/offset?challengeType=
-// OFFICIAL). 개별 /challenges/{id} 는 비인증 400(AUTH-002)이라 목록에서 id 로
-// 찾는다. 공식 챌린지는 큐레이션 대상이라 수가 적어 한 페이지(size=100)면
-// 충분하다. ponytail: 100개 초과 시에만 페이지네이션 추가.
-export async function fetchOfficialChallenge(
+// 챌린지 상세는 비인증 GET /challenges/{id} 가 열려 있어(dev tip 248a99d~)
+// 게스트 응답으로 제목·설명·썸네일을 그대로 OG 에 채운다. 비공개(403)·예약 전
+// 공식(404)·네트워크 오류는 null 을 반환해 루트 기본 OG 로 폴백한다(정보
+// 노출 없음).
+export async function fetchPublicChallengeMeta(
   id: string
-): Promise<OfficialChallengeMeta | null> {
+): Promise<PublicChallengeMeta | null> {
   if (!API_BASE_URL) {
     return null;
   }
   try {
-    const res = await fetch(
-      `${API_BASE_URL}/challenges/offset?challengeType=OFFICIAL&size=100`,
-      { headers: { accept: 'application/json' }, next: { revalidate: 300 } }
-    );
+    const res = await fetch(`${API_BASE_URL}/challenges/${id}`, {
+      headers: { accept: 'application/json' },
+      next: { revalidate: 300 },
+    });
     if (!res.ok) {
       return null;
     }
     const body = (await res.json()) as {
-      data?: { items?: OfficialChallengeMeta[] };
+      data?: {
+        challengeSummary?: { title?: string; thumbnailImage?: string | null };
+        challengeDetail?: { description?: string | null };
+      };
     };
-    const items = body.data?.items ?? [];
-    return items.find((item) => String(item.challengeId) === id) ?? null;
+    const title = body.data?.challengeSummary?.title;
+    if (!title) {
+      return null;
+    }
+    return {
+      title,
+      description: body.data?.challengeDetail?.description,
+      thumbnailImage: body.data?.challengeSummary?.thumbnailImage,
+    };
   } catch {
     return null;
   }

--- a/src/app.module/middleware/auth.ts
+++ b/src/app.module/middleware/auth.ts
@@ -13,11 +13,8 @@ type ProtectedRoute =
   | { pattern: RegExp; type: 'login-redirect' };
 
 const PROTECTED_ROUTES: ProtectedRoute[] = [
-  {
-    pattern: /^\/challenge\/\d+\/?$/,
-    type: 'list-redirect',
-    fallback: '/challenge',
-  },
+  // 챌린지 상세(/challenge/{id})는 비인증 공개 조회가 열려 있어 보호 대상에서
+  // 제외한다. 비공개(403)·예약 전(404)은 상세 화면이 클라이언트에서 처리한다.
   { pattern: /^\/diary\/\d+\/?$/, type: 'list-redirect', fallback: '/diary' },
 
   { pattern: /^\/challenge\/\d+\/edit\/?$/, type: 'login-redirect' },

--- a/src/app/challenge/[id]/page.tsx
+++ b/src/app/challenge/[id]/page.tsx
@@ -2,7 +2,7 @@ import { ChallengeDetailSkeleton } from '@component/skeletons/ChallengeDetailSke
 import { ChallengeDetailScreen } from '@feature/challenge/detail/screen/ChallengeDetailScreen';
 import {
   buildResourceMetadata,
-  fetchOfficialChallenge,
+  fetchPublicChallengeMeta,
   SITE_DESCRIPTION,
   SITE_TITLE,
 } from '@module/metadata/seo';
@@ -14,25 +14,24 @@ interface ChallengeDetailProps {
 }
 
 /**
- * 공식(OFFICIAL) 챌린지만 전용 OG 를 채운다. 개별 챌린지 상세는 비인증 조회가
- * 막혀 있어(400 AUTH-002) 목록(/challenges/offset?challengeType=OFFICIAL)에서
- * id 로 찾는다. 일반(비공식)·비공개·조회 실패는 빈 객체를 반환해 루트 기본
- * 메타(기본 OG)로 폴백한다. 배너/썸네일이 있으면 OG 이미지로, 없으면 기본
- * 이미지. 목록엔 설명이 없어 사이트 설명을 쓴다.
+ * 챌린지 상세는 비인증 GET /challenges/{id} 로 제목·설명·썸네일을 채운다.
+ * 조회 실패(비공개 403·예약 전 공식 404·네트워크)는 빈 객체를 반환해 루트
+ * 기본 메타(기본 OG)로 폴백한다(정보 노출 없음). 썸네일이 있으면 og:image 로,
+ * 없으면 기본 OG 이미지.
  */
 export async function generateMetadata({
   params,
 }: ChallengeDetailProps): Promise<Metadata> {
   const { id } = await params;
-  const official = await fetchOfficialChallenge(id);
-  if (!official) {
+  const challenge = await fetchPublicChallengeMeta(id);
+  if (!challenge) {
     return {};
   }
 
   return buildResourceMetadata({
-    title: `${official.title} | ${SITE_TITLE}`,
-    description: SITE_DESCRIPTION,
-    imageUrl: official.thumbnailImage,
+    title: `${challenge.title} | ${SITE_TITLE}`,
+    description: challenge.description?.trim() || SITE_DESCRIPTION,
+    imageUrl: challenge.thumbnailImage,
   });
 }
 


### PR DESCRIPTION
## 릴리즈 범위 (develop → main 승격)

챌린지 상세 게스트 개방을 중심으로 한 비로그인 UX 개선 + 관련 후속 수정 6건.
서버는 이미 운영 배포 완료(챌린지 상세 게스트 개방 라이브), 이번 PR은 클라 승격.

### 포함 커밋
| SHA | 내용 |
| --- | --- |
| `c64be82` (#199) | 챌린지 상세 **비로그인 열람 허용** + **OG 챌린지 썸네일** 반영 |
| `53f1bd2` (#200) | 챌린지 **리스트**에서 비로그인 상세 진입 허용 |
| `9418a36` (#201) | **탐색** 공식/추천 챌린지 카드 비로그인 상세 진입 허용 |
| `1250f13` (#202) | 챌린지 카드 썸네일 **배지 오버플로우** 수정 (좁은 폭 겹침·줄바꿈) |
| `a5f94b1` (#203) | 비로그인 상태 인증 에러(**AUTH-002**) 토스트 노출 차단 |
| `beed7a8` (#204) | 비로그인 상태 **데스크톱 GNB 마이페이지** 노출 차단 |

### 릴리즈 요약
- **챌린지 상세 비로그인 열람** — 게스트도 챌린지 상세 진입 가능
- **리스트·홈·탐색 카드 게스트 진입** — 각 진입점에서 비로그인 상세 이동 허용
- **OG 챌린지 썸네일** — 링크 프리뷰 og:image에 챌린지 썸네일 반영
- **카드 배지 오버플로우 수정** — 좁은 폭에서 배지 겹침/줄바꿈 깨짐 해소
- **비로그인 AUTH-002 토스트 차단** — 익명 세션의 인증 에러 토스트 억제
- **데스크톱 GNB 마이페이지 게이팅** — 비로그인 시 마이페이지 메뉴 숨김

### 검증
- `pnpm lint` / 타입 체크 기준(브라우저 확인은 배포 후 curl 검증)
