### PR TITLE
feat: 마이페이지 설정 공식 챌린지 안내 추가·모바일 나가기 버튼 참여자 탭 한정

### DIFF
--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -1055,7 +1055,9 @@ export function ChallengeDetailScreen({
                   className={cn(
                     'mt-1 self-center text-[12px] text-gray-500',
                     'underline-offset-2 hover:text-gray-700 hover:underline',
-                    'disabled:opacity-50'
+                    'disabled:opacity-50',
+                    // 모바일에선 참여자 탭에서만 노출. 데스크톱은 항상 노출.
+                    activeTab !== 'participants' && 'hidden lg:block'
                   )}
                 >
                   챌린지 나가기

--- a/src/app.feature/member/settings/screen/SettingsScreen.tsx
+++ b/src/app.feature/member/settings/screen/SettingsScreen.tsx
@@ -14,6 +14,7 @@ import {
   ChevronRight,
   HelpCircle,
   LogOut,
+  Trophy,
   User,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -151,6 +152,13 @@ export default function SettingsScreen(): React.ReactElement {
             label="사용 가이드"
             description="1D1S 사용법을 5단계로 확인해요"
             onClick={() => router.push('/guide')}
+          />
+          <div className="h-px w-full bg-gray-100" />
+          <SettingsRow
+            icon={<Trophy className="h-5 w-5" />}
+            label="공식 챌린지 안내"
+            description="공식 챌린지 참여·보상 조건을 확인해요"
+            onClick={() => router.push('/guide/official')}
           />
           <div className="h-px w-full bg-gray-100" />
           <SettingsRow


### PR DESCRIPTION
## 변경 사항

### 1. 마이페이지 > 설정: 공식 챌린지 안내 바로가기 추가
- '사용 가이드' 항목 바로 아래에 `공식 챌린지 안내`(`/guide/official`) 행 추가
- 기존 `SettingsRow` 패턴 그대로 사용 (Trophy 아이콘)

### 2. 모바일 챌린지 상세: '챌린지 나가기' 참여자 탭 한정
- 기존: 참여 중이면 모든 탭(소개·통계·일지·참여자)에서 노출
- 변경: 모바일에선 참여자 탭에서만 노출
- 데스크톱은 우측 sticky rail에 항상 노출(기존 동작 유지). `activeTab !== 'participants' && 'hidden lg:block'` 조건으로 모바일만 분기

## 검증
- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test` ✅ (159 passed)
- `pnpm knip` ✅
- `pnpm build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Official Challenge Guide” option to Settings, with direct navigation to the guide.

* **Bug Fixes**
  * Updated the challenge exit button’s mobile visibility so it appears only on the Participants tab. On desktop, it remains visible across tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->