### PR TITLE
feat: 홈 배너에 디스코드 참여 슬라이드 추가 및 외부 링크 지원

### DIFF
--- a/src/app.constants/consts/homeData.ts
+++ b/src/app.constants/consts/homeData.ts
@@ -19,6 +19,14 @@ export const HOME_MAIN_BANNERS: HomeMainBanner[] = [
     href: '/challenge/25',
   },
   {
+    id: 'discord-community',
+    kind: 'HOT',
+    title: '디스코드\n참여하기',
+    subtitle: '챌린저들과 실시간으로 이야기 나눠요',
+    gradient: 'linear-gradient(135deg, #7289da 0%, #5865f2 100%)',
+    href: 'https://discord.gg/JaHRYHtrE7',
+  },
+  {
     id: 'usage-guide',
     kind: 'TIP',
     title: '1D1S가\n처음이라면',
@@ -32,14 +40,6 @@ export const HOME_MAIN_BANNERS: HomeMainBanner[] = [
     title: '꾸준함이\n실력이 됩니다',
     subtitle: '매일 조금씩, 30일 후 달라진 나',
     gradient: 'linear-gradient(135deg, #7dd8b5 0%, #3eb489 100%)',
-    href: '/diary',
-  },
-  {
-    id: 'challenge-create',
-    kind: 'NEW',
-    title: '오늘의 일지\n인기글',
-    subtitle: '챌린저들의 진솔한 하루를 만나보세요',
-    gradient: 'linear-gradient(135deg, #7ab3ef 0%, #1666ba 100%)',
     href: '/diary',
   },
   {

--- a/src/app.feature/home/components/HomeWarmBanner.tsx
+++ b/src/app.feature/home/components/HomeWarmBanner.tsx
@@ -37,6 +37,17 @@ export default function HomeWarmBanner({
 
   const current = banners[index];
 
+  const handleClick = (): void => {
+    if (!current.href) {
+      return;
+    }
+    if (/^https?:\/\//.test(current.href)) {
+      window.open(current.href, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    router.push(current.href);
+  };
+
   return (
     <div className="relative h-full w-full">
       <Banner
@@ -47,7 +58,7 @@ export default function HomeWarmBanner({
         bg={current.gradient}
         size="md"
         role="link"
-        onClick={() => current.href && router.push(current.href)}
+        onClick={handleClick}
         className={cn(
           'shadow-warm h-full cursor-pointer transition',
           'data-fade-in hover:brightness-105'


### PR DESCRIPTION
## 변경 사항

홈·탐색 메인 배너 캐러셀(`HOME_MAIN_BANNERS`)을 수정했습니다.

### 배너 순서
1. 공식 챌린지 시작!
2. **디스코드 참여하기** (신규, 외부 링크)
3. 1D1S가 처음이라면 (사용 가이드)
4. 꾸준함이 실력이 됩니다
5. 내 기록을 통계로 보기

### 상세
- **디스코드 참여 배너 추가** — `href: https://discord.gg/JaHRYHtrE7`, 디스코드 브랜드 컬러(#5865F2) 그라디언트 반영, 배너 디자인 일관성 유지
- **외부 링크 지원** — 배너 클릭 핸들러가 `http/https`로 시작하는 href면 `window.open(url, '_blank', 'noopener,noreferrer')`로 새 탭 열기, 내부 경로는 기존대로 `router.push`
- **오늘의 일지 인기글 배너 제거**
- 인디케이터는 `banners.length` 기반으로 자동 반영되어 레이아웃 시프트 없음

## 검증
- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test` ✅ (159 passed)
- `pnpm knip` ✅
- `pnpm build` ✅