### PR TITLE
feat: support hybrid app authentication

### DIFF
--- a/src/app.feature/auth/api/authApi.ts
+++ b/src/app.feature/auth/api/authApi.ts
@@ -1,6 +1,7 @@
 import { apiClient, publicApiClient } from '@module/api/client';
 import { requestBody } from '@module/api/request';
 import { refreshAccessTokenOnce } from '@module/api/tokenRefresh';
+import { postNativeMessage } from '@module/utils/nativeBridge';
 
 import {
   LogoutResponse,
@@ -17,12 +18,13 @@ export const authApi = {
   socialLogin: async (
     provider: OAuthProvider,
     code: string,
-    state?: string
+    state?: string,
+    nativeCodeChallenge?: string
   ): Promise<SocialLoginResponse> =>
     requestBody<SocialLoginResponse>(publicApiClient, {
       url: `/login/oauth2/code/${provider}`,
       method: 'GET',
-      params: { code, state },
+      params: { code, state, nativeCodeChallenge },
       withCredentials: true,
     }),
 
@@ -51,10 +53,18 @@ export const authApi = {
   refreshToken: async (): Promise<void> => refreshAccessTokenOnce(),
 
   // 로그아웃
-  logout: async (): Promise<LogoutResponse> =>
-    requestBody<LogoutResponse, Record<string, never>>(apiClient, {
-      url: '/auth/logout',
-      method: 'POST',
-      data: {},
-    }),
+  logout: async (): Promise<LogoutResponse> => {
+    try {
+      return await requestBody<LogoutResponse, Record<string, never>>(
+        apiClient,
+        {
+          url: '/auth/logout',
+          method: 'POST',
+          data: {},
+        }
+      );
+    } finally {
+      postNativeMessage({ type: 'logout' });
+    }
+  },
 };

--- a/src/app.feature/auth/components/LoginButtons.tsx
+++ b/src/app.feature/auth/components/LoginButtons.tsx
@@ -3,6 +3,10 @@
 import { Button } from '@1d1s/design-system';
 import { API_BASE_URL } from '@module/api/config';
 import { cn } from '@module/utils/cn';
+import {
+  isNativeBridgeAvailable,
+  postNativeMessage,
+} from '@module/utils/nativeBridge';
 import { RETURN_TO_PARAM, returnToStorage } from '@module/utils/returnTo';
 import Image from 'next/image';
 
@@ -28,6 +32,15 @@ const handleSocialLogin = (provider: OAuthProvider): void => {
     returnToStorage.save(
       new URLSearchParams(window.location.search).get(RETURN_TO_PARAM)
     );
+    if (isNativeBridgeAvailable()) {
+      const startUrl = new URL('/login', window.location.origin);
+      startUrl.searchParams.set('nativeProvider', provider);
+      postNativeMessage({
+        type: 'oauth_open',
+        payload: { url: startUrl.toString() },
+      });
+      return;
+    }
   }
   window.location.href = `${API_BASE_URL}/oauth2/authorization/${provider}`;
 };

--- a/src/app.feature/auth/hooks/useAuthQueries.ts
+++ b/src/app.feature/auth/hooks/useAuthQueries.ts
@@ -1,3 +1,4 @@
+import { peekNativeOAuth } from '@module/utils/nativeBridge';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
 import { authApi } from '../api/authApi';
@@ -12,7 +13,13 @@ export function useSocialLogin(
 ): UseQueryResult<SocialLoginResponse, Error> {
   return useQuery({
     queryKey: AUTH_QUERY_KEYS.socialLogin(provider, code, state),
-    queryFn: () => authApi.socialLogin(provider, code!, state ?? undefined),
+    queryFn: () =>
+      authApi.socialLogin(
+        provider,
+        code!,
+        state ?? undefined,
+        peekNativeOAuth() ?? undefined
+      ),
     enabled: Boolean(provider) && Boolean(code),
     retry: false,
     staleTime: Infinity,

--- a/src/app.feature/auth/screen/LoginScreen.tsx
+++ b/src/app.feature/auth/screen/LoginScreen.tsx
@@ -2,7 +2,9 @@
 
 import { Text } from '@1d1s/design-system';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
+import { API_BASE_URL } from '@module/api/config';
 import { cn } from '@module/utils/cn';
+import { markNativeOAuth } from '@module/utils/nativeBridge';
 import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -30,6 +32,19 @@ export function LoginScreen(): React.ReactElement {
   );
 
   React.useEffect(() => {
+    const nativeProvider = new URLSearchParams(window.location.search).get(
+      'nativeProvider'
+    );
+    const codeChallenge = new URLSearchParams(window.location.search).get(
+      'pkceChallenge'
+    );
+    if (nativeProvider === 'naver' && codeChallenge) {
+      markNativeOAuth(codeChallenge);
+      window.location.replace(
+        `${API_BASE_URL}/oauth2/authorization/${nativeProvider}`
+      );
+      return;
+    }
     setRecommended(getLastOAuthProvider());
     setStreakDay(getLaunchStreakDay());
   }, []);

--- a/src/app.feature/auth/type/auth.ts
+++ b/src/app.feature/auth/type/auth.ts
@@ -17,6 +17,8 @@ export interface SocialLoginResponse {
   message: string;
   data: {
     profileComplete: boolean;
+    nativeLoginCode?: string;
+    nativeLoginCodeExpiresInSeconds?: number;
   };
 }
 

--- a/src/app.module/api/tokenRefresh.ts
+++ b/src/app.module/api/tokenRefresh.ts
@@ -1,4 +1,5 @@
 import { authStorage } from '@module/utils/auth';
+import { requestNativeTokenRefresh } from '@module/utils/nativeBridge';
 import axios from 'axios';
 
 import { API_BASE_URL } from './config';
@@ -21,8 +22,11 @@ let inFlight: Promise<void> | null = null;
  */
 export function refreshAccessTokenOnce(): Promise<void> {
   if (!inFlight) {
-    inFlight = axios
-      .get(`${API_BASE_URL}/auth/token`, { withCredentials: true })
+    const nativeRefresh = requestNativeTokenRefresh();
+    const refreshRequest =
+      nativeRefresh ??
+      axios.get(`${API_BASE_URL}/auth/token`, { withCredentials: true });
+    inFlight = refreshRequest
       .then(() => {
         // 갱신 성공 = 세션 생존 확정. 일시적 401 로 지워졌을 수 있는
         // 로그인 힌트(쿠키/localStorage)를 복구한다.

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -8,6 +8,8 @@
 const CHANNEL_NAME = 'OneDayOneStreakNative';
 const NAVIGATE_EVENT = 'native:navigate';
 const MODAL_RESULT_EVENT = 'native:modal_result';
+const TOKEN_REFRESH_RESULT_EVENT = 'native:token_refresh_result';
+const NATIVE_OAUTH_MARKER = '1d1s:native-oauth';
 
 export interface NativeAuthPayload {
   isLoggedIn: boolean;
@@ -55,6 +57,9 @@ export type NativeMessage =
   // collapse/expand 하는 용도. 매 프레임 보내는 대신 방향 전환에만 발화해
   // JS 채널 트래픽을 최소화한다.
   | { type: 'scroll_dir'; payload: NativeScrollDirPayload }
+  | { type: 'oauth_open'; payload: { url: string } }
+  | { type: 'token_refresh'; payload: { id: string } }
+  | { type: 'logout' }
   // 네이티브 다이얼로그 노출 요청. 응답은 native:modal_result CustomEvent
   // 로 비동기 도착. openNativeModal() 헬퍼가 id 매칭으로 Promise 화 한다.
   | { type: 'modal_open'; payload: NativeModalOpenPayload };
@@ -90,6 +95,90 @@ export function postNativeMessage(message: NativeMessage): void {
   } catch {
     // 네이티브 쉘이 응답하지 못하더라도 웹 흐름을 멈추지 않는다.
   }
+}
+
+export function isNativeBridgeAvailable(): boolean {
+  return getNativeWindow()?.[CHANNEL_NAME] != null;
+}
+
+export function markNativeOAuth(codeChallenge: string): void {
+  window.sessionStorage.setItem(NATIVE_OAUTH_MARKER, codeChallenge);
+}
+
+export function consumeNativeOAuth(): string | null {
+  const codeChallenge = window.sessionStorage.getItem(NATIVE_OAUTH_MARKER);
+  if (codeChallenge) {
+    window.sessionStorage.removeItem(NATIVE_OAUTH_MARKER);
+  }
+  return codeChallenge;
+}
+
+export function peekNativeOAuth(): string | null {
+  return window.sessionStorage.getItem(NATIVE_OAUTH_MARKER);
+}
+
+interface PendingTokenRefresh {
+  resolve(): void;
+  reject(): void;
+  timeout: number;
+}
+
+const pendingTokenRefreshes = new Map<string, PendingTokenRefresh>();
+let tokenRefreshListenerAttached = false;
+
+function ensureTokenRefreshListener(): void {
+  if (tokenRefreshListenerAttached) {
+    return;
+  }
+  const win = getNativeWindow();
+  if (!win) {
+    return;
+  }
+  win.addEventListener(TOKEN_REFRESH_RESULT_EVENT, (event: Event) => {
+    const detail = (event as CustomEvent<{ id?: string; ok?: boolean }>).detail;
+    if (!detail?.id) {
+      return;
+    }
+    const pending = pendingTokenRefreshes.get(detail.id);
+    if (!pending) {
+      return;
+    }
+    pendingTokenRefreshes.delete(detail.id);
+    window.clearTimeout(pending.timeout);
+    if (detail.ok) {
+      pending.resolve();
+    } else {
+      pending.reject();
+    }
+  });
+  tokenRefreshListenerAttached = true;
+}
+
+export function requestNativeTokenRefresh(): Promise<void> | null {
+  const channel = getNativeWindow()?.[CHANNEL_NAME];
+  if (!channel) {
+    return null;
+  }
+  ensureTokenRefreshListener();
+  const id = `refresh_${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+  return new Promise<void>((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      pendingTokenRefreshes.delete(id);
+      reject();
+    }, 15_000);
+    pendingTokenRefreshes.set(id, { resolve, reject, timeout });
+    try {
+      channel.postMessage(
+        JSON.stringify({ type: 'token_refresh', payload: { id } })
+      );
+    } catch {
+      window.clearTimeout(timeout);
+      pendingTokenRefreshes.delete(id);
+      reject();
+    }
+  });
 }
 
 export function onNativeNavigateRequest(

--- a/src/app/(auth)/login/oauth2/code/[provider]/page.tsx
+++ b/src/app/(auth)/login/oauth2/code/[provider]/page.tsx
@@ -5,6 +5,7 @@ import { OAuthProvider } from '@feature/auth/type/auth';
 import { MEMBER_QUERY_KEYS } from '@feature/member/consts/queryKeys';
 import { NotificationOptInPrompt } from '@feature/notification/components/NotificationOptInPrompt';
 import { authStorage } from '@module/utils/auth';
+import { consumeNativeOAuth } from '@module/utils/nativeBridge';
 import { RETURN_TO_PARAM, returnToStorage } from '@module/utils/returnTo';
 import { useQueryClient } from '@tanstack/react-query';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
@@ -50,6 +51,20 @@ function OAuthCallbackContent(): React.ReactElement {
 
     if (isSuccess) {
       processed.current = true;
+      const nativeCodeChallenge = consumeNativeOAuth();
+      if (nativeCodeChallenge) {
+        const nativeLoginCode = data?.data?.nativeLoginCode;
+        if (!nativeLoginCode) {
+          processed.current = false;
+          console.error('[OAuth] 앱 로그인 코드가 응답에 없습니다.');
+          router.replace('/login');
+          return;
+        }
+        const callback = new URL('onedayonestreak://auth/callback');
+        callback.searchParams.set('code', nativeLoginCode);
+        window.location.replace(callback.toString());
+        return;
+      }
       authStorage.markAuthenticated();
       returnToRef.current = returnToStorage.consume();
       // 로그인 전 null로 캐시된 사이드바 무효화 → 홈에서 즉시 리페치


### PR DESCRIPTION
## 변경 사항

- WebView에서 네이티브 OAuth 시작 요청을 브리지로 전달합니다.
- Naver WebView OAuth에 PKCE challenge를 연결하고 일회용 native login code를 앱 callback으로 반환합니다.
- WebView 토큰 갱신과 로그아웃을 네이티브 토큰 저장소에 위임합니다.

## 목적

웹 쿠키 세션과 네이티브 refresh token을 분리하면서도 하이브리드 앱에서 로그인, 토큰 갱신, 로그아웃을 일관되게 처리하기 위한 변경입니다.

## 검증

- `pnpm exec eslint src --max-warnings=-1` (오류 없음, 기존 경고만 존재)
- `pnpm exec tsc --noEmit`
- `pnpm test` (18 files, 163 tests)
- `pnpm knip --reporter=compact`
- `NEXT_PUBLIC_ODOS_API_URL=https://dev.api.1day1streak.com/ pnpm build`
