### PR TITLE
feat: 공식 챌린지 오픈 홍보 배너·공지 반영

### DIFF
--- a/src/app.constants/consts/homeData.ts
+++ b/src/app.constants/consts/homeData.ts
@@ -11,6 +11,14 @@ export interface HomeMainBanner {
 
 export const HOME_MAIN_BANNERS: HomeMainBanner[] = [
   {
+    id: 'official-challenge',
+    kind: 'NEW',
+    title: '공식 챌린지\n시작!',
+    subtitle: '지금 참여하고 1만원 기프티콘 받아가요',
+    gradient: 'linear-gradient(135deg, #fcd34d 0%, #f59e0b 100%)',
+    href: '/challenge/25',
+  },
+  {
     id: 'usage-guide',
     kind: 'TIP',
     title: '1D1S가\n처음이라면',

--- a/src/app.constants/consts/noticeData.ts
+++ b/src/app.constants/consts/noticeData.ts
@@ -7,15 +7,18 @@ export interface NoticeItem {
   body: string;
   /** 표시용 ISO 날짜 문자열 (YYYY-MM-DD) */
   createdAt: string;
+  /** 클릭 시 이동할 경로 (없으면 공지 목록으로 이동) */
+  href?: string;
 }
 
 export const NOTICE_ITEMS: NoticeItem[] = [
   {
-    id: 'notice-2026-07-11',
-    category: '업데이트',
-    title: '통계 기능이 추가됐어요! 나의 기록을 한눈에',
-    body: '마이페이지에 통계 기능이 새로 추가됐습니다. 주·월·연 단위 활동 요약부터 감정 분포, 일지 작성 추이, 친구들과 나의 활동까지 한눈에 확인할 수 있어요. 마이페이지 > 활동 통계의 더보기에서 만나보세요. 꾸준히 쌓아온 기록이 얼마나 성장했는지 지금 확인해 보세요!',
-    createdAt: '2026-07-11',
+    id: 'notice-2026-07-13',
+    category: '이벤트',
+    title: '공식 챌린지 시작!',
+    body: '공식 챌린지가 시작됐어요! 모두 함께 참여하고 1만원 기프티콘 받아가요.',
+    createdAt: '2026-07-13',
+    href: '/challenge/25',
   },
   {
     id: 'notice-2026-05-23',

--- a/src/app.feature/home/components/HomeNoticeStrip.tsx
+++ b/src/app.feature/home/components/HomeNoticeStrip.tsx
@@ -13,7 +13,7 @@ export default function HomeNoticeStrip(): React.ReactElement | null {
   return (
     <div className="w-full">
       <Link
-        href="/notice"
+        href={latest.href ?? '/notice'}
         className={cn(
           'flex w-full cursor-pointer items-center gap-3',
           'rounded-4 border border-gray-200 bg-white px-4 py-3',


### PR DESCRIPTION
## 배경
공식 챌린지(`/challenge/25`) 오픈에 맞춰 홈·탐색 공용 홍보 영역을 갱신합니다.

## 변경사항
1. **배너 캐러셀 첫 슬라이드 교체** — `HOME_MAIN_BANNERS`
   - 첫 슬라이드를 `공식 챌린지 시작!`(부제: 지금 참여하고 1만원 기프티콘 받아가요)로 신규 추가, 링크 `/challenge/25` (내부 라우팅 `router.push`)
   - 기존 사용 가이드 배너는 두 번째 순서로 유지
   - 홈·탐색 페이지 모두 동일 배열을 공유하므로 양쪽에 반영됨
2. **공지 배너 교체** — `NOTICE_ITEMS`
   - 첫 공지를 `공식 챌린지 시작!` / `공식 챌린지가 시작됐어요! 모두 함께 참여하고 1만원 기프티콘 받아가요.`로 교체
   - `NoticeItem`에 선택적 `href` 추가 → 공지 스트립이 `/challenge/25`로 연결 (없으면 기존대로 `/notice`)

## 검증
- `pnpm tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test` ✅ (159 passed)
- `pnpm knip` ✅
- `pnpm build` ✅

_브라우저 실기기 확인은 미실행 — 정적 검증까지만 수행._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new home banner promoting the official challenge, with updated Korean messaging and a direct link to the challenge page.
  * Latest notices can now link directly to relevant content when available.

* **Bug Fixes**
  * Updated the latest notice to highlight the official challenge launch and route visitors to the correct page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->