### PR TITLE
feat: 공식 챌린지 가이드 보상 섹션에 완주 지급 조건 유의사항 추가

### DIFF
--- a/src/app.feature/guide/screen/OfficialGuideScreen.tsx
+++ b/src/app.feature/guide/screen/OfficialGuideScreen.tsx
@@ -10,6 +10,7 @@ import {
   Flame,
   Gift,
   Heart,
+  Info,
   type LucideIcon,
   Medal,
   MessageSquare,
@@ -627,6 +628,56 @@ function RewardSection(): React.ReactElement {
           </ul>
         </div>
       </div>
+
+      {/* 지급 유의사항 — 순위 안에 들어도 완주하지 않으면 미지급 */}
+      <div
+        className={cn(
+          'animate-pop-in rounded-4 mx-auto mt-5 flex max-w-[640px] gap-3.5',
+          'border border-red-200 bg-red-50 p-5 sm:p-6'
+        )}
+      >
+        <span
+          className={cn(
+            'flex h-10 w-10 shrink-0 items-center justify-center',
+            'rounded-[11px] border border-red-300 bg-white'
+          )}
+        >
+          <Info className="h-5 w-5 text-red-500" strokeWidth={2} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <Text
+            size="body1"
+            weight="extrabold"
+            className="mb-2 block break-keep text-gray-900"
+          >
+            지급 전 꼭 확인하세요
+          </Text>
+          <ul className="flex flex-col gap-2">
+            <li className="flex items-start gap-2">
+              <span className="mt-[7px] h-1 w-1 shrink-0 rounded-full bg-red-400" />
+              <Text
+                size="body2"
+                weight="regular"
+                className="block leading-relaxed break-keep text-gray-700"
+              >
+                순위가 <b>5위 안에 들더라도, 완주자가 아니면</b> 상품은 지급되지
+                않아요.
+              </Text>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-[7px] h-1 w-1 shrink-0 rounded-full bg-red-400" />
+              <Text
+                size="body2"
+                weight="regular"
+                className="block leading-relaxed break-keep text-gray-700"
+              >
+                완주 기준은 <b>챌린지 목표의 70% 이상 수행</b>이에요.
+              </Text>
+            </li>
+          </ul>
+        </div>
+      </div>
+
       <Text
         size="caption2"
         weight="regular"


### PR DESCRIPTION
## 요약
공식 챌린지 가이드(`/guide/official`)의 보상 섹션에 지급 조건 유의사항을 추가합니다.

기존 보상 문구(상위 5명 지급 / 참여자 수에 따라 더 지급 가능)만으로는
"순위 안에 들어도 완주하지 않으면 미지급"이라는 핵심 조건이 드러나지
않아, 보상 카드 바로 아래에 유의사항 박스를 배치했습니다.

## 변경 내용
- `RewardSection`에 지급 유의사항 박스 추가
  - 순위 5위 안에 들더라도 **완주자가 아니면** 상품은 지급되지 않음
  - 완주 기준은 **챌린지 목표의 70% 이상 수행**
- `Info` 아이콘 import 추가
- 톤: 기존 red 팔레트 기반 soft caution 박스(눈에 띄되 과하지 않게)
- 반응형/DS 토큰 유지, 볼드는 핵심 조건에만

## 검증
- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test` (vitest) ✅ 159 passed
- `pnpm knip` ✅
- `pnpm build` ✅ (`/guide/official` static)

브라우저 확인은 하지 않았습니다(프로젝트 정책상 정적 검증까지만 수행).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible “Reward Notice” card to the rewards section.
  * Clarified that ranking in the top five does not guarantee a reward unless the challenge is completed.
  * Defined challenge completion as achieving at least 70% of the goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->