### PR TITLE
release: 공식 챌린지 오픈 홍보 배너·공지 운영 배포

### DIFF
--- a/src/app.constants/consts/homeData.ts
+++ b/src/app.constants/consts/homeData.ts
@@ -11,6 +11,14 @@ export interface HomeMainBanner {
 
 export const HOME_MAIN_BANNERS: HomeMainBanner[] = [
   {
+    id: 'official-challenge',
+    kind: 'NEW',
+    title: '공식 챌린지\n시작!',
+    subtitle: '지금 참여하고 1만원 기프티콘 받아가요',
+    gradient: 'linear-gradient(135deg, #fcd34d 0%, #f59e0b 100%)',
+    href: '/challenge/25',
+  },
+  {
     id: 'usage-guide',
     kind: 'TIP',
     title: '1D1S가\n처음이라면',

--- a/src/app.constants/consts/noticeData.ts
+++ b/src/app.constants/consts/noticeData.ts
@@ -7,15 +7,18 @@ export interface NoticeItem {
   body: string;
   /** 표시용 ISO 날짜 문자열 (YYYY-MM-DD) */
   createdAt: string;
+  /** 클릭 시 이동할 경로 (없으면 공지 목록으로 이동) */
+  href?: string;
 }
 
 export const NOTICE_ITEMS: NoticeItem[] = [
   {
-    id: 'notice-2026-07-11',
-    category: '업데이트',
-    title: '통계 기능이 추가됐어요! 나의 기록을 한눈에',
-    body: '마이페이지에 통계 기능이 새로 추가됐습니다. 주·월·연 단위 활동 요약부터 감정 분포, 일지 작성 추이, 친구들과 나의 활동까지 한눈에 확인할 수 있어요. 마이페이지 > 활동 통계의 더보기에서 만나보세요. 꾸준히 쌓아온 기록이 얼마나 성장했는지 지금 확인해 보세요!',
-    createdAt: '2026-07-11',
+    id: 'notice-2026-07-13',
+    category: '이벤트',
+    title: '공식 챌린지 시작!',
+    body: '공식 챌린지가 시작됐어요! 모두 함께 참여하고 1만원 기프티콘 받아가요.',
+    createdAt: '2026-07-13',
+    href: '/challenge/25',
   },
   {
     id: 'notice-2026-05-23',

--- a/src/app.feature/home/components/HomeNoticeStrip.tsx
+++ b/src/app.feature/home/components/HomeNoticeStrip.tsx
@@ -13,7 +13,7 @@ export default function HomeNoticeStrip(): React.ReactElement | null {
   return (
     <div className="w-full">
       <Link
-        href="/notice"
+        href={latest.href ?? '/notice'}
         className={cn(
           'flex w-full cursor-pointer items-center gap-3',
           'rounded-4 border border-gray-200 bg-white px-4 py-3',


### PR DESCRIPTION
## 운영 배포 (develop → main)
공식 챌린지(`/challenge/25`) 오픈 홍보 반영분을 운영에 배포합니다.

### 포함 변경 (#215)
- 배너 캐러셀 첫 슬라이드 `공식 챌린지 시작!` → `/challenge/25`, 기존 가이드 배너 2번째로 유지
- 공지 배너 `공식 챌린지 시작!` / `공식 챌린지가 시작됐어요! 모두 함께 참여하고 1만원 기프티콘 받아가요.` → `/challenge/25`

### develop 검증 결과
- CI 전체 green (Build / ESLint / Knip / TypeScript / Vitest)
- dev 배포 확인: 홈 배너 부제 `지금 참여하고 1만원…`, 탐색 공지 `공식 챌린지 시작` / `1만원 기프티콘 받아가요` 반영, `/challenge/25` 200

merge commit 방식으로 운영 승격합니다.