### PR TITLE
release: 마이페이지 설정 공식 챌린지 안내·모바일 나가기 버튼 참여자 탭 한정 (#221) 운영 배포

### DIFF
--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -1055,7 +1055,9 @@ export function ChallengeDetailScreen({
                   className={cn(
                     'mt-1 self-center text-[12px] text-gray-500',
                     'underline-offset-2 hover:text-gray-700 hover:underline',
-                    'disabled:opacity-50'
+                    'disabled:opacity-50',
+                    // 모바일에선 참여자 탭에서만 노출. 데스크톱은 항상 노출.
+                    activeTab !== 'participants' && 'hidden lg:block'
                   )}
                 >
                   챌린지 나가기

--- a/src/app.feature/member/settings/screen/SettingsScreen.tsx
+++ b/src/app.feature/member/settings/screen/SettingsScreen.tsx
@@ -14,6 +14,7 @@ import {
   ChevronRight,
   HelpCircle,
   LogOut,
+  Trophy,
   User,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -151,6 +152,13 @@ export default function SettingsScreen(): React.ReactElement {
             label="사용 가이드"
             description="1D1S 사용법을 5단계로 확인해요"
             onClick={() => router.push('/guide')}
+          />
+          <div className="h-px w-full bg-gray-100" />
+          <SettingsRow
+            icon={<Trophy className="h-5 w-5" />}
+            label="공식 챌린지 안내"
+            description="공식 챌린지 참여·보상 조건을 확인해요"
+            onClick={() => router.push('/guide/official')}
           />
           <div className="h-px w-full bg-gray-100" />
           <SettingsRow


### PR DESCRIPTION
## 운영 배포 (develop → main)

### 포함 커밋
- a874950 feat: 마이페이지 설정에 공식 챌린지 안내 추가·모바일 나가기 버튼 참여자 탭 한정 (#221)

### 변경 요약
- **설정 화면**: 마이페이지 설정에 공식 챌린지 안내(가이드) 바로가기 추가
  - `src/app.feature/member/settings/screen/SettingsScreen.tsx`
- **챌린지 상세**: 모바일 나가기 버튼을 참여자 탭에서만 노출되도록 한정
  - `src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx`

### 참고
- 완주 지급 조건 유의사항(#219), 공식 챌린지 오픈 홍보 배너(#215) 등은 이미 이전 릴리즈(#220)로 main 반영 완료.
- 이번 승격 대상은 #221 단일 커밋.