### PR TITLE
release: 홈 디스코드 배너 및 외부 링크 지원 운영 배포

### DIFF
--- a/src/app.constants/consts/homeData.ts
+++ b/src/app.constants/consts/homeData.ts
@@ -19,6 +19,14 @@ export const HOME_MAIN_BANNERS: HomeMainBanner[] = [
     href: '/challenge/25',
   },
   {
+    id: 'discord-community',
+    kind: 'HOT',
+    title: '디스코드\n참여하기',
+    subtitle: '챌린저들과 실시간으로 이야기 나눠요',
+    gradient: 'linear-gradient(135deg, #7289da 0%, #5865f2 100%)',
+    href: 'https://discord.gg/JaHRYHtrE7',
+  },
+  {
     id: 'usage-guide',
     kind: 'TIP',
     title: '1D1S가\n처음이라면',
@@ -32,14 +40,6 @@ export const HOME_MAIN_BANNERS: HomeMainBanner[] = [
     title: '꾸준함이\n실력이 됩니다',
     subtitle: '매일 조금씩, 30일 후 달라진 나',
     gradient: 'linear-gradient(135deg, #7dd8b5 0%, #3eb489 100%)',
-    href: '/diary',
-  },
-  {
-    id: 'challenge-create',
-    kind: 'NEW',
-    title: '오늘의 일지\n인기글',
-    subtitle: '챌린저들의 진솔한 하루를 만나보세요',
-    gradient: 'linear-gradient(135deg, #7ab3ef 0%, #1666ba 100%)',
     href: '/diary',
   },
   {

--- a/src/app.feature/home/components/HomeWarmBanner.tsx
+++ b/src/app.feature/home/components/HomeWarmBanner.tsx
@@ -37,6 +37,17 @@ export default function HomeWarmBanner({
 
   const current = banners[index];
 
+  const handleClick = (): void => {
+    if (!current.href) {
+      return;
+    }
+    if (/^https?:\/\//.test(current.href)) {
+      window.open(current.href, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    router.push(current.href);
+  };
+
   return (
     <div className="relative h-full w-full">
       <Banner
@@ -47,7 +58,7 @@ export default function HomeWarmBanner({
         bg={current.gradient}
         size="md"
         role="link"
-        onClick={() => current.href && router.push(current.href)}
+        onClick={handleClick}
         className={cn(
           'shadow-warm h-full cursor-pointer transition',
           'data-fade-in hover:brightness-105'


### PR DESCRIPTION
## 운영 배포 (develop → main)

### 포함 변경
- feat: 홈 배너에 디스코드 참여 슬라이드 추가 및 외부 링크 지원 (#217)
  - 배너 순서: 공식 챌린지 → **디스코드 참여** → 사용 가이드 → 꾸준함 → 통계
  - 디스코드 참여 배너(`https://discord.gg/JaHRYHtrE7`) 신규 추가, 외부 링크 새 탭(`noopener,noreferrer`)
  - 오늘의 일지 인기글 배너 제거

### 검증
- develop CI 전체 green (tsc/lint/test/knip/build)
- 승격 PR은 정책에 따라 **merge commit** 사용

머지 후 `main → develop` 동기화 예정.