### PR TITLE
feat: 문의하기에 1D1S 소개 FAQ 섹션과 디스코드 참여 배너 추가

### DIFF
--- a/src/app.constants/consts/inquiryData.ts
+++ b/src/app.constants/consts/inquiryData.ts
@@ -4,6 +4,28 @@ export interface FaqItem {
   answer: string;
 }
 
+export const DISCORD_INVITE_URL = 'https://discord.gg/JaHRYHtrE7';
+
+export const INQUIRY_ABOUT_ITEMS: FaqItem[] = [
+  {
+    id: 'about-1',
+    question: '1D1S는 왜 시즌 4부터 시작하나요?',
+    answer:
+      '기존에는 노션과 디스코드로 시즌 3까지 운영되었습니다. 1D1S 주인장의 개인적인 사정으로 인해 잠시 중단되었다가 웹 서비스와 함께 시즌 4로 찾아오게 되었습니다.',
+  },
+  {
+    id: 'about-2',
+    question: '1D1S는 어쩌다가 만들어진 서비스인가요?',
+    answer:
+      '사실 서비스라고 하기엔 뭐하고 동아리에 조금 더 가깝고, 제 개인적인 동기로 만들어진 동아리입니다. 매일 무언가를 한다는 것은 힘들지만, 다 같이 함께 한다면 그걸 조금 더 쉽게 할 수 있음을 느껴 이를 동기로 만들게 되었습니다.',
+  },
+  {
+    id: 'about-3',
+    question: '1D1S 동아리?',
+    answer: `동아리이고 디스코드 채널도 있습니다. 시즌3을 마무리하면서 개인적인 사정으로 인해 관리가 잘 안되어 있긴 하지만... 이제 다시 활발해지리라 믿습니다...!\n디스코드 참여하실 분은 ${DISCORD_INVITE_URL} 여기로 와주세요!`,
+  },
+];
+
 export const INQUIRY_FAQ_ITEMS: FaqItem[] = [
   {
     id: 'item-1',

--- a/src/app.feature/inquiry/screen/InquiryScreen.tsx
+++ b/src/app.feature/inquiry/screen/InquiryScreen.tsx
@@ -9,12 +9,38 @@ import {
   Text,
 } from '@1d1s/design-system';
 import { SubPageShell } from '@component/layout/SubPageShell';
-import { INQUIRY_FAQ_ITEMS } from '@constants/consts/inquiryData';
+import {
+  DISCORD_INVITE_URL,
+  INQUIRY_ABOUT_ITEMS,
+  INQUIRY_FAQ_ITEMS,
+} from '@constants/consts/inquiryData';
 import { cn } from '@module/utils/cn';
-import { ExternalLink, Mail } from 'lucide-react';
+import { ExternalLink, Mail, MessagesSquare } from 'lucide-react';
 import React from 'react';
 
 const INQUIRY_FORM_URL = 'https://forms.gle/yxgnTJdYViRmb2zR6';
+
+/** 답변 본문에 포함된 디스코드 초대 링크를 클릭 가능한 새 탭 앵커로 렌더링. */
+function renderAnswer(answer: string): React.ReactNode {
+  const parts = answer.split(DISCORD_INVITE_URL);
+  if (parts.length === 1) {
+    return answer;
+  }
+  return (
+    <>
+      {parts[0]}
+      <a
+        href={DISCORD_INVITE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-[#5865F2] underline underline-offset-2"
+      >
+        {DISCORD_INVITE_URL}
+      </a>
+      {parts[1]}
+    </>
+  );
+}
 
 export function InquiryScreen(): React.ReactElement {
   return (
@@ -53,6 +79,47 @@ export function InquiryScreen(): React.ReactElement {
                 <AccordionContent className="pb-4">
                   <Text size="body2" weight="regular" className="text-gray-500">
                     {item.answer}
+                  </Text>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </section>
+
+        <section className="rounded-4 border border-gray-200 bg-white">
+          <div className="border-b border-gray-100 px-5 py-4">
+            <Text size="body1" weight="bold" className="text-gray-500">
+              1D1S에 관해
+            </Text>
+          </div>
+
+          <Accordion
+            type="single"
+            collapsible
+            className="divide-y divide-gray-100"
+          >
+            {INQUIRY_ABOUT_ITEMS.map((item) => (
+              <AccordionItem
+                key={item.id}
+                value={item.id}
+                className="border-0 px-5"
+              >
+                <AccordionTrigger className="py-4 hover:no-underline">
+                  <Text
+                    size="body1"
+                    weight="medium"
+                    className="text-left text-gray-800"
+                  >
+                    {item.question}
+                  </Text>
+                </AccordionTrigger>
+                <AccordionContent className="pb-4">
+                  <Text
+                    size="body2"
+                    weight="regular"
+                    className="whitespace-pre-line text-gray-500"
+                  >
+                    {renderAnswer(item.answer)}
                   </Text>
                 </AccordionContent>
               </AccordionItem>
@@ -102,6 +169,36 @@ export function InquiryScreen(): React.ReactElement {
             </a>
           </div>
         </section>
+
+        <a
+          href={DISCORD_INVITE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            'rounded-4 flex items-center gap-3 px-5 py-4',
+            'border border-[#5865F2]/20 bg-[#5865F2]/5',
+            'transition-colors hover:bg-[#5865F2]/10'
+          )}
+        >
+          <span
+            className={cn(
+              'flex h-10 w-10 shrink-0 items-center justify-center',
+              'rounded-full bg-[#5865F2] text-white'
+            )}
+            aria-hidden
+          >
+            <MessagesSquare className="h-5 w-5" />
+          </span>
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <Text size="body1" weight="bold" className="text-gray-900">
+              디스코드 참여하기
+            </Text>
+            <Text size="caption1" weight="regular" className="text-gray-500">
+              1D1S 동아리 채널에서 함께 이어가요.
+            </Text>
+          </div>
+          <ExternalLink className="ml-auto h-4 w-4 shrink-0 text-[#5865F2]" />
+        </a>
       </div>
     </SubPageShell>
   );


### PR DESCRIPTION
## 개요
문의하기(`/inquiry`) 화면에 **1D1S에 관해** FAQ 섹션과 **디스코드 참여하기** 배너를 추가합니다.

## 변경 사항
- **1D1S에 관해** 섹션 신설 — 기존 FAQ와 동일한 아코디언 톤으로 3개 문항(시즌 4 시작 배경 / 서비스 탄생 계기 / 동아리·디스코드 안내) 추가
  - 세 번째 답변 속 디스코드 초대 링크는 클릭 가능한 앵커(새 탭, `rel="noopener noreferrer"`)로 렌더링
- **디스코드 참여하기** 배너 추가 — 화면 하단 배치, 디스코드 브랜드 톤(#5865F2) 살짝 반영, 외부 링크 보안 속성 적용

## 검증
- `pnpm tsc --noEmit` ✅
- `pnpm lint` ✅ (신규 에러 0)
- `pnpm vitest run` ✅ (159 passed)
- `pnpm knip` ✅
- `pnpm build` ✅
- 브라우저 확인은 사용자에게 위임 (프로젝트 정책상 preview 도구 미사용)