### PR TITLE
feat: 홈 상단 스토리를 원형 아이템으로 간소화

### DIFF
--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Icon, Text } from '@1d1s/design-system';
+import { Icon } from '@1d1s/design-system';
 import EmptyState from '@component/EmptyState';
 import FadeInImage from '@component/FadeInImage';
 import { cn } from '@module/utils/cn';
@@ -9,49 +9,27 @@ import Image from 'next/image';
 import React from 'react';
 
 import { StoryGroup } from '../type/story';
-import {
-  formatStoryDate,
-  isGroupAllSeen,
-} from '../utils/storyHelpers';
+import { isGroupAllSeen } from '../utils/storyHelpers';
 
 interface StoryRingProps {
   groups: StoryGroup[];
   onSelect(index: number): void;
-  compact?: boolean;
   myProfileImage?: string | null;
   onAddStory?(): void;
 }
 
-interface StoryVisual {
-  badge: string;
-  moodImage: { src: string; alt: string };
-  surface: string;
-  accent: string;
-  avatar: string;
+interface StoryMood {
+  src: string;
+  alt: string;
+  tint: string;
 }
 
-const STORY_VISUALS: StoryVisual[] = [
-  {
-    badge: '뿌듯함',
-    moodImage: { src: '/images/mood-happy.svg', alt: '행복한 얼굴' },
-    surface: 'bg-[linear-gradient(180deg,#ffe1d7_0%,#fff7f3_100%)]',
-    accent: 'text-main-800',
-    avatar: 'border-main-500 bg-[#c9f1e7]',
-  },
-  {
-    badge: '좋아요',
-    moodImage: { src: '/images/mood-soso.svg', alt: '무표정 얼굴' },
-    surface: 'bg-[linear-gradient(180deg,#def4ec_0%,#f8fffc_100%)]',
-    accent: 'text-green-800',
-    avatar: 'border-green-700 bg-[#e6f1ff]',
-  },
-  {
-    badge: '기록',
-    moodImage: { src: '/images/mood-sad.svg', alt: '슬픈 얼굴' },
-    surface: 'bg-[linear-gradient(180deg,#f4e8dc_0%,#fffaf5_100%)]',
-    accent: 'text-gray-700',
-    avatar: 'border-main-400 bg-[#fff1c8]',
-  },
+// 감정(무드) 아이콘은 API 에 실제 감정 필드가 없어 userId 로 고정 배정한다.
+// 같은 사용자는 항상 같은 무드/틴트를 받는다(장식 목적).
+const STORY_MOODS: StoryMood[] = [
+  { src: '/images/mood-happy.svg', alt: '행복한 얼굴', tint: 'bg-[#c9f1e7]' },
+  { src: '/images/mood-soso.svg', alt: '무표정 얼굴', tint: 'bg-[#e6f1ff]' },
+  { src: '/images/mood-sad.svg', alt: '슬픈 얼굴', tint: 'bg-[#fff1c8]' },
 ];
 
 // next/image 는 절대 URL 또는 / 시작 상대 경로만 허용한다.
@@ -65,20 +43,19 @@ function isValidNextImageSrc(src: string | undefined): src is string {
   return /^(https?:|data:|blob:)/i.test(src);
 }
 
-function pickStoryVisual(userId: number): StoryVisual {
-  return STORY_VISUALS[userId % STORY_VISUALS.length];
+function pickStoryMood(userId: number): StoryMood {
+  return STORY_MOODS[Math.abs(userId) % STORY_MOODS.length];
 }
 
+// 프로필 썸네일(52px 원) + 무드 아이콘 오버레이 + 읽음 테두리 링만 남긴
+// 원형 스토리 아이템. 링 색으로 읽음/안읽음을 표현한다.
 function StoryRing({
   groups,
   onSelect,
-  compact = false,
   myProfileImage,
   onAddStory,
 }: StoryRingProps): React.ReactElement {
   const showMySlot = typeof onAddStory === 'function';
-  const cardWidthClass = compact ? 'w-[136px]' : 'w-[168px]';
-  const cardHeightClass = compact ? 'h-[174px]' : 'h-[208px]';
   // 내 스토리는 sortStoryGroups 로 항상 맨 앞에 고정된다. 응답에 포함되면
   // 일반 스토리 카드로 렌더돼 뷰어로 열리고, 없으면 일지 작성으로 유도하는
   // 추가 카드를 대신 그린다.
@@ -89,10 +66,8 @@ function StoryRing({
   return (
     <div
       className={cn(
-        'scrollbar-hide flex w-full overflow-x-auto',
-        // "나의 활동" 패널 내부에 놓이므로 좌우 패딩 없이 패널 내부 라인에서
-        // 시작한다(첫 카드 좌측 = 헤더·배너와 동일 세로선).
-        compact ? 'gap-2.5 px-4 py-3' : 'gap-3 py-3.5'
+        'scrollbar-hide flex w-full items-start gap-3.5',
+        'overflow-x-auto py-3'
       )}
     >
       {showMySlot && !hasMyStory ? (
@@ -100,73 +75,44 @@ function StoryRing({
           type="button"
           onClick={onAddStory}
           aria-label="오늘 일지 올리기"
-          className={cn(
-            'flex shrink-0 flex-col overflow-hidden rounded-[22px]',
-            'border-main-200 border border-dashed bg-white text-left',
-            'hover:shadow-warm transition-all duration-300 ease-out',
-            cardWidthClass,
-            cardHeightClass
-          )}
+          className="relative shrink-0"
         >
           <span
             className={cn(
-              'flex flex-1 flex-col items-center justify-center gap-3',
-              'px-4 text-center'
+              'flex h-13 w-13 items-center justify-center overflow-hidden',
+              'border-main-200 rounded-full border-2 border-dashed bg-white'
             )}
           >
-            <span
-              className={cn(
-                'flex h-14 w-14 items-center justify-center rounded-full',
-                'bg-main-500 shadow-warm text-white'
-              )}
-              aria-hidden
-            >
-              <Icon name="Plus" size={24} />
-            </span>
-            <Text size="caption2" weight="extrabold" className="text-main-800">
-              오늘 일지 올리기
-            </Text>
+            {isValidNextImageSrc(myImageUrl) ? (
+              <span className="relative h-full w-full">
+                <FadeInImage
+                  src={myImageUrl}
+                  alt=""
+                  fill
+                  sizes="52px"
+                  className="object-cover"
+                />
+              </span>
+            ) : null}
           </span>
-          <span className="flex items-center gap-3 px-4 pb-6">
-            <span
-              className={cn(
-                'flex h-9 w-9 shrink-0 items-center justify-center',
-                'overflow-hidden rounded-full bg-[#ffe1a8]'
-              )}
-              aria-hidden
-            >
-              {isValidNextImageSrc(myImageUrl) ? (
-                <span className="relative h-full w-full">
-                  <FadeInImage
-                    src={myImageUrl}
-                    alt=""
-                    fill
-                    sizes="36px"
-                    className="object-cover"
-                  />
-                </span>
-              ) : (
-                <span className="h-2 w-4 rounded-full bg-white" />
-              )}
-            </span>
-            <span className="min-w-0 text-base font-extrabold text-gray-900">
-              내 스토리
-            </span>
+          <span
+            className={cn(
+              'absolute -right-0.5 -bottom-0.5 flex h-[22px] w-[22px]',
+              'bg-main-500 items-center justify-center rounded-full',
+              'text-white ring-2 ring-white'
+            )}
+            aria-hidden
+          >
+            <Icon name="Plus" size={12} />
           </span>
         </button>
       ) : null}
       {groups.map((group, index) => {
         const seen = isGroupAllSeen(group);
-        const [preview] = group.stories;
         const profileUrl =
           resolveDiaryImageUrl(group.profileImage) ?? undefined;
         const name = group.userName?.trim() || `친구 ${group.userId}`;
-        const title = preview?.diaryTitle ?? '';
-        const time = preview ? formatStoryDate(preview.createdAt) : '';
-        const visual = pickStoryVisual(group.userId);
-        const unreadCount = group.stories.filter(
-          (story) => story.hasUnreadJournal
-        ).length;
+        const mood = pickStoryMood(group.userId);
 
         return (
           <button
@@ -174,96 +120,52 @@ function StoryRing({
             type="button"
             onClick={() => onSelect(index)}
             aria-label={`${name} 스토리 열기`}
-            className={cn(
-              'relative flex shrink-0 flex-col overflow-hidden rounded-[22px]',
-              'border bg-white text-left transition-all duration-300 ease-out',
-              'hover:shadow-warm',
-              seen ? 'border-gray-100' : 'border-main-200',
-              visual.surface,
-              cardWidthClass,
-              cardHeightClass
-            )}
+            className="relative shrink-0"
           >
             <span
               className={cn(
-                'absolute top-4 left-4 inline-flex max-w-[112px]',
-                'items-center gap-1 rounded-full bg-white/75 px-2.5 py-1',
-                'text-[11px] font-extrabold',
-                visual.accent
+                'flex h-13 w-13 items-center justify-center overflow-hidden',
+                'rounded-full border-2 p-0.5',
+                seen ? 'border-gray-200' : 'border-main-500'
               )}
             >
-              <Icon name="Flag" size={10} aria-hidden />
-              <span className="truncate">{title || visual.badge}</span>
-            </span>
-            {!seen ? (
               <span
                 className={cn(
-                  'absolute top-4 right-4 flex h-5 min-w-5 items-center',
-                  'bg-main-600 justify-center rounded-full px-1',
-                  'text-[11px] font-bold text-white ring-2 ring-white'
+                  'relative flex h-full w-full items-center justify-center',
+                  'overflow-hidden rounded-full',
+                  mood.tint
                 )}
-                aria-label={`${unreadCount || 1}개 새 스토리`}
-              >
-                {unreadCount || 1}
-              </span>
-            ) : null}
-
-            <span
-              className={cn(
-                'flex flex-1 items-center justify-center pt-9',
-                'px-4'
-              )}
-            >
-              {/* 무드 SVG는 정적 에셋이라 Next 이미지 최적화 없이 서빙한다. */}
-              <Image
-                src={visual.moodImage.src}
-                alt={visual.moodImage.alt}
-                width={56}
-                height={56}
-                className="h-14 w-14"
-                unoptimized
-              />
-            </span>
-
-            <span className="flex items-end gap-3 px-4 pb-6">
-              <span
-                className={cn(
-                  'relative flex h-10 w-10 shrink-0 items-center',
-                  'justify-center overflow-hidden rounded-full border-2',
-                  visual.avatar
-                )}
-                aria-hidden
               >
                 {isValidNextImageSrc(profileUrl) ? (
                   <FadeInImage
                     src={profileUrl}
                     alt=""
                     fill
-                    sizes="40px"
+                    sizes="48px"
                     className="object-cover"
                   />
                 ) : (
-                  <span className="h-4 w-7 rounded-full bg-white/80" />
+                  <span className="h-3.5 w-6 rounded-full bg-white/80" />
                 )}
               </span>
-              <span className="min-w-0">
-                <span
-                  className={cn(
-                    'block truncate text-base font-extrabold',
-                    seen ? 'text-gray-700' : 'text-gray-900'
-                  )}
-                >
-                  {name}
-                </span>
-                <span
-                  className={cn(
-                    'block truncate text-[13px] font-medium',
-                    seen ? 'text-gray-400' : 'text-gray-500'
-                  )}
-                >
-                  {time}
-                </span>
-              </span>
+            </span>
+            <span
+              className={cn(
+                'absolute -right-0.5 -bottom-0.5 flex h-[22px] w-[22px]',
+                'items-center justify-center overflow-hidden rounded-full',
+                'bg-white ring-2 ring-white'
+              )}
+              aria-hidden
+            >
+              {/* 무드 SVG는 정적 에셋이라 Next 이미지 최적화 없이 서빙한다. */}
+              <Image
+                src={mood.src}
+                alt={mood.alt}
+                width={20}
+                height={20}
+                className="h-5 w-5"
+                unoptimized
+              />
             </span>
           </button>
         );

--- a/src/app.feature/stories/components/StoryRingSkeleton.tsx
+++ b/src/app.feature/stories/components/StoryRingSkeleton.tsx
@@ -4,25 +4,20 @@ import { cn } from '@module/utils/cn';
 import React from 'react';
 
 interface StoryRingSkeletonProps {
-  /** 표시할 스켈레톤 카드 수 (default 5) */
+  /** 표시할 스켈레톤 원 수 (default 6) */
   count?: number;
 }
 
-const SKELETON_SURFACES = [
-  'bg-[linear-gradient(180deg,#ffe1d7_0%,#fff7f3_100%)]',
-  'bg-[linear-gradient(180deg,#def4ec_0%,#f8fffc_100%)]',
-  'bg-[linear-gradient(180deg,#f4e8dc_0%,#fffaf5_100%)]',
-];
-
-// 실제 StoryRing 과 동일한 비율을 두고 내용만 pulse 플레이스홀더로 채운다.
+// 실제 StoryRing 과 동일한 원형 크기/간격을 두고 내용만 pulse 로 채운다.
+// (h-13 w-13 + gap-3.5 + py-3 → 레이아웃 시프트 없이 데이터로 전환)
 export default function StoryRingSkeleton({
-  count = 3,
+  count = 6,
 }: StoryRingSkeletonProps): React.ReactElement {
   return (
     <div
       className={cn(
-        'scrollbar-hide flex w-full overflow-x-auto',
-        'gap-3 py-3.5'
+        'scrollbar-hide flex w-full items-start gap-3.5',
+        'overflow-x-auto py-3'
       )}
       aria-busy
       aria-label="스토리 불러오는 중"
@@ -31,28 +26,10 @@ export default function StoryRingSkeleton({
         <div
           key={index}
           className={cn(
-            'h-[208px] w-[168px] shrink-0 overflow-hidden rounded-[22px]',
-            'border border-gray-100',
-            SKELETON_SURFACES[index % SKELETON_SURFACES.length]
+            'skeleton-pulse h-13 w-13 shrink-0 rounded-full',
+            'bg-gray-100'
           )}
-        >
-          <div className="flex h-full flex-col justify-between px-4 py-6">
-            <div className="skeleton-pulse h-6 w-25 rounded-full bg-white/55" />
-            <div
-              className={cn(
-                'skeleton-pulse mx-auto h-12 w-12 rounded-full',
-                'bg-white/65'
-              )}
-            />
-            <div className="flex items-center gap-3">
-              <span
-                className="skeleton-pulse h-10 w-10 rounded-full bg-white/60"
-                aria-hidden
-              />
-              <span className="skeleton-pulse h-4 w-20 rounded bg-white/60" />
-            </div>
-          </div>
-        </div>
+        />
       ))}
     </div>
   );

--- a/src/app.feature/stories/utils/storyHelpers.ts
+++ b/src/app.feature/stories/utils/storyHelpers.ts
@@ -42,7 +42,7 @@ function sortStoriesByRecent(stories: StoryItem[]): StoryItem[] {
 // 스토리가 있는 그룹을 앞에 둔다(시간 내림차순). 시청 여부로 순서를 바꾸면,
 // 방금 본 최신 스토리가 더 오래된 미시청 그룹 뒤로 밀려 "최신이 먼저 보이지
 // 않는" 문제가 생기므로 시간만으로 정렬한다.
-// (미시청 표시는 StoryRing 의 NEW 배지가 isGroupAllSeen 으로 별도 처리한다.)
+// (미시청 표시는 StoryRing 이 isGroupAllSeen 으로 테두리 링 색을 바꿔 처리한다.)
 // 각 그룹 내부 스토리도 최신순으로 정렬한다.
 export function sortStoryGroups(groups: StoryGroup[]): StoryGroup[] {
   return groups


### PR DESCRIPTION
## 요약

홈 상단 스토리(StoryRing) UI를 카드형에서 인스타그램 스타일 원형 아이템으로 간소화합니다.

## 변경 사항

| 항목 | Before | After |
| --- | --- | --- |
| 아이템 크기 | 카드 168×208px | 원형 외곽 60px / 썸네일 52px (`h-13 w-13`) |
| 텍스트 라벨 | 닉네임 + 시간 | 제거 (aria-label 만 유지) |
| 개수 배지 | `unreadCount` 배지 노출 | 제거 |
| 제목 배지 | Flag + 일지 제목 | 제거 |
| 읽음 표현 | 카드 border + 텍스트 색 | 테두리 링 색으로 표현 |
| 감정 아이콘 | 카드 중앙 이미지 | 우하단 오버레이 배지 |

## 읽음/안읽음

기존 상태 소스를 그대로 사용합니다.
- 안읽음: `isGroupAllSeen(group) === false` → `border-main-500` (브랜드 컬러 링)
- 읽음: 모두 시청 → `border-gray-200` (흐린 회색 링)
- `hasUnreadJournal` / `useViewStory` 캐시 갱신 로직은 변경 없음

## 감정(무드) 아이콘

API에 실제 감정 필드가 없어 기존과 동일하게 `userId % 3` 으로 무드 아이콘을 고정 배정합니다(장식 목적). 실제 감정 데이터가 생기면 `pickStoryMood` 를 교체하면 됩니다.

## 정리

- 미사용 `compact` prop, `STORY_VISUALS`/`pickStoryVisual`, 텍스트(`Text`)·시간(`formatStoryDate`) 관련 코드 제거 (knip 통과)
- 스켈레톤을 새 원형 크기에 맞춰 레이아웃 시프트 방지

## 검증

tsc / lint(0 errors) / knip / vitest(156 passed) / build 모두 통과.
UI 실제 브라우저 확인은 리뷰어에게 맡깁니다(직접 preview 미실행).