### PR TITLE
feat: PostHog 프로덕트 애널리틱스 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ NEXT_PUBLIC_WEB_URL=https://your-site.example.com
 # 챌린지 공유의 카카오톡 버튼에 사용. 미설정 시 버튼은 안내 토스트만 표시.
 NEXT_PUBLIC_KAKAO_JS_KEY=your-kakao-javascript-key
 
+# PostHog 프로덕트 애널리틱스 (PostHog 프로젝트 설정 > Project API Key)
+# 미설정 시 초기화를 스킵하므로 로컬/프리뷰에서 에러가 나지 않는다.
+# HOST 미설정 시 기본값 https://us.i.posthog.com (EU 프로젝트는 eu.i.posthog.com)
+NEXT_PUBLIC_POSTHOG_KEY=phc_your-posthog-project-key
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
 # production example (replace in production env)
 # NEXT_PUBLIC_ODOS_API_URL=https://your-production-api.example.com/
 # NEXT_PUBLIC_ACCESS_TOKEN_COOKIE_NAME=accessToken

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Optional env vars:
 - `LOCAL_ALLOW_INSECURE_TLS=true` (optional, allow insecure backend TLS in dev)
 - `LOCAL_BIND_HOST` (optional bind host override)
 - `LOCAL_ALIAS_OPEN_BROWSER=false` (optional, disable auto-open)
+- `NEXT_PUBLIC_POSTHOG_KEY` (PostHog product analytics; unset → init skipped)
+- `NEXT_PUBLIC_POSTHOG_HOST` (default `https://us.i.posthog.com`)
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lucide-react": "^0.487.0",
     "next": "16.2.10",
     "postcss": "^8.5.16",
+    "posthog-js": "^1.399.5",
     "react": "^19.2.4",
     "react-day-picker": "8.10.1",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       postcss:
         specifier: ^8.5.16
         version: 8.5.16
+      posthog-js:
+        specifier: ^1.399.5
+        version: 1.399.5
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1080,6 +1083,12 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@posthog/core@1.40.2':
+    resolution: {integrity: sha512-H12j7O9iHGvpK9t2ko8W4pvfbV1pBDxrsWC1LA6yp2RhzwvC4T3sWhu+AekDQJSRSrJEWlB0t/Ueq9QhPSq7FQ==}
+
+  '@posthog/types@1.393.0':
+    resolution: {integrity: sha512-vzWeEJZ7ERQhFRoQYaP5jzN1JvIu46UJyHXsuv+dTGW2r3sMgREOhNxXLZjmFHwZ8/FOHQoyqqQmXTCXZSfMSg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2834,6 +2843,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cosmiconfig-typescript-loader@6.1.0:
     resolution: {integrity: sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==}
     engines: {node: '>=v18'}
@@ -3267,6 +3279,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4210,6 +4225,17 @@ packages:
     resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.399.5:
+    resolution: {integrity: sha512-5z7piKHxzZeDhdZ/XtivVHKIFr+09mDPcN3kIIkBS1zHmUTzDhQAR0T3R6NZTLog/8wzhY2jlu16anve1fdMAA==}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4327,6 +4353,9 @@ packages:
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4954,6 +4983,9 @@ packages:
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -5875,6 +5907,12 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@posthog/core@1.40.2':
+    dependencies:
+      '@posthog/types': 1.393.0
+
+  '@posthog/types@1.393.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7559,6 +7597,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  core-js@3.49.0: {}
+
   cosmiconfig-typescript-loader@6.1.0(@types/node@20.17.28)(cosmiconfig@9.0.0(typescript@5.8.2))(typescript@5.8.2):
     dependencies:
       '@types/node': 20.17.28
@@ -8163,6 +8203,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.4.8: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -9119,6 +9161,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.399.5:
+    dependencies:
+      '@posthog/core': 1.40.2
+      '@posthog/types': 1.393.0
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.7
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  preact@10.29.7: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-tailwindcss@0.6.11(prettier@3.5.3):
@@ -9213,6 +9270,8 @@ snapshots:
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -9877,6 +9936,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   walk-up-path@4.0.0: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@7.0.0: {}
 

--- a/src/app.module/providers/PostHogProvider.tsx
+++ b/src/app.module/providers/PostHogProvider.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useAuthStatus } from '@module/hooks/useAuthStatus';
+import { usePathname, useSearchParams } from 'next/navigation';
+import posthog from 'posthog-js';
+import React, { Suspense, useEffect } from 'react';
+
+import { useSidebar } from '@/app.feature/member/hooks/useMemberQueries';
+
+const DEFAULT_HOST = 'https://us.i.posthog.com';
+
+// 초기화 여부를 자체 플래그로 추적한다(posthog 내부 필드 의존 회피).
+let initialized = false;
+
+/**
+ * PostHog 클라이언트 1회 초기화. 키가 없으면(로컬/프리뷰) 스킵해 에러를 막는다.
+ * 모듈 로드 시점(클라이언트)에 호출되어 이후 pageview/identify 이펙트가
+ * 초기화 완료 상태를 볼 수 있게 한다.
+ */
+function initPostHog(): void {
+  if (initialized || typeof window === 'undefined') {
+    return;
+  }
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) {
+    return;
+  }
+  posthog.init(key, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_HOST,
+    // App Router 는 자동 pageview 가 오동작하므로 수동 캡처한다.
+    capture_pageview: false,
+    // 개인정보 보호: 세션 리코딩 비활성, 로그인 사용자만 person 프로필 생성.
+    disable_session_recording: true,
+    person_profiles: 'identified_only',
+  });
+  initialized = true;
+}
+
+if (typeof window !== 'undefined') {
+  initPostHog();
+}
+
+/**
+ * pathname/searchParams 변경마다 `$pageview` 수동 캡처(App Router 공식 권장).
+ * useSearchParams 는 Suspense 경계 안에서만 사용해야 한다.
+ */
+function PostHogPageView(): null {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!initialized || !pathname) {
+      return;
+    }
+    posthog.capture('$pageview', { $current_url: window.location.href });
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+/**
+ * 로그인 확정 시 nickname 으로 식별, 로그아웃 시 reset.
+ * 서버가 memberId 를 클라이언트에 노출하지 않으므로 안정 식별자로 nickname 을
+ * 쓴다. 민감정보(이메일·전화번호·생년월일)는 전송하지 않는다.
+ */
+function PostHogIdentify(): null {
+  const status = useAuthStatus();
+  const { data: sidebar } = useSidebar();
+  const nickname = sidebar?.nickname;
+
+  useEffect(() => {
+    if (!initialized) {
+      return;
+    }
+    if (status === 'authenticated' && nickname) {
+      posthog.identify(nickname, { nickname });
+    } else if (status === 'guest') {
+      posthog.reset();
+    }
+  }, [status, nickname]);
+
+  return null;
+}
+
+export function PostHogProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <>
+      <Suspense fallback={null}>
+        <PostHogPageView />
+      </Suspense>
+      <PostHogIdentify />
+      {children}
+    </>
+  );
+}

