### PR TITLE
release: 전화번호 미입력 사용자 입력 유도 UI 운영 배포 (#226)

### DIFF
--- a/src/app.component/ProfileAlertBadge.tsx
+++ b/src/app.component/ProfileAlertBadge.tsx
@@ -1,0 +1,33 @@
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+/**
+ * 프로필 아바타 우상단에 겹치는 작은 경고 배지(느낌표).
+ * 전화번호 미입력처럼 사용자 조치가 필요할 때 노출한다.
+ *
+ * - 부모 요소는 `relative` 여야 하며, 아바타의 `overflow-hidden` 바깥에
+ *   형제로 둬야 잘리지 않는다.
+ * - `absolute` 라 레이아웃 시프트를 만들지 않는다.
+ * - `pointer-events-none` 로 아바타 클릭을 가로막지 않는다.
+ */
+export function ProfileAlertBadge({
+  className,
+}: {
+  className?: string;
+}): React.ReactElement {
+  return (
+    <span
+      role="img"
+      aria-label="전화번호 미입력"
+      className={cn(
+        'pointer-events-none absolute -top-0.5 -right-0.5 z-10',
+        'flex h-4 w-4 items-center justify-center rounded-full',
+        'bg-amber-500 text-[10px] leading-none font-extrabold text-white',
+        'ring-2 ring-white',
+        className
+      )}
+    >
+      !
+    </span>
+  );
+}

--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@1d1s/design-system';
 import { AddToHomeScreenPrompt } from '@feature/install/components/AddToHomeScreenPrompt';
+import { usePhoneNumberMissing } from '@feature/member/hooks/usePhoneNumberMissing';
 import { BrowserPermissionPrompt } from '@feature/notification/components/BrowserPermissionPrompt';
 import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
 import { useServiceWorkerNavigation } from '@module/hooks/useServiceWorkerNavigation';
@@ -143,6 +144,10 @@ export default function AppLayoutShell({
   const { isLoggedIn, isAuthLoading, hasUnread, sidebarData, railChallenges } =
     authState;
 
+  // 전화번호 미입력 시 프로필 아바타에 경고 배지를 띄운다. 사이드바 응답에는
+  // phoneNumber 가 없어 my-page 쿼리를 재사용한다(동일 queryKey dedupe).
+  const showPhoneBadge = usePhoneNumberMissing();
+
   useEffect(() => {
     if (
       !isLoggedIn ||
@@ -214,6 +219,7 @@ export default function AppLayoutShell({
             hasUnread={hasUnread}
             streakDays={sidebarData?.streakCount ?? 0}
             profileImageUrl={sidebarData?.profileUrl}
+            showPhoneBadge={showPhoneBadge}
             onProfileClick={handleProfileClick}
             className={topNavRespClass}
           />
@@ -245,6 +251,7 @@ export default function AppLayoutShell({
                   sidebarData?.nickname ? `@${sidebarData.nickname}` : undefined
                 }
                 profileImageUrl={sidebarData?.profileUrl}
+                showPhoneBadge={showPhoneBadge}
                 streakDays={sidebarData?.streakCount ?? 0}
                 todayGoalCount={sidebarData?.todayGoalCount ?? 0}
                 challenges={railChallenges}

--- a/src/app.component/layout/AppRightRail.tsx
+++ b/src/app.component/layout/AppRightRail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Icon, StreakHero } from '@1d1s/design-system';
+import { ProfileAlertBadge } from '@component/ProfileAlertBadge';
 import { Skeleton } from '@component/Skeleton';
 import { cn } from '@module/utils/cn';
 import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
@@ -24,6 +25,7 @@ interface AppRightRailProps {
   nickname: string;
   handle?: string;
   profileImageUrl?: string;
+  showPhoneBadge?: boolean;
   streakDays: number;
   todayGoalCount: number;
   challenges: ChallengeProgressItem[];
@@ -80,6 +82,7 @@ export default function AppRightRail({
   nickname,
   handle,
   profileImageUrl,
+  showPhoneBadge = false,
   streakDays,
   todayGoalCount,
   challenges,
@@ -189,21 +192,24 @@ export default function AppRightRail({
                 'text-left transition hover:bg-gray-50'
               )}
             >
-              <span
-                className={cn(
-                  'h-12 w-12 shrink-0 overflow-hidden rounded-full',
-                  'border-main-200 bg-main-100 border-2'
-                )}
-              >
-                {profileImageUrl ? (
-                  <Image
-                    src={profileImageUrl}
-                    alt={nickname}
-                    width={48}
-                    height={48}
-                    className="h-full w-full object-cover"
-                  />
-                ) : null}
+              <span className="relative shrink-0">
+                <span
+                  className={cn(
+                    'block h-12 w-12 overflow-hidden rounded-full',
+                    'border-main-200 bg-main-100 border-2'
+                  )}
+                >
+                  {profileImageUrl ? (
+                    <Image
+                      src={profileImageUrl}
+                      alt={nickname}
+                      width={48}
+                      height={48}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : null}
+                </span>
+                {showPhoneBadge ? <ProfileAlertBadge /> : null}
               </span>
               <div className="min-w-0 flex-1">
                 <div

--- a/src/app.component/layout/AppTopNav.tsx
+++ b/src/app.component/layout/AppTopNav.tsx
@@ -2,6 +2,7 @@
 
 import { Icon, StreakChip } from '@1d1s/design-system';
 import { ChallengeTrophyIcon } from '@component/ChallengeTrophyIcon';
+import { ProfileAlertBadge } from '@component/ProfileAlertBadge';
 import { Skeleton } from '@component/Skeleton';
 import { cn } from '@module/utils/cn';
 import {
@@ -41,6 +42,7 @@ interface AppTopNavProps {
   hasUnread: boolean;
   streakDays: number;
   profileImageUrl?: string;
+  showPhoneBadge?: boolean;
   onProfileClick(): void;
   className?: string;
 }
@@ -52,6 +54,7 @@ export default function AppTopNav({
   hasUnread,
   streakDays,
   profileImageUrl,
+  showPhoneBadge = false,
   onProfileClick,
   className,
 }: AppTopNavProps): React.ReactElement {
@@ -154,25 +157,28 @@ export default function AppTopNav({
               {streakDays > 0 ? (
                 <StreakChip days={streakDays} unit="일" />
               ) : null}
-              <button
-                type="button"
-                onClick={onProfileClick}
-                aria-label="프로필"
-                className={cn(
-                  'h-9 w-9 overflow-hidden rounded-full',
-                  'border-main-200 bg-main-100 border-2'
-                )}
-              >
-                {profileImageUrl ? (
-                  <Image
-                    src={profileImageUrl}
-                    alt="프로필"
-                    width={36}
-                    height={36}
-                    className="h-full w-full object-cover"
-                  />
-                ) : null}
-              </button>
+              <span className="relative inline-flex">
+                <button
+                  type="button"
+                  onClick={onProfileClick}
+                  aria-label="프로필"
+                  className={cn(
+                    'h-9 w-9 overflow-hidden rounded-full',
+                    'border-main-200 bg-main-100 border-2'
+                  )}
+                >
+                  {profileImageUrl ? (
+                    <Image
+                      src={profileImageUrl}
+                      alt="프로필"
+                      width={36}
+                      height={36}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : null}
+                </button>
+                {showPhoneBadge ? <ProfileAlertBadge /> : null}
+              </span>
             </>
           ) : (
             <Link

--- a/src/app.feature/member/hooks/phoneNumberMissing.test.ts
+++ b/src/app.feature/member/hooks/phoneNumberMissing.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPhoneNumberMissing } from './phoneNumberMissing';
+
+describe('isPhoneNumberMissing', () => {
+  it('인증 확정 + 데이터 도착 + phoneNumber 없음이면 true', () => {
+    expect(isPhoneNumberMissing('authenticated', {})).toBe(true);
+    expect(isPhoneNumberMissing('authenticated', { phoneNumber: '' })).toBe(
+      true
+    );
+  });
+
+  it('phoneNumber 가 있으면 false', () => {
+    expect(
+      isPhoneNumberMissing('authenticated', { phoneNumber: '01012345678' })
+    ).toBe(false);
+  });
+
+  it('데이터 미도착(로딩 중)이면 false', () => {
+    expect(isPhoneNumberMissing('authenticated', undefined)).toBe(false);
+  });
+
+  it('인증 미확정(unknown/guest)이면 false', () => {
+    expect(isPhoneNumberMissing('unknown', {})).toBe(false);
+    expect(isPhoneNumberMissing('guest', {})).toBe(false);
+  });
+});

--- a/src/app.feature/member/hooks/phoneNumberMissing.ts
+++ b/src/app.feature/member/hooks/phoneNumberMissing.ts
@@ -1,0 +1,20 @@
+import type { AuthStatus } from '@module/utils/auth';
+
+import type { MyPageData } from '../type/member';
+
+/**
+ * 전화번호 미입력 여부(순수 판정). 훅에서 분리해 API 클라이언트 의존 없이
+ * 단위 테스트가 가능하다.
+ * - `authenticated` 로 확정되고
+ * - my-page 응답이 도착했으며(`data` 존재)
+ * - 응답에 phoneNumber 가 없을 때만 true.
+ *
+ * unknown/guest 이거나 아직 로딩 중(`data` 미도착)이면 false 를 돌려,
+ * 인증 확정 전 배지·배너가 번쩍이는 것을 막는다.
+ */
+export function isPhoneNumberMissing(
+  status: AuthStatus,
+  data: Pick<MyPageData, 'phoneNumber'> | undefined
+): boolean {
+  return status === 'authenticated' && Boolean(data) && !data?.phoneNumber;
+}

--- a/src/app.feature/member/hooks/usePhoneNumberMissing.ts
+++ b/src/app.feature/member/hooks/usePhoneNumberMissing.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useAuthStatus } from '@module/hooks/useAuthStatus';
+
+import { isPhoneNumberMissing } from './phoneNumberMissing';
+import { useMyPage } from './useMemberQueries';
+
+/**
+ * 로그인 사용자의 전화번호 미입력 여부.
+ * 데이터 소스는 기존 my-page 쿼리(`useMyPage`)를 재사용한다 — 사이드바
+ * 응답에는 phoneNumber 가 없기 때문. 동일 queryKey 로 dedupe/캐시된다.
+ */
+export function usePhoneNumberMissing(): boolean {
+  const status = useAuthStatus();
+  const { data } = useMyPage();
+  return isPhoneNumberMissing(status, data);
+}

--- a/src/app.feature/member/mypage/components/MyPagePhoneBanner.tsx
+++ b/src/app.feature/member/mypage/components/MyPagePhoneBanner.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { ChevronRight, Phone } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+
+/**
+ * 전화번호 미입력 안내 배너. 누르면 프로필 설정(전화번호 입력 항목이 있는
+ * 화면)으로 이동한다. 노출 조건(전화번호 없음)은 호출부에서 판단한다.
+ */
+export function MyPagePhoneBanner({
+  className,
+}: {
+  className?: string;
+}): React.ReactElement {
+  const router = useRouter();
+  return (
+    <button
+      type="button"
+      onClick={() => router.push('/mypage/settings/profile')}
+      className={cn(
+        'rounded-2 flex w-full items-center gap-3 border border-amber-200',
+        'bg-amber-50 px-4 py-3 text-left transition hover:bg-amber-100',
+        className
+      )}
+    >
+      <span
+        className={cn(
+          'flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+          'bg-amber-100 text-amber-700'
+        )}
+      >
+        <Phone className="h-[18px] w-[18px]" aria-hidden />
+      </span>
+      <span className="min-w-0 flex-1">
+        <Text size="body1" weight="bold" className="block text-amber-900">
+          전화번호를 추가해주세요!
+        </Text>
+        <Text size="caption1" weight="regular" className="block text-amber-700">
+          상품 수령에 필요해요.
+        </Text>
+      </span>
+      <ChevronRight
+        className="h-4 w-4 shrink-0 text-amber-600"
+        aria-hidden
+      />
+    </button>
+  );
+}

--- a/src/app.feature/member/mypage/components/MyPageProfileCard.tsx
+++ b/src/app.feature/member/mypage/components/MyPageProfileCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button, CircleAvatar, Icon, Text } from '@1d1s/design-system';
+import { ProfileAlertBadge } from '@component/ProfileAlertBadge';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useUnreadCount } from '@feature/notification/hooks/useNotificationQueries';
 import { cn } from '@module/utils/cn';
@@ -98,6 +99,8 @@ interface MyPageProfileCardProps {
   completedFiniteChallengeCount: number;
   /** 모바일 3-col grid에서 스트릭 카운트 표시용 */
   currentStreak?: number;
+  /** 전화번호 미입력 시 아바타에 경고 배지 노출 */
+  showPhoneBadge?: boolean;
   /** 우측 액션 영역 — 미지정 시 기본 (프로필 편집 + 설정) 사용 */
   actions?: React.ReactNode;
   /** 지정 시 챌린지 스탯을 누르면 해당 경로로 이동 */
@@ -117,6 +120,7 @@ export function MyPageProfileCard({
   totalChallengeCount,
   completedFiniteChallengeCount,
   currentStreak,
+  showPhoneBadge = false,
   actions,
   challengeHref,
   diaryHref,
@@ -197,13 +201,18 @@ export function MyPageProfileCard({
           )}
         </div>
         <div className="mt-1 flex items-center gap-3.5">
-          <div
-            className={cn(
-              'h-18 w-18 shrink-0 overflow-hidden rounded-full',
-              'border-[3px] border-gray-100'
-            )}
-          >
-            <CircleAvatar imageUrl={profileUrl} size={66} />
+          <div className="relative shrink-0">
+            <div
+              className={cn(
+                'h-18 w-18 overflow-hidden rounded-full',
+                'border-[3px] border-gray-100'
+              )}
+            >
+              <CircleAvatar imageUrl={profileUrl} size={66} />
+            </div>
+            {showPhoneBadge ? (
+              <ProfileAlertBadge className="h-5 w-5 text-[11px]" />
+            ) : null}
           </div>
           <div className="min-w-0 flex-1">
             <Text size="heading1" weight="extrabold" className="text-gray-900">
@@ -252,13 +261,18 @@ export function MyPageProfileCard({
         )}
       >
         <div className="flex shrink-0 justify-center sm:block">
-          <div
-            className={cn(
-              'h-24 w-24 overflow-hidden rounded-full border-4',
-              'border-gray-100'
-            )}
-          >
-            <CircleAvatar imageUrl={profileUrl} size={88} />
+          <div className="relative inline-block">
+            <div
+              className={cn(
+                'h-24 w-24 overflow-hidden rounded-full border-4',
+                'border-gray-100'
+              )}
+            >
+              <CircleAvatar imageUrl={profileUrl} size={88} />
+            </div>
+            {showPhoneBadge ? (
+              <ProfileAlertBadge className="h-5 w-5 text-[11px]" />
+            ) : null}
           </div>
         </div>
 

--- a/src/app.feature/member/mypage/screen/MyPageScreen.tsx
+++ b/src/app.feature/member/mypage/screen/MyPageScreen.tsx
@@ -18,6 +18,7 @@ import { MyPageActivityHeatmap } from '../components/MyPageActivityHeatmap';
 import { MyPageBadgesSection } from '../components/MyPageBadgesSection';
 import { MyPageDiarySection } from '../components/MyPageDiarySection';
 import { MyPageHeroBanner } from '../components/MyPageHeroBanner';
+import { MyPagePhoneBanner } from '../components/MyPagePhoneBanner';
 import { MyPageProfileCard } from '../components/MyPageProfileCard';
 import { MyPageStatSection } from '../components/MyPageStatSection';
 import { MyPageStreakHeroCard } from '../components/MyPageStreakHeroCard';
@@ -48,6 +49,8 @@ export default function MyPageScreen(): React.ReactElement | null {
   }
 
   const { nickname, profileUrl, streak, challengeList } = data;
+  // 미입력 회원은 응답에 phoneNumber 키가 없다.
+  const phoneMissing = !data.phoneNumber;
   const myDiaries = myDiariesData?.items ?? [];
   const hasMoreDiaries = myDiariesData?.pageInfo.hasNextPage ?? false;
 
@@ -74,9 +77,12 @@ export default function MyPageScreen(): React.ReactElement | null {
             streak.completedFiniteChallengeCount ?? 0
           }
           currentStreak={streak.currentStreak}
+          showPhoneBadge={phoneMissing}
           diaryHref="/mypage/diary"
           challengeHref="/mypage/challenge"
         />
+
+        {phoneMissing ? <MyPagePhoneBanner className="mt-6" /> : null}
 
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
           <MyPageFriendsEntry />


### PR DESCRIPTION
PR #226 상용 승격.

- 전화번호 미입력 로그인 사용자에게 프로필 아바타 경고 배지(탑바·우측 레일·마이페이지) + 마이페이지 안내 배너 노출
- 배너 클릭 시 `/mypage/settings/profile` 이동, 저장 시 my-page 쿼리 무효화로 배지 즉시 해제
- 판정 로직(`isPhoneNumberMissing`)은 순수 함수로 분리 + 유닛 테스트 4건

검증: lint 0 errors / tsc clean / vitest pass. 브라우저 확인은 미실시.