### PR TITLE
fix: 가이드 히어로 배경을 둥근 패널로 정리

### DIFF
--- a/src/app.feature/guide/screen/GuideScreen.tsx
+++ b/src/app.feature/guide/screen/GuideScreen.tsx
@@ -91,9 +91,9 @@ export default function GuideScreen(): React.ReactElement {
         {/* 히어로 */}
         <header
           className={cn(
-            'animate-pop-in -mx-5 mb-2 px-5 pt-14 pb-16 text-center lg:-mx-6',
-            'lg:px-6 lg:pt-20 lg:pb-20',
-            'bg-[linear-gradient(160deg,var(--main-100)_0%,var(--gray-50)_70%)]'
+            'animate-pop-in rounded-3 lg:rounded-4 mb-4 px-6 pt-14 pb-16',
+            'text-center lg:px-10 lg:pt-20 lg:pb-20',
+            'bg-[linear-gradient(180deg,var(--main-100),var(--gray-50))]'
           )}
         >
           <span
@@ -126,7 +126,7 @@ export default function GuideScreen(): React.ReactElement {
         </header>
 
         {/* 3줄 요약 */}
-        <section className="animate-pop-in -mt-9">
+        <section className="animate-pop-in">
           <div className="grid gap-3.5 sm:grid-cols-3">
             {GUIDE_SUMMARY.map((c) => {
               const CardIcon = c.icon;

--- a/src/app.feature/guide/screen/OfficialGuideScreen.tsx
+++ b/src/app.feature/guide/screen/OfficialGuideScreen.tsx
@@ -126,7 +126,7 @@ const NAVER_GREEN = '#03C75A';
 
 function SummaryCards(): React.ReactElement {
   return (
-    <section className="animate-pop-in -mt-9">
+    <section className="animate-pop-in">
       <div className="grid gap-3.5 sm:grid-cols-3">
         {SUMMARY.map((c) => {
           const CardIcon = c.icon;
@@ -696,9 +696,9 @@ export default function OfficialGuideScreen(): React.ReactElement {
         {/* 히어로 */}
         <header
           className={cn(
-            'animate-pop-in -mx-5 mb-2 px-5 pt-14 pb-16 text-center lg:-mx-6',
-            'lg:px-6 lg:pt-20 lg:pb-20',
-            'bg-[linear-gradient(160deg,var(--main-100)_0%,var(--gray-50)_70%)]'
+            'animate-pop-in rounded-3 lg:rounded-4 mb-4 px-6 pt-14 pb-16',
+            'text-center lg:px-10 lg:pt-20 lg:pb-20',
+            'bg-[linear-gradient(180deg,var(--main-100),var(--gray-50))]'
           )}
         >
           <span


### PR DESCRIPTION
## 문제
데스크톱에서 `/guide`, `/guide/official` 히어로 배경(연회색/그라데이션 블록)이:
- `-mx-5 lg:-mx-6` 전체 폭 돌출 + 대각선(160deg) 그라데이션 → 컨테이너 폭보다 좁게 잘린 직사각형처럼 보임
- 아래 요약 카드가 `-mt-9`로 히어로 위로 겹치면서 배경 하단이 카드 뒤에서 뚝 끊김

## 수정
- 히어로를 컨테이너 폭 **내부의 둥근 패널**로 변경 (`rounded-3 lg:rounded-4`)
- 대각선 그라데이션 → **담백한 세로 그라데이션**(`main-100` → `gray-50`)으로 완화
- 요약 카드 `-mt-9` 오버랩 제거, 히어로 `mb-4` 여백으로 자연스럽게 종료
- 반응형 패딩·라운딩(`px-6 lg:px-10`) 적용
- 두 가이드 페이지 동일 톤

## 검증
tsc / lint(0 errors) / vitest(159 passed) / knip / build 통과.
브라우저 시각 확인은 직접 돌려보지 않음 — 리뷰어 확인 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the guide page hero sections with updated spacing, padding, rounded corners, and gradient backgrounds.
  - Improved responsive layout and visual presentation across guide screens.
  - Adjusted summary sections to provide more consistent spacing with surrounding content.
  - Preserved existing animations and content while improving overall page balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->