### PR TITLE
fix: 네이티브 쉘 chrome 가시성을 첫 페인트 전에 확정

### DIFF
--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -120,10 +120,10 @@ export default function AppLayoutShell({
   // UA 를 다시 점검해 chrome 중복을 방지한다.
   const isNativeApp = useIsNativeApp(isNativeAppFromServer);
 
-  // SSR 가 false 로 내려왔어도 클라이언트 감지가 true 로 바뀌면 <html> 의
-  // data 속성을 동기화해, globals.css 의 sticky 헤더 차단 규칙이 즉시
-  // 적용되도록 한다. RootLayout 은 App Router 에서 재렌더되지 않으므로
-  // 이 effect 가 유일한 갱신 경로다.
+  // 첫 판정은 RootLayout <head> 의 inline script 가 페인트 전에 끝낸다.
+  // 이 effect 는 늦게 도착한 `native:ready` handshake 처럼 그 이후에
+  // 값이 바뀌는 경우만 <html> 속성에 반영한다. RootLayout 은 App Router
+  // 에서 재렌더되지 않으므로 이 effect 가 유일한 갱신 경로다.
   useEffect(() => {
     if (typeof document === 'undefined') {
       return;
@@ -163,14 +163,14 @@ export default function AppLayoutShell({
   }, [isLoggedIn, sidebarData, pathname, router]);
 
   const isLoginPage = matchesRoute(pathname, TOP_NAV_HIDDEN_ROUTES);
-  // TopNav 가시성: 로그인/회원가입 페이지거나 네이티브 앱 쉘이면 완전 제거.
-  // 그 외엔 CSS로 처리.
-  const showTopNav = !isLoginPage && !isNativeApp;
+  // TopNav 가시성: 로그인/회원가입 페이지면 완전 제거. 네이티브 쉘 숨김은
+  // BottomNav 와 같은 이유로 `native-hide` 클래스(CSS) 에 맡긴다.
+  const showTopNav = !isLoginPage;
   // 모든 라우트에서 `lg`(1024px) 기준으로 데스크탑/태블릿 전환을 통일한다.
   // - 데스크탑(≥lg): 글로벌 TopNav 노출
   // - 태블릿/모바일(<lg): 글로벌 TopNav 숨김, BottomNav 노출
   //   (페이지별 자체 sticky 헤더가 있으면 화면 상단을 채운다)
-  const topNavRespClass = 'hidden lg:flex';
+  const topNavRespClass = 'hidden lg:flex native-hide';
 
   const showBackButton = needsBackButton(pathname);
   const isContentRouteForRail = !matchesRoute(
@@ -178,8 +178,13 @@ export default function AppLayoutShell({
     RIGHT_RAIL_HIDDEN_ROUTES
   );
   const showRightRail = isContentRouteForRail;
-  const showBottomNav = isBottomNavVisible(pathname) && !isNativeApp;
-  const bottomNavRespClass = 'lg:hidden';
+  // 바텀 네비는 네이티브에서도 마운트하되 CSS(`native-hide`) 로 가린다.
+  // isNativeApp 으로 언마운트하면 서버 HTML → 하이드레이션 사이에 한 번
+  // 그려졌다 사라져 본문이 위로 튄다. 가시성 판단은 inline script 가
+  // 세팅한 `data-native-app` 이 첫 페인트 전에 끝낸다.
+  // ponytail: 네이티브에서도 훅(라우트 prefetch) 은 그대로 돈다.
+  const showBottomNav = isBottomNavVisible(pathname);
+  const bottomNavRespClass = 'lg:hidden native-hide';
   const activeNavId = resolveActiveNavId(pathname);
 
   // 프로필 아바타 클릭 — pathname 이 변해 AppLayoutShell 이 재렌더돼도

--- a/src/app.module/utils/nativeAppScript.ts
+++ b/src/app.module/utils/nativeAppScript.ts
@@ -1,0 +1,15 @@
+// RootLayout <head> 에 blocking inline script 로 주입되는 판정 코드.
+// 첫 페인트 이전에 <html data-native-app> 을 확정해, 네이티브 쉘에서
+// 웹 chrome(헤더/바텀바)이 한 프레임 보였다 사라지는 레이아웃 시프트를
+// 없앤다. headers() 를 쓰지 않으므로 라우트는 정적 prefetch 가능 상태를
+// 유지한다.
+//
+// 판정 신호는 `useIsNativeApp` 의 detect() 와 동일하다. 한쪽을 바꾸면
+// 다른 쪽도 함께 맞춰야 한다.
+export const NATIVE_APP_INIT_SCRIPT =
+  '(function(){try{var w=window;' +
+  'var n=w.__IS_NATIVE_APP__===true||' +
+  "typeof w.OneDayOneStreakNative!=='undefined'||" +
+  '/1D1S-App/i.test(navigator.userAgent);' +
+  'if(n){w.__IS_NATIVE_APP__=true;' +
+  "document.documentElement.dataset.nativeApp='true';}}catch(e){}})();";

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -111,8 +111,10 @@
   }
 
   /* 네이티브에서 강제 숨김 마커. 헤더 외 임의 요소(인라인 버튼, 푸터,
-     PWA 프롬프트 등) 에 부착해 isNativeApp 분기를 JS 없이도 처리한다. */
-  html[data-native-app='true'] [data-native-hide] {
+     PWA 프롬프트 등) 에 부착해 isNativeApp 분기를 JS 없이도 처리한다.
+     data 속성을 못 받는 컴포넌트(className 만 뚫려 있는 경우) 는
+     `.native-hide` 클래스를 쓴다. */
+  html[data-native-app='true'] :is([data-native-hide], .native-hide) {
     display: none !important;
   }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import {
 } from '@module/metadata/seo';
 import { AppProviders } from '@module/providers';
 import { cn } from '@module/utils/cn';
+import { NATIVE_APP_INIT_SCRIPT } from '@module/utils/nativeAppScript';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata, Viewport } from 'next';
 
@@ -81,22 +82,17 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }): React.ReactElement {
-  // 네이티브 앱 감지는 클라이언트 `useIsNativeApp`(AppLayoutShell) 이
-  // 단독으로 수행한다: window.__IS_NATIVE_APP__ / JS 채널 / navigator.userAgent
-  // (서버와 동일한 `1D1S-App` UA 토큰) 를 읽어 correctness 를 완결한다.
-  //
-  // 과거엔 SSR 에서 headers() 로 UA 를 읽어 `data-native-app` 을 미리 세팅했지만,
-  // headers() 는 Dynamic API 라 루트 레이아웃이 앱 전체 route 를 dynamic 렌더로
-  // 강제했다 → `<Link>` 가 데이터까지 prefetch 하지 못하고 이동마다 RSC 를
-  // 다시 받아오는 "매번 로딩" 의 근본 원인. 이를 제거해 route 를 정적
-  // prefetch 가능 상태로 되돌린다.
-  //
-  // 트레이드오프: `data-native-app` 초기값이 항상 "false" 라, 네이티브 쉘
-  // 사용자는 하드 로드(콜드) 첫 페인트에서 웹 chrome(sticky 헤더 등)을 한
-  // 프레임 볼 수 있다. 하이드레이션 직후 AppLayoutShell 의 useEffect 가
-  // 속성을 다시 세팅해 즉시 사라진다(SPA 이동에는 영향 없음).
+  // 네이티브 앱 감지는 <head> 의 blocking inline script 가 첫 페인트 전에
+  // 확정한다. headers() 를 쓰면 루트 레이아웃이 dynamic 렌더로 강제돼
+  // `<Link>` prefetch 가 죽으므로(= "이동마다 로딩") 서버 UA 판정은 쓰지
+  // 않는다. 스크립트는 정적 HTML 에 그대로 실려 나가므로 route 는 정적
+  // prefetch 가능 상태를 유지하면서도 chrome 가시성은 페인트 시점에 이미
+  // 결정돼 있다. 하이드레이션 이후 토글되는 값이 아니라 시프트가 없다.
   return (
     <html lang="ko" data-native-app="false">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: NATIVE_APP_INIT_SCRIPT }} />
+      </head>
       <body
         className={cn(
           pretendard.variable,


### PR DESCRIPTION
## 문제

하이브리드 앱(Flutter WebView)에서 웹 헤더/바텀바가 **한 프레임 그려졌다 사라지며** 레이아웃 시프트가 발생했습니다.

원인은 네이티브 판정 시점입니다. 서버는 항상 `data-native-app="false"`로 내려가고, `AppLayoutShell`의 `useEffect` / `useSyncExternalStore`가 **하이드레이션 이후**에 true로 뒤집으니, 그 사이에 웹 chrome이 그려졌다 제거됐습니다.

## 해결

가시성을 "로딩 중에 토글되는 값"이 아니라 **첫 페인트 전에 결정된 상태**로 바꿨습니다.

- `RootLayout`의 `<head>`에 blocking inline script를 넣어, `<body>` 파싱 전에 `<html data-native-app>`을 확정합니다. (`next-themes`의 다크모드 FOUC 방지와 동일한 패턴)
- `TopNav` / `BottomNav`를 `isNativeApp`으로 언마운트하지 않고 항상 마운트한 뒤 CSS(`native-hide`)로 가립니다. 언마운트 자체가 시프트의 원인이었습니다.
- 페이지별 sticky 헤더는 이미 `data-native-app` 기반 CSS라, 스크립트만으로 함께 해결됩니다.

## prefetch 유지

`headers()`로 서버 UA 판정을 하는 방법도 있지만, 루트 레이아웃이 Dynamic API를 쓰면 **앱 전체 라우트가 dynamic 렌더**로 떨어집니다. 그러면 `<Link>` 기본 prefetch(`auto`)가 dynamic 라우트에서 `loading.js` 경계까지만 담아오고, `staleTimes.dynamic: 120` 설정도 무의미해집니다(= "매번 로딩"). 인라인 스크립트는 정적 HTML에 그대로 실려 나가므로 라우트는 정적 prefetch 가능 상태를 유지합니다.

## 테스트

- `pnpm lint`, `tsc --noEmit` 통과
- 브라우저 동작 확인은 하지 않았습니다. 네이티브 WebView 콜드 로드에서 헤더/바텀바 플래시가 사라졌는지 확인 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)