### PR TITLE
feat: 카테고리 기타·어학 아이콘을 DS 신규 아이콘으로 교체

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@1d1s/design-system": "^2.10.1",
+    "@1d1s/design-system": "^2.11.0",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-aspect-ratio": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@1d1s/design-system':
-        specifier: ^2.10.1
-        version: 2.10.1(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^2.11.0
+        version: 2.11.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.0.1(react-hook-form@7.55.0(react@19.2.4))
@@ -252,8 +252,8 @@ importers:
 
 packages:
 
-  '@1d1s/design-system@2.10.1':
-    resolution: {integrity: sha512-am3tfJ9qnUkZEn2TQ9nUWyQ+W7FX2cK2fjNXK5DOBkSGA/MAzU958LL7Ne9U/qKZQP1anJWjjcPOS8Un1R0ohg==}
+  '@1d1s/design-system@2.11.0':
+    resolution: {integrity: sha512-Jem9vqIm/9C0ot14yeXy8bVOqTxga4HXqaL206vkgXK5d/+3HiuFDSvA75QT8dFwFoE3extNOfnLcmczMbu4Dw==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0
       react: ^19.0.0
@@ -5086,14 +5086,14 @@ packages:
 
 snapshots:
 
-  '@1d1s/design-system@2.10.1(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@1d1s/design-system@2.11.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.16(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-checkbox': 1.1.5(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog': 1.1.7(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-popover': 1.1.19(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-select': 2.1.7(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-slot': 1.2.0(@types/react@19.0.12)(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.0.12)(react@19.2.4)
       '@radix-ui/react-toggle-group': 1.1.3(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tooltip': 1.2.12(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1

--- a/src/app.constants/categories.tsx
+++ b/src/app.constants/categories.tsx
@@ -12,9 +12,9 @@ export const CATEGORY_OPTIONS: ReadonlyArray<{
   { value: 'DIET', label: '식단', iconName: 'Salad' },
   { value: 'HEALTH', label: '건강', iconName: 'Heart' },
   { value: 'HOBBY', label: '취미', iconName: 'Palette' },
-  { value: 'LANGUAGE', label: '어학', iconName: 'Flag' },
+  { value: 'LANGUAGE', label: '어학', iconName: 'Languages' },
   { value: 'SELF_DEV', label: '자기계발', iconName: 'Target' },
-  { value: 'ETC', label: '기타', iconName: 'Pin' },
+  { value: 'ETC', label: '기타', iconName: 'Shapes' },
 ];
 
 // 카테고리별 stripe/hero accent 색. 같은 보드/일지 화면에 여러 카테고리가


### PR DESCRIPTION
## 배경
카테고리 아이콘 중 **기타(ETC)** 만 비트맵 PNG 를 임베드한 DS `Pin` 으로 대체돼 있어, 나머지 lucide 라인 아이콘들(Code2·Dumbbell·Salad 등)과 톤(선 굵기·`currentColor` 반응)이 어긋나 보였습니다. **어학(LANGUAGE)** 도 전용 아이콘이 없어 `Flag` 로 대체된 상태였습니다.

## 변경
DS `2.11.0` 에 추가된 전용 아이콘으로 교체 ([design-system#18](https://github.com/1D1S/1D1S-design-system/pull/18)):

- `@1d1s/design-system` `^2.10.1` → `^2.11.0`
- `src/app.constants/categories.tsx`
  - ETC(기타): `Pin` → `Shapes`
  - LANGUAGE(어학): `Flag` → `Languages`

## 검증
- `tsc --noEmit` ✅ (신규 IconName 이 DS 2.11.0 타입에서 검증됨)
- `pnpm lint` ✅ (0 errors)
- `pnpm test` ✅ (147 passed)
- `pnpm knip` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)