--- a/src/app.module/providers/index.tsx
+++ b/src/app.module/providers/index.tsx
@@ -1,3 +1,4 @@
+import { PostHogProvider } from './PostHogProvider';
 import { TanStackQueryProvider } from './QueryClientProvider';
 import { ToastProvider } from './ToastProvider';
 
@@ -8,7 +9,9 @@ export function AppProviders({
 }): React.ReactElement {
   return (
     <TanStackQueryProvider>
-      <ToastProvider>{children}</ToastProvider>
+      <PostHogProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </PostHogProvider>
     </TanStackQueryProvider>
   );
 }


### PR DESCRIPTION
## 개요
1D1S 웹(Next.js App Router)에 PostHog 프로덕트 애널리틱스를 연동한다.

## 변경 사항
- `posthog-js` 도입, `PostHogProvider`에서 클라이언트 1회 초기화
  - **키(`NEXT_PUBLIC_POSTHOG_KEY`) 미설정 시 초기화 스킵** → 로컬/프리뷰에서 에러 없음
  - `NEXT_PUBLIC_POSTHOG_HOST` 미설정 시 기본값 `https://us.i.posthog.com`
- **App Router pageview 수동 캡처**: `capture_pageview: false`로 두고 `pathname`/`searchParams` 변경마다 `$pageview` 캡처. `useSearchParams`는 `Suspense` 경계 안에서만 사용(정적 렌더 유지 확인)
- **사용자 식별**: `useAuthStatus`가 `authenticated`로 확정되면 `identify(nickname, { nickname })`, `guest`면 `reset()`
  - 서버가 memberId를 클라이언트에 노출하지 않아 안정 식별자로 nickname 사용
  - 민감정보(이메일·전화번호·생년월일) **미전송**
- **개인정보 옵션**: 세션 리코딩 비활성(`disable_session_recording: true`), `person_profiles: 'identified_only'`(로그인 사용자만 person 생성). autocapture는 기본값 유지
- `.env.example`·README에 환경변수 문서화

## 캡처 범위
| 항목 | 상태 |
|---|---|
| pageview | 수동 캡처 (App Router 대응) |
| identify | 로그인 확정 시 nickname |
| autocapture | 기본값 유지 |
| 세션 리코딩 | 비활성 |

## 검증
- tsc `--noEmit` / eslint(0 errors) / vitest(159 passed) / knip / `next build` 모두 통과
- 브라우저 실동작은 미확인(프로젝트 정책상 사용자가 직접 확인). PostHog 키는 Vercel 환경변수 등록 후 동작

## 배포 후 필요 작업
- PostHog 프로젝트 생성 → Project API Key 발급
- Vercel 환경변수 등록: `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST` (Development/Preview/Production)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy-conscious PostHog analytics integration.
  * Added automatic pageview tracking and signed-in member identification.
  * Analytics are skipped when no tracking key is configured.
* **Documentation**
  * Documented optional analytics environment variables and their defaults for local development.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->