### PR TITLE
release: develop → main 프로덕션 승격 (Apple 웹 로그인·최적화·버그픽스)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ NEXT_PUBLIC_KAKAO_JS_KEY=your-kakao-javascript-key
 NEXT_PUBLIC_POSTHOG_KEY=phc_your-posthog-project-key
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
+# Sign in with Apple (웹) — Apple Developer > Certificates, Identifiers & Profiles
+# CLIENT_ID: Services ID(예: com.yourcompany.app.web)
+# REDIRECT_URI: 해당 Services ID 에 등록한 Return URL(https 필수, 정확히 일치)
+# 둘 중 하나라도 미설정 시 Apple 로그인 버튼은 숨겨진다(다른 로그인은 정상).
+NEXT_PUBLIC_APPLE_CLIENT_ID=com.yourcompany.app.web
+NEXT_PUBLIC_APPLE_REDIRECT_URI=https://your-domain.example.com/login
+
 # production example (replace in production env)
 # NEXT_PUBLIC_ODOS_API_URL=https://your-production-api.example.com/
 # NEXT_PUBLIC_ACCESS_TOKEN_COOKIE_NAME=accessToken

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -47,7 +47,6 @@ const config: KnipConfig = {
     'postcss',
     // 디자인 시스템 내부에서 사용되는 보조 라이브러리
     'class-variance-authority',
-    'react-day-picker',
     // 훅/커밋/테스트 체인 (husky, jest 등)
     '@commitlint/cli',
     '@eslint/eslintrc',

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "postcss": "^8.5.16",
     "posthog-js": "^1.399.5",
     "react": "^19.2.4",
-    "react-day-picker": "8.10.1",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.55.0",
     "tailwind-merge": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 1.1.3(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot':
         specifier: ^1.2.0
-        version: 1.2.0(@types/react@19.0.12)(react@19.2.4)
+        version: 1.3.0(@types/react@19.0.12)(react@19.2.4)
       '@radix-ui/react-switch':
         specifier: ^1.2.5
         version: 1.2.5(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -97,7 +97,7 @@ importers:
         version: 2.0.0(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       autoprefixer:
         specifier: ^10.4.21
-        version: 10.4.21(postcss@8.5.16)
+        version: 10.4.21(postcss@8.5.17)
       axios:
         specifier: ^1.18.1
         version: 1.18.1
@@ -133,16 +133,13 @@ importers:
         version: 16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss:
         specifier: ^8.5.16
-        version: 8.5.16
+        version: 8.5.17
       posthog-js:
         specifier: ^1.399.5
         version: 1.399.5
       react:
         specifier: ^19.2.4
         version: 19.2.4
-      react-day-picker:
-        specifier: 8.10.1
-        version: 8.10.1(date-fns@4.1.0)(react@19.2.4)
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
@@ -157,7 +154,7 @@ importers:
         version: 1.2.5
       zod:
         specifier: ^3.24.2
-        version: 3.24.2
+        version: 3.25.76
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.8.0
@@ -4217,10 +4214,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.17:
     resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4994,6 +4987,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -5106,9 +5100,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
-
-  zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -6783,7 +6774,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.8
       '@tailwindcss/oxide': 4.1.8
-      postcss: 8.5.16
+      postcss: 8.5.17
       tailwindcss: 4.1.8
 
   '@tanstack/query-core@5.90.6': {}
@@ -7440,14 +7431,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.21(postcss@8.5.16):
+  autoprefixer@10.4.21(postcss@8.5.17):
     dependencies:
       browserslist: 4.25.0
       caniuse-lite: 1.0.30001707
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.16
+      postcss: 8.5.17
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -8059,7 +8050,7 @@ snapshots:
   eslint-plugin-tailwindcss@4.0.0-beta.0(tailwindcss@4.1.8):
     dependencies:
       fast-glob: 3.3.1
-      postcss: 8.5.16
+      postcss: 8.5.17
       synckit: 0.11.12
       tailwind-api-utils: 1.0.3(tailwindcss@4.1.8)
       tailwindcss: 4.1.8
@@ -8931,7 +8922,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.42
       caniuse-lite: 1.0.30001802
-      postcss: 8.5.16
+      postcss: 8.5.17
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
@@ -9148,12 +9139,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.5.16:
-    dependencies:
-      nanoid: 3.3.15
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.17:
     dependencies:
@@ -10053,8 +10038,6 @@ snapshots:
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod@3.24.2: {}
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3740,8 +3740,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
@@ -3752,8 +3752,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -3764,8 +3764,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
@@ -3776,8 +3776,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -3788,8 +3788,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
@@ -3800,8 +3800,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -3812,8 +3812,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -3824,8 +3824,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -3836,8 +3836,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -3848,8 +3848,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -3860,8 +3860,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
@@ -3870,8 +3870,8 @@ packages:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
 
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -4028,6 +4028,11 @@ packages:
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4216,6 +4221,10 @@ packages:
 
   postcss@8.5.17:
     resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.20:
+    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.399.5:
@@ -5035,8 +5044,8 @@ packages:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
 
-  ws@8.18.2:
-    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8596,7 +8605,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.18.2
+      ws: 8.21.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -8666,67 +8675,67 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightningcss-android-arm64@1.32.0:
+  lightningcss-android-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-arm64@1.30.1:
     optional: true
 
-  lightningcss-darwin-arm64@1.32.0:
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.1:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
+  lightningcss-darwin-x64@1.33.0:
     optional: true
 
   lightningcss-freebsd-x64@1.30.1:
     optional: true
 
-  lightningcss-freebsd-x64@1.32.0:
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
+  lightningcss-linux-arm-gnueabihf@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.30.1:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.32.0:
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.1:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
+  lightningcss-linux-arm64-musl@1.33.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.30.1:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.32.0:
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.1:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
+  lightningcss-linux-x64-musl@1.33.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.30.1:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.32.0:
+  lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.30.1:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.30.1:
@@ -8744,21 +8753,21 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
 
-  lightningcss@1.32.0:
+  lightningcss@1.33.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lilconfig@3.1.3: {}
 
@@ -8911,6 +8920,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.15: {}
+
+  nanoid@3.3.16: {}
 
   napi-postinstall@0.2.4: {}
 
@@ -9143,6 +9154,12 @@ snapshots:
   postcss@8.5.17:
     dependencies:
       nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.20:
+    dependencies:
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9875,9 +9892,9 @@ snapshots:
 
   vite@8.1.4(@types/node@20.17.28)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.20
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -10001,7 +10018,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.0
 
-  ws@8.18.2: {}
+  ws@8.21.1: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/src/app.component/NativeDatePicker.tsx
+++ b/src/app.component/NativeDatePicker.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { DatePicker, type DatePickerProps } from '@1d1s/design-system';
+import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
+import {
+  isNativeDatePickerAvailable,
+  openNativeDatePicker,
+} from '@module/utils/nativeBridge';
+import React from 'react';
+
+// 하루씩 훑어 disabled 목록을 만들 때의 상한. min~max 가 이보다 넓으면
+// 목록을 보내지 않는다 (현재 사용처는 일지 작성의 3일 창뿐).
+const MAX_DISABLED_SCAN_DAYS = 62;
+
+function toLocalDateString(date: Date): string {
+  const y = String(date.getFullYear()).padStart(4, '0');
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function fromLocalDateString(value: string): Date | undefined {
+  const [y, m, d] = value.split('-').map(Number);
+  if (!y || !m || !d) {
+    return undefined;
+  }
+  return new Date(y, m - 1, d);
+}
+
+interface NativeDatePickerProps extends DatePickerProps {
+  /** 네이티브 피커의 선택 하한 (없으면 제한 없음). */
+  nativeMin?: Date;
+  /** 네이티브 피커의 선택 상한 (없으면 제한 없음). */
+  nativeMax?: Date;
+  /**
+   * 개별 비활성 날짜 판정. min/max 가 모두 있고 창이 좁을 때만 하루씩
+   * 평가해 네이티브로 보낸다 — 함수는 브릿지로 직렬화할 수 없다.
+   */
+  nativeIsDisabled?(date: Date): boolean;
+}
+
+/**
+ * DS DatePicker 의 네이티브 위임 래퍼. 웹 캘린더 시트는 WebView 안에 갇혀
+ * 아래가 잘리고 네이티브 헤더도 못 가린다. 네이티브 쉘에서는 트리거 위에
+ * 투명 버튼을 겹쳐 클릭을 가로채고 네이티브 피커를 연다. 브라우저에서는
+ * DS DatePicker 그대로.
+ */
+export function NativeDatePicker({
+  nativeMin,
+  nativeMax,
+  nativeIsDisabled,
+  ...pickerProps
+}: NativeDatePickerProps): React.ReactElement {
+  // useIsNativeApp 는 native:ready 이벤트를 구독하므로, 핸드셰이크가
+  // 세우는 기능 플래그도 이 재렌더 시점에는 읽을 수 있다. 플래그가 없는
+  // 구버전 쉘에서는 오버레이를 그리지 않아 웹 피커가 그대로 동작한다.
+  const delegate = useIsNativeApp(false) && isNativeDatePickerAvailable();
+
+  const handleNativeOpen = async (): Promise<void> => {
+    const disabled: string[] = [];
+    if (nativeMin && nativeMax && nativeIsDisabled) {
+      const cursor = new Date(nativeMin);
+      for (let i = 0; i < MAX_DISABLED_SCAN_DAYS; i += 1) {
+        if (cursor > nativeMax) {
+          break;
+        }
+        if (nativeIsDisabled(cursor)) {
+          disabled.push(toLocalDateString(cursor));
+        }
+        cursor.setDate(cursor.getDate() + 1);
+      }
+    }
+    const picked = await openNativeDatePicker({
+      value: pickerProps.value
+        ? toLocalDateString(pickerProps.value)
+        : undefined,
+      min: nativeMin ? toLocalDateString(nativeMin) : undefined,
+      max: nativeMax ? toLocalDateString(nativeMax) : undefined,
+      disabled: disabled.length > 0 ? disabled : undefined,
+    });
+    if (picked) {
+      const date = fromLocalDateString(picked);
+      if (date) {
+        pickerProps.onChange(date);
+      }
+    }
+  };
+
+  return (
+    <div className="relative">
+      <DatePicker {...pickerProps} />
+      {delegate ? (
+        <button
+          type="button"
+          aria-label="날짜 선택"
+          className="absolute inset-0"
+          onClick={(event) => {
+            event.preventDefault();
+            void handleNativeOpen();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/app.component/cards/DiaryCard.tsx
+++ b/src/app.component/cards/DiaryCard.tsx
@@ -151,6 +151,12 @@ function DiaryCard({
         // 배경과의 구분을 위해 기본(gray-200)보다 한 단계 진한 보더
         'border-gray-300 p-4 transition-all duration-500 ease-out',
         'hover:shadow-warm',
+        // 화면 밖 카드는 레이아웃/페인트를 스킵해 긴 무한스크롤 목록의
+        // 렌더 비용을 줄인다. auto 는 화면에 들어와 한 번 렌더되면 실제
+        // 높이를 기억해 재스크롤 시 점프가 없다(초기 추정 360px). 카드
+        // 자신의 hover:shadow-warm 는 own 박스 데코라 contain:paint 로도
+        // 잘리지 않고, LikeBurst 는 이미 Card 의 overflow-hidden 에 갇힌다.
+        '[content-visibility:auto] [contain-intrinsic-size:auto_360px]',
         href && 'relative',
         className
       )}

--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -120,10 +120,10 @@ export default function AppLayoutShell({
   // UA 를 다시 점검해 chrome 중복을 방지한다.
   const isNativeApp = useIsNativeApp(isNativeAppFromServer);
 
-  // SSR 가 false 로 내려왔어도 클라이언트 감지가 true 로 바뀌면 <html> 의
-  // data 속성을 동기화해, globals.css 의 sticky 헤더 차단 규칙이 즉시
-  // 적용되도록 한다. RootLayout 은 App Router 에서 재렌더되지 않으므로
-  // 이 effect 가 유일한 갱신 경로다.
+  // 첫 판정은 RootLayout <head> 의 inline script 가 페인트 전에 끝낸다.
+  // 이 effect 는 늦게 도착한 `native:ready` handshake 처럼 그 이후에
+  // 값이 바뀌는 경우만 <html> 속성에 반영한다. RootLayout 은 App Router
+  // 에서 재렌더되지 않으므로 이 effect 가 유일한 갱신 경로다.
   useEffect(() => {
     if (typeof document === 'undefined') {
       return;
@@ -163,14 +163,14 @@ export default function AppLayoutShell({
   }, [isLoggedIn, sidebarData, pathname, router]);
 
   const isLoginPage = matchesRoute(pathname, TOP_NAV_HIDDEN_ROUTES);
-  // TopNav 가시성: 로그인/회원가입 페이지거나 네이티브 앱 쉘이면 완전 제거.
-  // 그 외엔 CSS로 처리.
-  const showTopNav = !isLoginPage && !isNativeApp;
+  // TopNav 가시성: 로그인/회원가입 페이지면 완전 제거. 네이티브 쉘 숨김은
+  // BottomNav 와 같은 이유로 `native-hide` 클래스(CSS) 에 맡긴다.
+  const showTopNav = !isLoginPage;
   // 모든 라우트에서 `lg`(1024px) 기준으로 데스크탑/태블릿 전환을 통일한다.
   // - 데스크탑(≥lg): 글로벌 TopNav 노출
   // - 태블릿/모바일(<lg): 글로벌 TopNav 숨김, BottomNav 노출
   //   (페이지별 자체 sticky 헤더가 있으면 화면 상단을 채운다)
-  const topNavRespClass = 'hidden lg:flex';
+  const topNavRespClass = 'hidden lg:flex native-hide';
 
   const showBackButton = needsBackButton(pathname);
   const isContentRouteForRail = !matchesRoute(
@@ -178,8 +178,13 @@ export default function AppLayoutShell({
     RIGHT_RAIL_HIDDEN_ROUTES
   );
   const showRightRail = isContentRouteForRail;
-  const showBottomNav = isBottomNavVisible(pathname) && !isNativeApp;
-  const bottomNavRespClass = 'lg:hidden';
+  // 바텀 네비는 네이티브에서도 마운트하되 CSS(`native-hide`) 로 가린다.
+  // isNativeApp 으로 언마운트하면 서버 HTML → 하이드레이션 사이에 한 번
+  // 그려졌다 사라져 본문이 위로 튄다. 가시성 판단은 inline script 가
+  // 세팅한 `data-native-app` 이 첫 페인트 전에 끝낸다.
+  // ponytail: 네이티브에서도 훅(라우트 prefetch) 은 그대로 돈다.
+  const showBottomNav = isBottomNavVisible(pathname);
+  const bottomNavRespClass = 'lg:hidden native-hide';
   const activeNavId = resolveActiveNavId(pathname);
 
   // 프로필 아바타 클릭 — pathname 이 변해 AppLayoutShell 이 재렌더돼도

--- a/src/app.component/layout/BoardScreenLayout.tsx
+++ b/src/app.component/layout/BoardScreenLayout.tsx
@@ -34,6 +34,8 @@ export function BoardScreenLayout({
       {mobileHeader}
 
       <div
+        // 네이티브 쉘: 웹 헤더가 사라진 자리의 상단 패딩 제거.
+        data-native-flush-top
         className={cn(
           'mx-auto w-full max-w-[1200px]',
           'px-5 py-5 lg:px-8 lg:py-10'

--- a/src/app.component/skeletons/ChallengeDetailSkeleton.tsx
+++ b/src/app.component/skeletons/ChallengeDetailSkeleton.tsx
@@ -45,6 +45,11 @@ export function ChallengeDetailSkeleton(): React.ReactElement {
             type="button"
             aria-label="뒤로가기"
             onClick={() => router.back()}
+            // 실제 페이지(ChallengeDetailScreen)의 floating 백버튼과 같은
+            // 이유로 네이티브에서 숨긴다 — absolute 라 글로벌 sticky 차단
+            // 룰이 못 잡는다. 스켈레톤에만 마커가 빠져 있어서 로딩 동안만
+            // 웹 백버튼이 네이티브 백바 밑에 겹쳐 보였다.
+            data-native-hide
             className={cn(
               'absolute left-3.5 z-10 flex h-9 w-9',
               'top-[calc(0.875rem+env(safe-area-inset-top))]',

--- a/src/app.component/skeletons/MyPageSkeleton.tsx
+++ b/src/app.component/skeletons/MyPageSkeleton.tsx
@@ -25,7 +25,14 @@ export function MyPageSkeleton(): React.ReactElement {
       >
         {/* 모바일 프로필 */}
         <div className="lg:hidden">
-          <div className="flex min-h-8 items-center justify-end gap-1">
+          {/* 실제 페이지(MyPageProfileCard)의 액션 행(벨+설정)은 네이티브
+              에서 data-native-hide 로 숨는다. skeleton 만 그 자리를 그리면
+              로딩 → 실제 전환 때 행 높이만큼 레이아웃이 밀린다 — 같은
+              마커로 skeleton 쪽도 숨긴다. */}
+          <div
+            data-native-hide
+            className="flex min-h-8 items-center justify-end gap-1"
+          >
             <Skeleton shape="rounded" className="h-8 w-8 rounded-lg" />
             <Skeleton shape="rounded" className="h-8 w-8 rounded-lg" />
           </div>

--- a/src/app.feature/auth/api/authApi.ts
+++ b/src/app.feature/auth/api/authApi.ts
@@ -1,6 +1,7 @@
 import { apiClient, publicApiClient } from '@module/api/client';
 import { requestBody } from '@module/api/request';
 import { refreshAccessTokenOnce } from '@module/api/tokenRefresh';
+import { postNativeMessage } from '@module/utils/nativeBridge';
 
 import {
   LogoutResponse,
@@ -17,12 +18,13 @@ export const authApi = {
   socialLogin: async (
     provider: OAuthProvider,
     code: string,
-    state?: string
+    state?: string,
+    nativeCodeChallenge?: string
   ): Promise<SocialLoginResponse> =>
     requestBody<SocialLoginResponse>(publicApiClient, {
       url: `/login/oauth2/code/${provider}`,
       method: 'GET',
-      params: { code, state },
+      params: { code, state, nativeCodeChallenge },
       withCredentials: true,
     }),
 
@@ -51,10 +53,18 @@ export const authApi = {
   refreshToken: async (): Promise<void> => refreshAccessTokenOnce(),
 
   // 로그아웃
-  logout: async (): Promise<LogoutResponse> =>
-    requestBody<LogoutResponse, Record<string, never>>(apiClient, {
-      url: '/auth/logout',
-      method: 'POST',
-      data: {},
-    }),
+  logout: async (): Promise<LogoutResponse> => {
+    try {
+      return await requestBody<LogoutResponse, Record<string, never>>(
+        apiClient,
+        {
+          url: '/auth/logout',
+          method: 'POST',
+          data: {},
+        }
+      );
+    } finally {
+      postNativeMessage({ type: 'logout' });
+    }
+  },
 };

--- a/src/app.feature/auth/api/authApi.ts
+++ b/src/app.feature/auth/api/authApi.ts
@@ -1,7 +1,6 @@
 import { apiClient, publicApiClient } from '@module/api/client';
 import { requestBody } from '@module/api/request';
 import { refreshAccessTokenOnce } from '@module/api/tokenRefresh';
-import { postNativeMessage } from '@module/utils/nativeBridge';
 
 import {
   LogoutResponse,
@@ -53,18 +52,14 @@ export const authApi = {
   refreshToken: async (): Promise<void> => refreshAccessTokenOnce(),
 
   // 로그아웃
-  logout: async (): Promise<LogoutResponse> => {
-    try {
-      return await requestBody<LogoutResponse, Record<string, never>>(
-        apiClient,
-        {
-          url: '/auth/logout',
-          method: 'POST',
-          data: {},
-        }
-      );
-    } finally {
-      postNativeMessage({ type: 'logout' });
-    }
-  },
+  //
+  // 네이티브 쉘 통지는 여기가 아니라 useLogout 의 onSettled 가 한다. 여기서
+  // 알리면 로컬 인증 힌트(localStorage/쿠키/사이드바 캐시)를 지우기 *전*이라,
+  // 통지를 받은 쉘이 리로드한 탭들이 그 힌트를 읽고 로그인 상태로 되돌아간다.
+  logout: async (): Promise<LogoutResponse> =>
+    requestBody<LogoutResponse, Record<string, never>>(apiClient, {
+      url: '/auth/logout',
+      method: 'POST',
+      data: {},
+    }),
 };

--- a/src/app.feature/auth/api/authApi.ts
+++ b/src/app.feature/auth/api/authApi.ts
@@ -3,6 +3,7 @@ import { requestBody } from '@module/api/request';
 import { refreshAccessTokenOnce } from '@module/api/tokenRefresh';
 
 import {
+  AppleLoginRequest,
   LogoutResponse,
   OAuthProvider,
   PresignedUrlRequest,
@@ -24,6 +25,18 @@ export const authApi = {
       url: `/login/oauth2/code/${provider}`,
       method: 'GET',
       params: { code, state, nativeCodeChallenge },
+      withCredentials: true,
+    }),
+
+  // Sign in with Apple (웹) — 클라에서 받은 identityToken 등을 서버로 전달.
+  // 서버가 Set-Cookie(HttpOnly)로 세션을 세우고 SocialLoginResponse 를 돌려준다.
+  appleLogin: async (
+    data: AppleLoginRequest
+  ): Promise<SocialLoginResponse> =>
+    requestBody<SocialLoginResponse, AppleLoginRequest>(publicApiClient, {
+      url: '/auth/apple/login',
+      method: 'POST',
+      data,
       withCredentials: true,
     }),
 

--- a/src/app.feature/auth/components/AppleLoginButton.tsx
+++ b/src/app.feature/auth/components/AppleLoginButton.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Button } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import React, { useEffect } from 'react';
+
+import { useAppleLogin } from '../hooks/useAuthMutations';
+import { getAppleAuthConfig } from '../utils/appleAuth';
+
+// Apple 로고 마크(공식 형태). 버튼 텍스트와 같은 흰색을 따르도록 currentColor.
+function AppleLogo(): React.ReactElement {
+  return (
+    <svg
+      width="16"
+      height="19"
+      viewBox="0 0 842 1000"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M824.7 779.9c-15.1 34.9-33 67-53.7 96.5-28.2 40.2-51.3 68-69.1 83.4-27.6 24.9-57.2 37.6-88.9 38.3-22.7 0-50.1-6.5-82-19.6-32-13.1-61.4-19.6-88.3-19.6-28.2 0-58.4 6.5-90.7 19.6-32.3 13.1-58.4 19.9-78.4 20.6-30.4 1.3-60.7-11.8-90.7-39.3-19.3-16.8-43.4-45.6-72.3-86.4-31-43.6-56.5-94.1-76.5-151.6-21.4-62.1-32.1-122.3-32.1-180.6 0-66.8 14.4-124.4 43.3-172.7 22.7-38.8 52.9-69.4 90.7-91.8 37.8-22.4 78.6-33.8 122.6-34.5 24.1 0 55.7 7.5 95 22.2 39.2 14.8 64.4 22.3 75.4 22.3 8.2 0 36.2-8.8 83.6-26.3 44.8-16.2 82.6-22.9 113.6-20.3 84 6.8 147.1 39.9 189.1 99.6-75.1 45.5-112.3 109.2-111.6 190.9.7 63.6 23.7 116.5 68.9 158.5 20.5 19.5 43.4 34.5 68.9 45.1-5.5 16-11.3 31.3-17.5 46zM630.8 20.3c0 49.8-18.2 96.3-54.5 139.3-43.8 51.2-96.8 80.8-154.3 76.1-1.1-6-1.7-12.3-1.7-18.9 0-47.8 20.8-99 57.7-140.8 18.4-21.2 41.8-38.8 70.2-52.8 28.3-13.8 55.1-21.4 80.3-22.8 1.1 6.9 1.6 13.8 1.6 20.6z" />
+    </svg>
+  );
+}
+
+interface AppleLoginButtonProps {
+  className?: string;
+  size?: 'md' | 'lg';
+}
+
+/**
+ * Sign in with Apple (웹) 버튼. 다른 소셜 버튼과 동일한 DS Button/레이아웃을
+ * 쓰되 애플 가이드(검정 배경, 흰 로고+텍스트)를 따른다.
+ *
+ * env(NEXT_PUBLIC_APPLE_CLIENT_ID / _REDIRECT_URI) 미설정 시 렌더하지 않아
+ * 로그인 화면의 나머지 흐름은 그대로 동작한다(값만 채우면 버튼이 나타난다).
+ */
+export function AppleLoginButton({
+  className,
+  size = 'lg',
+}: AppleLoginButtonProps): React.ReactElement | null {
+  const configured = getAppleAuthConfig() !== null;
+  const { mutate, isPending } = useAppleLogin();
+
+  useEffect(() => {
+    if (!configured && process.env.NODE_ENV !== 'production') {
+      console.warn(
+        '[Apple] NEXT_PUBLIC_APPLE_CLIENT_ID / _REDIRECT_URI 미설정 — ' +
+          'Apple 로그인 버튼을 숨깁니다.'
+      );
+    }
+  }, [configured]);
+
+  if (!configured) {
+    return null;
+  }
+
+  return (
+    <Button
+      size={size}
+      fullWidth
+      disabled={isPending}
+      onClick={() => mutate()}
+      className={cn(
+        'relative border-0 bg-black font-extrabold text-white',
+        'hover:bg-black/90 hover:brightness-100',
+        className
+      )}
+    >
+      <span className="absolute left-5 inline-flex">
+        <AppleLogo />
+      </span>
+      Apple로 계속하기
+    </Button>
+  );
+}

--- a/src/app.feature/auth/components/LoginButtons.tsx
+++ b/src/app.feature/auth/components/LoginButtons.tsx
@@ -3,6 +3,10 @@
 import { Button } from '@1d1s/design-system';
 import { API_BASE_URL } from '@module/api/config';
 import { cn } from '@module/utils/cn';
+import {
+  isNativeBridgeAvailable,
+  postNativeMessage,
+} from '@module/utils/nativeBridge';
 import { RETURN_TO_PARAM, returnToStorage } from '@module/utils/returnTo';
 import Image from 'next/image';
 
@@ -28,6 +32,15 @@ const handleSocialLogin = (provider: OAuthProvider): void => {
     returnToStorage.save(
       new URLSearchParams(window.location.search).get(RETURN_TO_PARAM)
     );
+    if (isNativeBridgeAvailable()) {
+      const startUrl = new URL('/login', window.location.origin);
+      startUrl.searchParams.set('nativeProvider', provider);
+      postNativeMessage({
+        type: 'oauth_open',
+        payload: { url: startUrl.toString() },
+      });
+      return;
+    }
   }
   window.location.href = `${API_BASE_URL}/oauth2/authorization/${provider}`;
 };

--- a/src/app.feature/auth/components/LoginMobileView.tsx
+++ b/src/app.feature/auth/components/LoginMobileView.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import { PROVIDER_META } from '../consts/providerMeta';
 import type { OAuthProvider } from '../type/auth';
+import { AppleLoginButton } from './AppleLoginButton';
 import { LoginButton } from './LoginButtons';
 
 interface LoginMobileViewProps {
@@ -144,6 +145,8 @@ export function LoginMobileView({
               />
             );
           })}
+          {/* env 설정 시에만 렌더(미설정이면 null) */}
+          <AppleLoginButton size="lg" className="h-14 text-[15px]" />
         </div>
 
         <Text

--- a/src/app.feature/auth/hooks/useAuthMutations.ts
+++ b/src/app.feature/auth/hooks/useAuthMutations.ts
@@ -1,14 +1,66 @@
+import { MEMBER_QUERY_KEYS } from '@feature/member/consts/queryKeys';
 import { clearCachedSidebar } from '@feature/member/hooks/useMemberQueries';
 import { authStorage } from '@module/utils/auth';
 import { postNativeMessage } from '@module/utils/nativeBridge';
+import {
+  RETURN_TO_PARAM,
+  sanitizeReturnTo,
+} from '@module/utils/returnTo';
 import {
   useMutation,
   UseMutationResult,
   useQueryClient,
 } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 
 import { authApi } from '../api/authApi';
-import { LogoutResponse } from '../type/auth';
+import { LogoutResponse, SocialLoginResponse } from '../type/auth';
+import { signInWithApple } from '../utils/appleAuth';
+
+// Sign in with Apple (웹) — 팝업으로 토큰 획득 → 서버 로그인 → 세션 확정.
+//
+// 콜백 페이지(OAuth 리다이렉트)의 성공 처리와 동일 패턴: markAuthenticated 로
+// 세션을 확정하고, 로그인 전 null 로 캐시된 사이드바를 무효화한 뒤,
+// profileComplete 여부로 /signup 또는 returnTo(없으면 홈)로 이동한다.
+// (구글 콜백의 NotificationOptInPrompt 는 이번 웹 애플 흐름엔 미포함 — 보고 참조)
+export function useAppleLogin(): UseMutationResult<
+  SocialLoginResponse,
+  Error,
+  void
+> {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const credential = await signInWithApple();
+      return authApi.appleLogin({ ...credential, platform: 'web' });
+    },
+    onSuccess: (res) => {
+      authStorage.markAuthenticated();
+      void queryClient.invalidateQueries({
+        queryKey: MEMBER_QUERY_KEYS.sidebar(),
+      });
+      // 팝업 흐름이라 페이지를 떠나지 않았으므로 returnTo 는 URL 에 그대로 있다.
+      const returnTo = sanitizeReturnTo(
+        new URLSearchParams(window.location.search).get(RETURN_TO_PARAM)
+      );
+      if (res.data.profileComplete === false) {
+        router.replace(
+          returnTo
+            ? `/signup?${RETURN_TO_PARAM}=${encodeURIComponent(returnTo)}`
+            : '/signup'
+        );
+        return;
+      }
+      router.replace(returnTo ?? '/');
+    },
+    onError: (error) => {
+      // 사용자가 팝업을 닫으면(popup_closed_by_user) 여기로 온다 — 조용히 로그.
+      console.error('[Apple] 로그인 실패:', error);
+    },
+  });
+}
 
 // 로그아웃
 export function useLogout(): UseMutationResult<LogoutResponse, Error, void> {

--- a/src/app.feature/auth/hooks/useAuthMutations.ts
+++ b/src/app.feature/auth/hooks/useAuthMutations.ts
@@ -1,5 +1,6 @@
 import { clearCachedSidebar } from '@feature/member/hooks/useMemberQueries';
 import { authStorage } from '@module/utils/auth';
+import { postNativeMessage } from '@module/utils/nativeBridge';
 import {
   useMutation,
   UseMutationResult,
@@ -13,17 +14,21 @@ import { LogoutResponse } from '../type/auth';
 export function useLogout(): UseMutationResult<LogoutResponse, Error, void> {
   const queryClient = useQueryClient();
 
+  const clearLocalSession = (): void => {
+    authStorage.clearTokens();
+    clearCachedSidebar();
+    queryClient.clear();
+  };
+
   return useMutation({
     mutationFn: () => authApi.logout(),
-    onSuccess: () => {
-      authStorage.clearTokens();
-      clearCachedSidebar();
-      queryClient.clear();
-    },
-    onError: () => {
-      authStorage.clearTokens();
-      clearCachedSidebar();
-      queryClient.clear();
-    },
+    onSuccess: clearLocalSession,
+    onError: clearLocalSession,
+    // 네이티브 쉘에는 로컬 정리가 끝난 뒤에 알린다. 쉘은 이 신호를 받으면
+    // 살아 있는 탭들을 리로드하는데, localStorage 의 로그인 힌트와 사이드바
+    // 캐시는 origin 단위로 공유되므로 아직 남아 있으면 새로 뜬 문서가 그걸
+    // 읽고 로그인 상태로 되돌아간다 (프로필 사진이 그대로 보이고, 로그아웃을
+    // 두 번 눌러야 했다). onSettled 는 onSuccess/onError 뒤에 돈다.
+    onSettled: () => postNativeMessage({ type: 'logout' }),
   });
 }

--- a/src/app.feature/auth/hooks/useAuthMutations.ts
+++ b/src/app.feature/auth/hooks/useAuthMutations.ts
@@ -1,7 +1,7 @@
 import { MEMBER_QUERY_KEYS } from '@feature/member/consts/queryKeys';
 import { clearCachedSidebar } from '@feature/member/hooks/useMemberQueries';
 import { authStorage } from '@module/utils/auth';
-import { postNativeMessage } from '@module/utils/nativeBridge';
+import { peekNativeOAuth, postNativeMessage } from '@module/utils/nativeBridge';
 import {
   RETURN_TO_PARAM,
   sanitizeReturnTo,
@@ -34,7 +34,11 @@ export function useAppleLogin(): UseMutationResult<
   return useMutation({
     mutationFn: async () => {
       const credential = await signInWithApple();
-      return authApi.appleLogin({ ...credential, platform: 'web' });
+      // 네이티브 쉘에서 시작된 경우에만 challenge 가 실린다(구글 흐름과 동일).
+      return authApi.appleLogin({
+        ...credential,
+        nativeCodeChallenge: peekNativeOAuth() ?? undefined,
+      });
     },
     onSuccess: (res) => {
       authStorage.markAuthenticated();

--- a/src/app.feature/auth/hooks/useAuthQueries.ts
+++ b/src/app.feature/auth/hooks/useAuthQueries.ts
@@ -1,3 +1,4 @@
+import { peekNativeOAuth } from '@module/utils/nativeBridge';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
 import { authApi } from '../api/authApi';
@@ -12,7 +13,13 @@ export function useSocialLogin(
 ): UseQueryResult<SocialLoginResponse, Error> {
   return useQuery({
     queryKey: AUTH_QUERY_KEYS.socialLogin(provider, code, state),
-    queryFn: () => authApi.socialLogin(provider, code!, state ?? undefined),
+    queryFn: () =>
+      authApi.socialLogin(
+        provider,
+        code!,
+        state ?? undefined,
+        peekNativeOAuth() ?? undefined
+      ),
     enabled: Boolean(provider) && Boolean(code),
     retry: false,
     staleTime: Infinity,

--- a/src/app.feature/auth/screen/LoginScreen.tsx
+++ b/src/app.feature/auth/screen/LoginScreen.tsx
@@ -2,7 +2,9 @@
 
 import { Text } from '@1d1s/design-system';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
+import { API_BASE_URL } from '@module/api/config';
 import { cn } from '@module/utils/cn';
+import { markNativeOAuth } from '@module/utils/nativeBridge';
 import { RETURN_TO_PARAM, sanitizeReturnTo } from '@module/utils/returnTo';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -30,6 +32,19 @@ export function LoginScreen(): React.ReactElement {
   );
 
   React.useEffect(() => {
+    const nativeProvider = new URLSearchParams(window.location.search).get(
+      'nativeProvider'
+    );
+    const codeChallenge = new URLSearchParams(window.location.search).get(
+      'pkceChallenge'
+    );
+    if (nativeProvider === 'naver' && codeChallenge) {
+      markNativeOAuth(codeChallenge);
+      window.location.replace(
+        `${API_BASE_URL}/oauth2/authorization/${nativeProvider}`
+      );
+      return;
+    }
     setRecommended(getLastOAuthProvider());
     setStreakDay(getLaunchStreakDay());
   }, []);

--- a/src/app.feature/auth/screen/LoginScreen.tsx
+++ b/src/app.feature/auth/screen/LoginScreen.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
+import { AppleLoginButton } from '../components/AppleLoginButton';
 import { BrandPanel } from '../components/BrandPanel';
 import { getLastOAuthProvider, LoginButton } from '../components/LoginButtons';
 import { LoginMobileView } from '../components/LoginMobileView';
@@ -154,6 +155,8 @@ export function LoginScreen(): React.ReactElement {
                   />
                 );
               })}
+              {/* env 설정 시에만 렌더(미설정이면 null) */}
+              <AppleLoginButton size="lg" className="h-13 text-[15px]" />
             </div>
 
             <Text

--- a/src/app.feature/auth/type/auth.ts
+++ b/src/app.feature/auth/type/auth.ts
@@ -22,6 +22,17 @@ export interface SocialLoginResponse {
   };
 }
 
+// Sign in with Apple (웹) 요청 body.
+// name/email 은 애플이 "최초 인가" 때만 내려주므로 optional. platform 은 서버가
+// 웹/네이티브 발급 경로를 구분하도록 항상 'web' 을 보낸다.
+export interface AppleLoginRequest {
+  identityToken: string;
+  authorizationCode: string;
+  name?: string;
+  email?: string;
+  platform: 'web';
+}
+
 export interface SignUpInfoRequest {
   nickname: string;
   phoneNumber: string;

--- a/src/app.feature/auth/type/auth.ts
+++ b/src/app.feature/auth/type/auth.ts
@@ -17,6 +17,8 @@ export interface SocialLoginResponse {
   message: string;
   data: {
     profileComplete: boolean;
+    nativeLoginCode?: string;
+    nativeLoginCodeExpiresInSeconds?: number;
   };
 }
 

--- a/src/app.feature/auth/type/auth.ts
+++ b/src/app.feature/auth/type/auth.ts
@@ -22,15 +22,17 @@ export interface SocialLoginResponse {
   };
 }
 
-// Sign in with Apple (웹) 요청 body.
-// name/email 은 애플이 "최초 인가" 때만 내려주므로 optional. platform 은 서버가
-// 웹/네이티브 발급 경로를 구분하도록 항상 'web' 을 보낸다.
+// Sign in with Apple (웹) 요청 body. (서버 확정 계약)
+// - identityToken 만 필수. name/email 은 애플 "최초 인가" 때만 오므로 optional.
+// - 응답은 구글 웹 로그인과 동일하게 Set-Cookie(accessToken/refreshToken)로
+//   세션을 세우고 { data: { profileComplete } } 를 돌려준다(별도 토큰 저장 안 함).
+// - nativeCodeChallenge 는 네이티브 쉘에서 시작된 경우에만 실린다(구글과 동일).
 export interface AppleLoginRequest {
   identityToken: string;
-  authorizationCode: string;
+  authorizationCode?: string;
   name?: string;
   email?: string;
-  platform: 'web';
+  nativeCodeChallenge?: string;
 }
 
 export interface SignUpInfoRequest {

--- a/src/app.feature/auth/utils/appleAuth.ts
+++ b/src/app.feature/auth/utils/appleAuth.ts
@@ -1,0 +1,126 @@
+// Sign in with Apple (웹) — Apple JS(AppleID.auth) 팝업 흐름.
+//
+// 구글 등 기존 소셜 로그인은 서버 리다이렉트 OAuth2(`/oauth2/authorization/*`)
+// 지만, 애플은 요청 계약(클라에서 identityToken 획득 → POST /auth/apple/login)
+// 에 맞춰 Apple JS 팝업으로 토큰을 받아 서버로 보낸다. usePopup:true 라
+// 리다이렉트/콜백 라우트 없이 signIn() 이 토큰을 직접 돌려준다.
+
+// Apple JS SDK(전역 window.AppleID). 필요한 부분만 좁게 타입핑한다.
+interface AppleSignInResponse {
+  authorization: { code: string; id_token: string; state?: string };
+  // name/email 은 사용자의 "최초 인가" 때만 내려온다. 이후 로그인엔 없다.
+  user?: {
+    name?: { firstName?: string; lastName?: string };
+    email?: string;
+  };
+}
+
+interface AppleIDAuth {
+  init(config: {
+    clientId: string;
+    scope: string;
+    redirectURI: string;
+    state?: string;
+    usePopup: boolean;
+  }): void;
+  signIn(): Promise<AppleSignInResponse>;
+}
+
+declare global {
+  interface Window {
+    AppleID?: { auth: AppleIDAuth };
+  }
+}
+
+const APPLE_SDK_URL =
+  'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/ko_KR/appleid.auth.js';
+
+export interface AppleAuthConfig {
+  clientId: string;
+  redirectUri: string;
+}
+
+/**
+ * env 로부터 애플 설정을 읽는다. Services ID(client_id)와 Return URL 이 모두
+ * 있어야 유효하며, 하나라도 없으면 null 을 돌려 버튼을 숨기는 근거로 쓴다.
+ */
+export function getAppleAuthConfig(): AppleAuthConfig | null {
+  const clientId = process.env.NEXT_PUBLIC_APPLE_CLIENT_ID;
+  const redirectUri = process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI;
+  if (!clientId || !redirectUri) {
+    return null;
+  }
+  return { clientId, redirectUri };
+}
+
+// SDK 는 애플 버튼을 처음 누를 때만 지연 로드한다(모든 페이지 로드 비용 회피).
+let sdkPromise: Promise<void> | null = null;
+
+function loadAppleSdk(): Promise<void> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('Apple SDK: window 없음'));
+  }
+  if (window.AppleID) {
+    return Promise.resolve();
+  }
+  if (sdkPromise) {
+    return sdkPromise;
+  }
+  sdkPromise = new Promise<void>((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = APPLE_SDK_URL;
+    script.async = true;
+    script.onload = (): void => resolve();
+    script.onerror = (): void => {
+      sdkPromise = null; // 실패 시 다음 클릭에서 재시도 가능하게 캐시 해제
+      reject(new Error('Apple SDK 로드 실패'));
+    };
+    document.head.appendChild(script);
+  });
+  return sdkPromise;
+}
+
+export interface AppleCredential {
+  identityToken: string;
+  authorizationCode: string;
+  name?: string;
+  email?: string;
+}
+
+/**
+ * 애플 팝업 로그인. SDK 로드 → init → signIn 팝업 → 토큰/최초 name·email 반환.
+ * env 미설정이면 호출 전에 걸러야 한다(getAppleAuthConfig).
+ */
+export async function signInWithApple(): Promise<AppleCredential> {
+  const config = getAppleAuthConfig();
+  if (!config) {
+    throw new Error('Apple 로그인 env(NEXT_PUBLIC_APPLE_*) 미설정');
+  }
+  await loadAppleSdk();
+  if (!window.AppleID) {
+    throw new Error('Apple SDK 사용 불가');
+  }
+
+  window.AppleID.auth.init({
+    clientId: config.clientId,
+    scope: 'name email',
+    redirectURI: config.redirectUri,
+    usePopup: true,
+  });
+
+  const res = await window.AppleID.auth.signIn();
+  const fullName = res.user?.name
+    ? [res.user.name.firstName, res.user.name.lastName]
+        .filter(Boolean)
+        .join(' ')
+        .trim()
+    : '';
+
+  return {
+    identityToken: res.authorization.id_token,
+    authorizationCode: res.authorization.code,
+    // 최초 로그인에만 존재. 이후엔 undefined 로 보내고 서버가 기존 값을 쓴다.
+    name: fullName || undefined,
+    email: res.user?.email || undefined,
+  };
+}

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -150,6 +150,35 @@ export default function ChallengeBoardScreen(): React.ReactElement {
     return () => window.removeEventListener('native:board_search', listener);
   }, [scrollListToTop]);
 
+  // 네이티브 툴바의 필터 선택. 검색과 같은 방식 — 카테고리/종류/상태를
+  // 한 번에 받아 로컬 상태에 반영한다.
+  useEffect(() => {
+    const listener = (event: Event): void => {
+      const detail = (
+        event as CustomEvent<{
+          category?: ChallengeCategory;
+          challengeType?: ChallengeTypeFilter | 'ALL';
+          statuses?: ChallengeStatus[];
+        }>
+      ).detail;
+      if (!detail) {
+        return;
+      }
+      if (detail.category) {
+        setCategory(detail.category);
+      }
+      if (detail.challengeType) {
+        setChallengeType(detail.challengeType);
+      }
+      if (Array.isArray(detail.statuses)) {
+        setStatuses(detail.statuses);
+      }
+      scrollListToTop();
+    };
+    window.addEventListener('native:board_filter', listener);
+    return () => window.removeEventListener('native:board_filter', listener);
+  }, [scrollListToTop]);
+
   const handleCategoryChange = useCallback(
     (value: ChallengeCategory): void => {
       setCategory(value);
@@ -230,11 +259,9 @@ export default function ChallengeBoardScreen(): React.ReactElement {
         //
         // 그래서 래퍼는 살리고(data-native-keep), 실제로 중복인 타이틀 행만
         // 가린다. 새 챌린지 버튼은 이미 자체 data-native-hide 가 있다.
+        // 네이티브 쉘은 검색과 필터를 전부 네이티브 툴바로 그린다 — 이
+        // 래퍼는 글로벌 sticky 차단 룰이 통째로 숨긴다 (keep 마커 없음).
         <div
-          data-native-keep
-          // 네이티브 검색 바(58px)가 body 위에 오버레이로 얹힌다 — 이
-          // 래퍼(필터)를 그 아래로 내리고 sticky 오프셋도 같이 민다.
-          data-native-search-offset
           className={cn(
             'sticky top-0 z-20 border-b border-gray-100',
             'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
@@ -363,7 +390,7 @@ export default function ChallengeBoardScreen(): React.ReactElement {
         />
       </div>
 
-      <div className="native-flush-top mt-4 lg:mt-6">
+      <div data-native-toolbar-offset className="mt-4 lg:mt-6">
         {isLoading && challenges.length === 0 ? (
           <ChallengeCardSkeletonGrid count={8} className="gap-4" />
         ) : challenges.length > 0 ? (

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -206,18 +206,29 @@ export default function ChallengeBoardScreen(): React.ReactElement {
         </Button>
       }
       mobileHeader={
-        // 모바일 sticky 헤더 — 타이틀 + 새 챌린지 + 검색바.
-        // 네이티브 쉘에서는 AppTopNav + sliver AppBar 가 동일 영역을
-        // 책임지고, FAB 가 "챌린지 추가" 액션을 제공하므로 이 헤더는
-        // 글로벌 sticky 차단 룰로 함께 가린다 (data-native-keep 제거).
+        // 모바일 sticky 헤더 — 타이틀 + 새 챌린지 + 검색바 + 필터.
+        //
+        // 네이티브 쉘이 대체하는 건 **타이틀과 새 챌린지 버튼뿐**이다
+        // (AppBoardHeader + FAB). 검색 입력과 ChallengeBoardFilters 는
+        // 네이티브에 대응물이 없다. 예전엔 data-native-keep 을 빼서 글로벌
+        // sticky 차단 룰이 이 래퍼를 통째로 가렸는데, 그러면 같은 래퍼 안에
+        // 있는 검색과 카테고리/종류/상태 필터까지 전부 사라진다 — 앱에서만
+        // 챌린지를 검색하거나 거를 수 없었다.
+        //
+        // 그래서 래퍼는 살리고(data-native-keep), 실제로 중복인 타이틀 행만
+        // 가린다. 새 챌린지 버튼은 이미 자체 data-native-hide 가 있다.
         <div
+          data-native-keep
           className={cn(
             'sticky top-0 z-20 border-b border-gray-100',
             'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
             'backdrop-blur lg:hidden'
           )}
         >
-          <div className="mb-3 flex items-center justify-between">
+          <div
+            data-native-hide
+            className="mb-3 flex items-center justify-between"
+          >
             <Text
               as="h1"
               size="heading1"

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -19,7 +19,7 @@ import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
 import { cn } from '@module/utils/cn';
 import { X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect,useMemo, useState } from 'react';
 
 import { ChallengeBoardFilters } from '../components/ChallengeBoardFilters';
 import { toCategoryParam } from '../consts/categoryFilters';
@@ -45,10 +45,7 @@ interface ChallengeBoardCardItemProps {
 // 카드 매핑에서 인라인 람다·파생 계산을 제거해 React.memo(ChallengeCard) 가
 // 실제로 재렌더를 건너뛸 수 있도록 한다.
 const ChallengeBoardCardItem = React.memo(
-  ({
-    challenge,
-    href,
-  }: ChallengeBoardCardItemProps): React.ReactElement => {
+  ({ challenge, href }: ChallengeBoardCardItemProps): React.ReactElement => {
     const isInfinite = isInfiniteChallengeEndDate(challenge.endDate);
     const ended = isChallengeEndedOrArchived(
       challenge.endDate,
@@ -135,6 +132,22 @@ export default function ChallengeBoardScreen(): React.ReactElement {
     setInputValue('');
     setQuery('');
     scrollListToTop();
+  }, [scrollListToTop]);
+
+  // 네이티브 쉘의 검색 다이얼로그. 검색 상태가 로컬 useState 뿐이라 URL
+  // 파라미터로는 전달할 수 없어 bridge 이벤트로 직접 꽂는다. 웹 검색
+  // 필드는 네이티브에서 숨겨지고(data-native-hide) 이 이벤트가 유일한
+  // 검색 입력 경로가 된다.
+  useEffect(() => {
+    const listener = (event: Event): void => {
+      const detail = (event as CustomEvent<{ keyword?: string }>).detail;
+      const keyword = detail?.keyword ?? '';
+      setInputValue(keyword);
+      setQuery(keyword);
+      scrollListToTop();
+    };
+    window.addEventListener('native:board_search', listener);
+    return () => window.removeEventListener('native:board_search', listener);
   }, [scrollListToTop]);
 
   const handleCategoryChange = useCallback(
@@ -251,30 +264,34 @@ export default function ChallengeBoardScreen(): React.ReactElement {
               <Icon name="Plus" size={12} />새 챌린지
             </button>
           </div>
-          <TextField
-            className="w-full"
-            placeholder="챌린지 검색"
-            value={inputValue}
-            iconLeft={<Icon name="Search" size={15} />}
-            iconRight={
-              inputValue ? (
-                <button
-                  type="button"
-                  aria-label="검색어 지우기"
-                  onClick={handleClear}
-                  className="text-gray-400 hover:text-gray-600"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              ) : undefined
-            }
-            onChange={(event) => setInputValue(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                handleSearch();
+          {/* 네이티브에서는 헤더의 검색 버튼(다이얼로그)이 이 필드를
+              대신한다 — native:board_search 이벤트로 같은 상태에 꽂힌다. */}
+          <div data-native-hide>
+            <TextField
+              className="w-full"
+              placeholder="챌린지 검색"
+              value={inputValue}
+              iconLeft={<Icon name="Search" size={15} />}
+              iconRight={
+                inputValue ? (
+                  <button
+                    type="button"
+                    aria-label="검색어 지우기"
+                    onClick={handleClear}
+                    className="text-gray-400 hover:text-gray-600"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                ) : undefined
               }
-            }}
-          />
+              onChange={(event) => setInputValue(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  handleSearch();
+                }
+              }}
+            />
+          </div>
           <ChallengeBoardFilters
             category={category}
             onCategoryChange={handleCategoryChange}

--- a/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
+++ b/src/app.feature/challenge/board/screen/ChallengeBoardScreen.tsx
@@ -232,6 +232,9 @@ export default function ChallengeBoardScreen(): React.ReactElement {
         // 가린다. 새 챌린지 버튼은 이미 자체 data-native-hide 가 있다.
         <div
           data-native-keep
+          // 네이티브 검색 바(58px)가 body 위에 오버레이로 얹힌다 — 이
+          // 래퍼(필터)를 그 아래로 내리고 sticky 오프셋도 같이 민다.
+          data-native-search-offset
           className={cn(
             'sticky top-0 z-20 border-b border-gray-100',
             'bg-white/95 px-5 pt-[calc(0.875rem+env(safe-area-inset-top))] pb-3',
@@ -310,7 +313,7 @@ export default function ChallengeBoardScreen(): React.ReactElement {
         description={loginDialogDescription}
       />
 
-      <div className="mt-2 flex flex-col gap-4 lg:mt-6">
+      <div className="native-flush-top mt-2 flex flex-col gap-4 lg:mt-6">
         {/* 데스크탑 검색바 — 모바일은 sticky 헤더에 있음 */}
         <div className="hidden w-full max-w-[480px] gap-2 lg:flex">
           <div className="w-full">
@@ -360,7 +363,7 @@ export default function ChallengeBoardScreen(): React.ReactElement {
         />
       </div>
 
-      <div className="mt-4 lg:mt-6">
+      <div className="native-flush-top mt-4 lg:mt-6">
         {isLoading && challenges.length === 0 ? (
           <ChallengeCardSkeletonGrid count={8} className="gap-4" />
         ) : challenges.length > 0 ? (

--- a/src/app.feature/challenge/detail/components/ChallengeDiaryList.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDiaryList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Tag, Text } from '@1d1s/design-system';
+import { Button, Tag, Text } from '@1d1s/design-system';
 import DiaryCard from '@component/cards/DiaryCard';
 import EmptyState from '@component/EmptyState';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
@@ -12,8 +12,8 @@ import {
   useUnlikeDiary,
 } from '@feature/diary/detail/hooks/useDiaryMutations';
 import { mapFeelingToEmotion } from '@feature/diary/shared/utils/feeling';
-import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { normalizeApiError } from '@module/api/error';
+import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
 import { cn } from '@module/utils/cn';
 import { formatMonthDayKR } from '@module/utils/date';
@@ -21,8 +21,10 @@ import {
   resolveDiaryImageList,
   resolveDiaryImageUrl,
 } from '@module/utils/diaryImageUrl';
+import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { useChallengeDiaryListInfinite } from '../hooks/useChallengeDiaryQueries';
@@ -106,7 +108,10 @@ export function ChallengeDiaryList({
   const activeDate =
     date && /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined;
   const filterLabel = activeDate ? formatMonthDayKR(activeDate) : '';
-  const isLoggedIn = useIsLoggedIn();
+  const router = useRouter();
+  // 'unknown'(세션 확인 중)에는 게스트 UI 를 그리지 않아 깜빡임을 막는다.
+  const authStatus = useAuthStatus();
+  const isLoggedIn = authStatus === 'authenticated';
   const [showLoginDialog, setShowLoginDialog] = useState(false);
   const likeDiary = useLikeDiary();
   const unlikeDiary = useUnlikeDiary();
@@ -121,9 +126,12 @@ export function ChallengeDiaryList({
   } = useChallengeDiaryListInfinite(
     challengeId,
     CHALLENGE_DIARY_PAGE_SIZE,
-    activeDate
+    activeDate,
+    isLoggedIn
   );
-  const showSkeleton = useMinimumLoading(isLoading);
+  const showSkeleton = useMinimumLoading(
+    isLoading || authStatus === 'unknown'
+  );
   const { ref } = useInfiniteScroll({
     hasNextPage: hasNextPage ?? false,
     isFetchingNextPage,
@@ -162,6 +170,28 @@ export function ChallengeDiaryList({
     },
     [isLoggedIn, isLikePending, likeDiary, unlikeDiary]
   );
+
+  const handleGoLogin = useCallback((): void => {
+    router.push(loginUrlFromCurrentLocation());
+  }, [router]);
+
+  // 일지 목록은 서버가 인증을 요구한다. 게스트는 요청을 보내지 않고
+  // 탭 안에서 로그인 CTA 를 보여준다 (401 → 강제 리다이렉트 방지).
+  if (authStatus === 'guest') {
+    return (
+      <EmptyState
+        variant="diary"
+        title="로그인이 필요해요"
+        description="챌린지 일지는 로그인 후 확인할 수 있어요"
+        action={
+          <Button variant="primary" onClick={handleGoLogin}>
+            로그인 하러가기
+          </Button>
+        }
+        className="mt-10"
+      />
+    );
+  }
 
   return (
     <>

--- a/src/app.feature/challenge/detail/hooks/useChallengeDiaryQueries.ts
+++ b/src/app.feature/challenge/detail/hooks/useChallengeDiaryQueries.ts
@@ -15,10 +15,12 @@ import { ChallengeStatistics } from '../type/challengeStatistics';
 const CHALLENGE_STATISTICS_STALE_TIME = 5 * 60 * 1000;
 
 // 챌린지 일지 목록 조회 (무한 스크롤). date 지정 시 그 날짜 일지만.
+// 서버가 인증을 요구하므로 비로그인 상태에서는 enabled=false 로 막는다.
 export function useChallengeDiaryListInfinite(
   challengeId: number,
   size?: number,
-  date?: string
+  date?: string,
+  enabled = true
 ): UseInfiniteQueryResult<InfiniteData<ChallengeDiaryListResponse>, Error> {
   return useInfiniteQuery({
     queryKey: CHALLENGE_QUERY_KEYS.diariesInfinite(challengeId, { size, date }),
@@ -31,7 +33,7 @@ export function useChallengeDiaryListInfinite(
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>
       lastPage.pageInfo.hasNextPage ? lastPage.pageInfo.page + 1 : undefined,
-    enabled: Boolean(challengeId),
+    enabled: Boolean(challengeId) && enabled,
   });
 }
 

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -739,8 +739,11 @@ export function ChallengeDetailScreen({
           >
             {/* 메인 콘텐츠: 탭(소개 / 일지 / 참여자) */}
             <div className="flex min-w-0 flex-col">
-              {/* 모바일에선 compact 헤더(h-14) 아래에 sticky 로 붙인다. */}
+              {/* 모바일에선 compact 헤더(h-14) 아래에 sticky 로 붙인다.
+                  네이티브 앱은 그 헤더를 숨기므로(data-native-hide) top-14
+                  가 허공을 가리킨다 — data-native-top-0 이 top:0 으로 보정. */}
               <div
+                data-native-top-0
                 className={cn(
                   'sticky top-14 z-20 bg-white',
                   'lg:static lg:top-auto lg:z-auto'

--- a/src/app.feature/challenge/write/components/ChallengeCreatePeriodSection.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeCreatePeriodSection.tsx
@@ -1,5 +1,4 @@
 import {
-  DatePicker,
   Icon,
   SegmentedControl,
   Text,
@@ -7,6 +6,7 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from '@1d1s/design-system';
+import { NativeDatePicker } from '@component/NativeDatePicker';
 import { cn } from '@module/utils/cn';
 import { formatDateKR } from '@module/utils/date';
 import { add, startOfToday } from 'date-fns';
@@ -99,11 +99,12 @@ export function ChallengeCreatePeriodSection(): React.ReactElement {
             render={({ field }) => (
               <FormItem>
                 <FormControl>
-                  <DatePicker
+                  <NativeDatePicker
                     value={field.value}
                     onChange={field.onChange}
                     placeholder="YYYY/MM/DD"
                     calendarProps={{ disabled: { before: startOfToday() } }}
+                    nativeMin={startOfToday()}
                   />
                 </FormControl>
                 <FormMessage />

--- a/src/app.feature/diary/board/screen/DiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/DiaryListScreen.tsx
@@ -261,11 +261,11 @@ export default function DiaryListScreen(): React.ReactElement {
       />
 
       {showSkeleton ? (
-        <DiaryCardSkeletonGrid count={12} className="data-fade-in mt-6" />
+        <DiaryCardSkeletonGrid count={12} className="data-fade-in native-flush-top mt-6" />
       ) : null}
 
       {isError && !hasLoadedDiaries ? (
-        <div className="mt-10 flex w-full justify-center py-10">
+        <div className="native-flush-top mt-10 flex w-full justify-center py-10">
           <Text size="body1" weight="medium" className="text-red-600">
             {error
               ? normalizeApiError(error).message
@@ -275,7 +275,7 @@ export default function DiaryListScreen(): React.ReactElement {
       ) : null}
 
       {!showSkeleton && hasLoadedDiaries ? (
-        <MasonryColumns className="data-fade-in mt-6">
+        <MasonryColumns className="data-fade-in native-flush-top mt-6">
           {sortedDiaries.map((item) => (
             <DiaryListItem
               key={item.id}
@@ -293,7 +293,7 @@ export default function DiaryListScreen(): React.ReactElement {
           variant="diary"
           title="아직 등록된 일지가 없어요"
           description="첫 일지를 남기고 스트릭을 시작해 보세요"
-          className="mt-10"
+          className="native-flush-top mt-10"
         />
       ) : null}
 

--- a/src/app.feature/diary/board/screen/DiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/DiaryListScreen.tsx
@@ -96,8 +96,9 @@ const DiaryListItem = React.memo(
     const diaryInfo = getDiaryInfo(item);
     const authorInfo = getDiaryAuthorInfo(item);
 
-    // 수동 useCallback 은 React Compiler 의 자동 메모이제이션과 충돌해
-    // (preserve-manual-memoization) 제거 — 컴파일러가 참조를 안정화한다.
+    // 얇은 어댑터 — 안정적인 onLikeToggle 에 item 을 바인딩만 한다.
+    // 이 컴포넌트는 React.memo 라 item/props 가 바뀔 때만 재렌더되므로,
+    // 매 렌더 새 함수가 생겨도 DiaryCard 메모를 유의미하게 깨뜨리지 않는다.
     const handleLike = (): void => {
       onLikeToggle(item);
     };

--- a/src/app.feature/diary/detail/components/DiaryImageGallery.tsx
+++ b/src/app.feature/diary/detail/components/DiaryImageGallery.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@module/utils/cn';
+import { openNativeImageViewer } from '@module/utils/nativeBridge';
 import { ChevronLeft, ChevronRight, X } from 'lucide-react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -80,7 +81,14 @@ export function DiaryImageGallery({
             key={`${url}-${index}`}
             type="button"
             aria-label={`이미지 ${index + 1} 크게 보기`}
-            onClick={() => setOpenIndex(index)}
+            // 네이티브 쉘에서는 Flutter 가 전체 화면 뷰어를 그린다. 웹
+            // 오버레이는 WebView 안에 갇혀 네이티브 헤더를 덮지 못한다.
+            // openNativeImageViewer 가 false 면(브라우저) 웹 라이트박스.
+            onClick={() => {
+              if (!openNativeImageViewer(imageUrls, index)) {
+                setOpenIndex(index);
+              }
+            }}
             className={cn(
               'aspect-square w-[200px] max-w-full cursor-zoom-in',
               'overflow-hidden rounded-xl border border-gray-200 bg-gray-100'

--- a/src/app.feature/diary/detail/utils/diaryViewData.test.ts
+++ b/src/app.feature/diary/detail/utils/diaryViewData.test.ts
@@ -188,4 +188,44 @@ describe('mapDiaryToViewData', () => {
     // 공식 챌린지 배지가 challengeType 을 읽어 0명이어도 종료로 보지 않게 한다.
     expect(view.connectedChallengeSummary?.challengeType).toBe('OFFICIAL');
   });
+
+  it('타인 일지: 열람자 챌린지 목표 id/문구가 달라도 작성자 diaryGoal 로 달성 표시', () => {
+    // 작성자(참여자)의 goal id 는 열람자와 다르다(challenge_goal 은 참여자별
+    // 복제). 두 목표 모두 달성한 일지.
+    const diary = {
+      id: 11,
+      challenge: { challengeId: 5, title: '공식 챌린지' },
+      author: { id: 2, nickname: '작성자', profileImage: null },
+      title: '일지',
+      content: '<p>내용</p>',
+      imgUrl: null,
+      thumbnailUrl: null,
+      likeInfo: { likedByMe: false, likeCnt: 0 },
+      diaryInfo: {
+        feeling: 'HAPPY',
+        achievementRate: 100,
+        diaryGoal: [
+          { challengeGoalId: 901, challengeGoalName: '물 마시기', isAchieved: true },
+          { challengeGoalId: 902, challengeGoalName: '운동하기', isAchieved: true },
+        ],
+      },
+    } as unknown as DiaryDetail;
+    // 열람자 시점의 챌린지 목표 — id 도 문구도 작성자와 다르다.
+    const challengeDetailData = {
+      challengeGoals: [
+        { challengeGoalId: 1, content: '열람자 목표 A' },
+        { challengeGoalId: 2, content: '열람자 목표 B' },
+      ],
+    } as unknown as ChallengeDetailResponse;
+
+    const view = mapDiaryToViewData(diary, challengeDetailData);
+
+    // 체크리스트는 작성자의 diaryGoal 을 반영해야 한다(열람자 목표 아님).
+    expect(view.checklistItems.map((item) => item.label)).toEqual([
+      '물 마시기',
+      '운동하기',
+    ]);
+    // 두 목표 모두 달성으로 표시(과거엔 id/문구 불일치로 미달성이었음).
+    expect(view.checkedChecklistIds).toEqual(['901', '902']);
+  });
 });

--- a/src/app.feature/diary/detail/utils/diaryViewData.ts
+++ b/src/app.feature/diary/detail/utils/diaryViewData.ts
@@ -241,34 +241,17 @@ export function mapDiaryToViewData(
   let checklistItems: ChecklistItem[] = [];
   let checkedChecklistIds: string[] = [];
 
-  if (checklistItemsFromChallenge.length > 0) {
-    checklistItems = checklistItemsFromChallenge;
-
-    if (diaryGoals.length > 0) {
-      const achievedDiaryGoalIds = new Set(
-        diaryGoals
-          .filter((goal) => goal.isAchieved)
-          .map((goal) => String(goal.challengeGoalId))
-      );
-      const achievedDiaryGoalNames = new Set(
-        diaryGoals
-          .filter((goal) => goal.isAchieved && Boolean(goal.challengeGoalName))
-          .map((goal) => goal.challengeGoalName.trim())
-      );
-
-      checkedChecklistIds = checklistItems
-        .filter(
-          (item) =>
-            achievedDiaryGoalIds.has(item.id) ||
-            achievedDiaryGoalNames.has(item.label.trim())
-        )
-        .map((item) => item.id);
-    } else {
-      checkedChecklistIds = checklistItems
-        .filter((item) => achievementIds.has(item.id))
-        .map((item) => item.id);
-    }
-  } else if (diaryGoals.length > 0) {
+  if (diaryGoals.length > 0) {
+    // 일지의 diaryGoal 은 그 일지(=작성자) 고유의 목표 목록과 달성 여부를
+    // 그대로 담는 유일하게 신뢰할 수 있는 소스다. 항상 이걸 우선 사용한다.
+    //
+    // 과거엔 challengeGoals(=열람자의 챌린지 목표)로 체크리스트를 만들고
+    // 작성자 달성분을 goal id/이름으로 매칭했다. 그런데 challenge_goal 은
+    // 참여자마다 복제돼 id 가 달라(FIXED 포함), "타인 일지"에서 id 매칭이
+    // 전부 깨졌다. 본인 일지는 열람자 id == 작성자 id 라 우연히 맞아 정상,
+    // 타인 일지는 이름 매칭에 의존하다 목표 문구가 조금만 달라도(FLEXIBLE
+    // 등) 실패해 달성한 목표가 미달성으로 표시됐다. diaryGoal 을 직접 쓰면
+    // 본인/타인 모두 정확하다.
     checklistItems = diaryGoals.map((goal) => ({
       id: String(goal.challengeGoalId),
       label: goal.challengeGoalName || `목표 ${goal.challengeGoalId}`,
@@ -276,6 +259,13 @@ export function mapDiaryToViewData(
     checkedChecklistIds = diaryGoals
       .filter((goal) => goal.isAchieved)
       .map((goal) => String(goal.challengeGoalId));
+  } else if (checklistItemsFromChallenge.length > 0) {
+    // 레거시(diaryGoal 이 없는 구 응답): 챌린지 목표 목록 + deprecated
+    // achievement(달성 목표 id 배열)로 구성한다.
+    checklistItems = checklistItemsFromChallenge;
+    checkedChecklistIds = checklistItems
+      .filter((item) => achievementIds.has(item.id))
+      .map((item) => item.id);
   } else {
     const achievedGoalIds = Array.from(achievementIds);
     checklistItems = achievedGoalIds.map((goalId) => ({

--- a/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
+++ b/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
@@ -2,13 +2,14 @@
 
 import {
   Button,
-  DatePicker,
   MobileHeader,
   Text,
 } from '@1d1s/design-system';
 import { AlertDialog } from '@component/AlertDialog';
 import { MobileBottomActionBar } from '@component/layout/MobileBottomActionBar';
+import { NativeDatePicker } from '@component/NativeDatePicker';
 import { cn } from '@module/utils/cn';
+import { startOfToday, subDays } from 'date-fns';
 import { Loader2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
@@ -212,11 +213,17 @@ export default function DiaryCreateScreen(): React.ReactElement {
             >
               언제의 기록인가요?
             </Text>
-            <DatePicker
+            <NativeDatePicker
               value={achievedDate}
               onChange={handleAchievedDateChange}
               placeholder="날짜를 선택해주세요"
               calendarProps={{ disabled: isAchievedDateDisabled }}
+              // "오늘 포함 최근 3일" 창. 창 안의 개별 비활성(이미 작성한
+              // 날, 챌린지 시작 전) 은 같은 판정 함수를 하루씩 평가해
+              // 네이티브로 보낸다.
+              nativeMin={subDays(startOfToday(), 2)}
+              nativeMax={startOfToday()}
+              nativeIsDisabled={isAchievedDateDisabled}
             />
             <Text
               size="caption2"

--- a/src/app.feature/home/components/HomePopup.tsx
+++ b/src/app.feature/home/components/HomePopup.tsx
@@ -10,9 +10,11 @@ import {
   DialogTitle,
 } from '@1d1s/design-system';
 import FadeInImage from '@component/FadeInImage';
+import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
 import { cn } from '@module/utils/cn';
+import { openNativePopup } from '@module/utils/nativeBridge';
 import { useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { useActivePopups } from '../hooks/usePopupQueries';
 import {
@@ -46,6 +48,11 @@ export default function HomePopup({
   );
   const [closed, setClosed] = useState(false);
   const [index, setIndex] = useState(0);
+  const isNativeApp = useIsNativeApp(false);
+  // 네이티브 쉘이 popup_open 을 모르면(구버전) null 이 돌아온다 → 웹 팝업으로
+  // 폴백한다.
+  const [nativeUnavailable, setNativeUnavailable] = useState(false);
+  const nativeRequested = useRef(false);
 
   // 노출 대상 = 응답 팝업 중 쿠키에 없는 것. 시작일 오름차순은 서버가 보장.
   const visiblePopups = popups.filter(
@@ -54,17 +61,79 @@ export default function HomePopup({
   const count = visiblePopups.length;
 
   // 노출 대상이 2개 이상이면 3초 간격으로 순환 슬라이드.
+  // 네이티브가 그리는 동안은 Flutter 쪽 타이머가 순환을 맡으므로 돌리지 않는다.
   useEffect(() => {
-    if (closed || count < 2) {
+    if (closed || count < 2 || (isNativeApp && !nativeUnavailable)) {
       return;
     }
     const timer = setInterval(() => {
       setIndex((prev) => (prev + 1) % count);
     }, SLIDE_INTERVAL_MS);
     return () => clearInterval(timer);
-  }, [closed, count]);
+  }, [closed, count, isNativeApp, nativeUnavailable]);
+
+  // 네이티브 쉘에서는 팝업을 Flutter 가 그린다. 웹 다이얼로그는 WebView 안에
+  // 갇혀 네이티브 헤더/바텀바를 덮지 못하기 때문 — z-index 로는 해결이 안 되는
+  // 구조적 제약이다.
+  //
+  // 표시만 네이티브에 맡기고 판단은 여기 그대로 둔다. "다시 보지 않기" 쿠키와
+  // 세션 차단 규칙(popupDismissal), CTA 이동 규칙이 두 곳으로 갈라지면 언젠가
+  // 반드시 어긋난다.
+  useEffect(() => {
+    if (!isNativeApp || closed || count === 0 || nativeRequested.current) {
+      return;
+    }
+    nativeRequested.current = true;
+    let cancelled = false;
+    void (async () => {
+      const shown = visiblePopups;
+      const keys = shown.map((popup) => popup.popupKey);
+      const outcome = await openNativePopup(
+        shown.map((popup) => ({
+          popupKey: popup.popupKey,
+          imageUrl: popup.imageUrl,
+          ctaText: popup.ctaText,
+          linkUrl: popup.linkUrl,
+        }))
+      );
+      if (cancelled) {
+        return;
+      }
+      if (!outcome) {
+        setNativeUnavailable(true);
+        return;
+      }
+      if (outcome.action === 'dismissForever') {
+        dismissPopupKeys(keys);
+      }
+      sessionDismissPopupKeys(keys);
+      setClosed(true);
+      if (outcome.action === 'cta') {
+        // 캐러셀이 돌기 때문에 CTA 를 누른 장은 첫 장이 아닐 수 있다.
+        const target =
+          shown.find((popup) => popup.popupKey === outcome.popupKey) ??
+          shown[0];
+        if (/^https?:\/\//i.test(target.linkUrl)) {
+          window.open(target.linkUrl, '_blank', 'noopener,noreferrer');
+        } else {
+          router.push(target.linkUrl);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // visiblePopups 는 렌더마다 새 배열이라 의존성에 넣으면 매번 다시 연다.
+    // count 가 그 내용 변화를 대신 잡고, nativeRequested 가 중복을 막는다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isNativeApp, closed, count]);
 
   if (count === 0) {
+    return null;
+  }
+
+  // 네이티브가 그리는 동안 웹 팝업은 아무것도 그리지 않는다.
+  if (isNativeApp && !nativeUnavailable) {
     return null;
   }
 

--- a/src/app.feature/home/components/HomeTodayRecordSection.tsx
+++ b/src/app.feature/home/components/HomeTodayRecordSection.tsx
@@ -12,7 +12,7 @@ import { cn } from '@module/utils/cn';
 import { Check } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { useTodayRecords } from '../hooks/useTodayRecords';
 import { formatChallengeRemainingLabel } from '../utils/homeFormatters';
@@ -215,6 +215,17 @@ export default function HomeTodayRecordSection({
   const { items, doneCount, pendingCount, isLoading } =
     useTodayRecords(challenges);
 
+  // 미작성 우선으로 정렬. 조건부 early return 위에서 훅을 호출해야 하므로
+  // (Rules of Hooks) 여기서 계산하고 items 변경 시에만 재정렬한다.
+  const ordered = useMemo(
+    () =>
+      [...items].sort(
+        (left, right) =>
+          Number(left.writtenToday) - Number(right.writtenToday)
+      ),
+    [items]
+  );
+
   // 인증/사이드바 또는 today 쿼리 로딩 중 — 개수를 모르므로 2행을 예약한다.
   if (isAuthLoading || isLoading) {
     return (
@@ -258,10 +269,6 @@ export default function HomeTodayRecordSection({
     );
   }
 
-  // 미작성 우선으로 정렬.
-  const ordered = [...items].sort(
-    (left, right) => Number(left.writtenToday) - Number(right.writtenToday)
-  );
   const allDone = pendingCount === 0;
 
   return (

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -82,6 +82,7 @@ export default function HomeScreen(): React.ReactElement {
     <>
       <HomePopup enabled={isLoggedIn} />
       <div
+        data-native-flush-top
         className={cn(
           'mx-auto flex w-full max-w-[1200px] flex-col gap-4 lg:gap-6',
           'px-5 py-7 lg:px-8 lg:py-10'

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -5,6 +5,7 @@ import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import Stories from '@feature/stories/components/Stories';
 import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { useHasMounted } from '@module/hooks/useHasMounted';
+import { authStorage } from '@module/utils/auth';
 import { cn } from '@module/utils/cn';
 import { loginUrlFromCurrentLocation } from '@module/utils/returnTo';
 import { useRouter } from 'next/navigation';
@@ -58,10 +59,18 @@ export default function HomeScreen(): React.ReactElement {
   const hasMounted = useHasMounted();
   const status = useAuthStatus();
   const isLoggedIn = status === 'authenticated';
-  // 부팅 세션 확인 중(unknown)에는 게스트 CTA 대신 로그인 셸을 스켈레톤으로
-  // 그린다. Safari standalone PWA 첫 진입에서 로그인 사용자가 게스트 CTA 를
-  // 봤다가 로그인 UI 로 점프하던 깜빡임을 없앤다. 확정된 게스트만 CTA 를 본다.
-  const showGuestCta = status === 'guest';
+  // 로그인 힌트(hasTokens)는 확인 중(unknown) 구간에 "어느 스켈레톤을 보여줄지"
+  // 만 고르는 provisional 신호다. 권위 있는 판정은 여전히 status(서버 확인)이며
+  // 힌트로 로그인 여부를 확정하지 않는다(tri-state 원칙 유지).
+  // - 마운트 전(SSR/하이드레이션): 힌트를 못 읽어 로그인 셸을 기본값으로 둔다
+  //   (기존과 동일 → hydration mismatch 방지).
+  // - 확인 중 + 힌트 있음: 로그인 셸 스켈레톤 유지 → Safari PWA 로그인 사용자의
+  //   게스트→로그인 점프 깜빡임 방지(#207).
+  // - 확인 중 + 힌트 없음(=일반 게스트): 게스트 CTA 를 바로 보여줘 로그인용
+  //   스켈레톤이 뜨지 않게 한다.
+  const hasAuthHint = hasMounted && authStorage.hasTokens();
+  const showGuestCta =
+    status === 'guest' || (status === 'unknown' && hasMounted && !hasAuthHint);
   const showLoggedInShell = !showGuestCta;
   const {
     data: sidebar,

--- a/src/app.feature/member/hooks/useMemberQueries.ts
+++ b/src/app.feature/member/hooks/useMemberQueries.ts
@@ -97,9 +97,10 @@ export function useSidebar(): UseQueryResult<SidebarData | null, Error> {
     },
     retry: false, // queryFn 내부에서 직접 재시도 처리
     enabled: !isServer && status === 'authenticated',
+    // staleTime: Infinity 라 마운트 시 데이터가 stale 이 아니므로
+    // refetchOnMount(기본 true)는 어차피 refetch 하지 않는다 — 명시 제거.
     staleTime: MEMBER_INFO_STALE_TIME,
     gcTime: MEMBER_INFO_GC_TIME,
-    refetchOnMount: true,
   });
 }
 
@@ -138,8 +139,8 @@ export function useMyPage(): UseQueryResult<MyPageData, Error> {
     queryKey: MEMBER_QUERY_KEYS.myPage(),
     queryFn: () => memberApi.getMyPage(),
     enabled: isLoggedIn,
+    // staleTime: Infinity 라 refetchOnMount(기본 true)는 no-op — 명시 제거.
     staleTime: MEMBER_INFO_STALE_TIME,
     gcTime: MEMBER_INFO_GC_TIME,
-    refetchOnMount: true,
   });
 }

--- a/src/app.feature/member/mypage/components/MyPageProfileCard.tsx
+++ b/src/app.feature/member/mypage/components/MyPageProfileCard.tsx
@@ -162,7 +162,21 @@ export function MyPageProfileCard({
     <>
       {/* 모바일: 부모 컨테이너 패딩에 정렬, 72px 아바타 + 3-col stats grid */}
       <section className="relative lg:hidden">
-        <div className="flex min-h-8 items-center justify-end gap-1">
+        {/*
+          네이티브 쉘에서는 이 액션 행이 통째로 숨는다. 알림 벨은 AppTopNav 의
+          벨과 중복이고, 설정 진입은 AppTopNav 가 /mypage 에서 톱니 버튼으로
+          제공한다. 이 행이 남아 있으면 네이티브 헤더 바로 밑에 또 하나의
+          헤더처럼 보인다.
+
+          이 섹션은 sticky/fixed 가 아니라 relative 라, globals.css 의 sticky
+          기반 차단 룰이 잡지 못한다 — 그래서 data-native-hide 를 직접 붙인다.
+          섹션 전체가 아니라 액션 행에만 붙이는 게 중요하다. 아바타/닉네임/
+          스트릭 타일은 네이티브가 대체하지 않는다.
+        */}
+        <div
+          data-native-hide
+          className="flex min-h-8 items-center justify-end gap-1"
+        >
           {actions ?? (
             <>
               <button

--- a/src/app.feature/member/settings/components/ConfirmDialog.tsx
+++ b/src/app.feature/member/settings/components/ConfirmDialog.tsx
@@ -4,7 +4,9 @@ import {
   ConfirmDialog as DSConfirmDialog,
   type IconName,
 } from '@1d1s/design-system';
-import React from 'react';
+import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
+import { openNativeModal } from '@module/utils/nativeBridge';
+import React, { useEffect } from 'react';
 
 type ConfirmTone = 'brand' | 'danger' | 'mint';
 
@@ -36,7 +38,56 @@ export function ConfirmDialog({
   onConfirm,
   tone = 'brand',
   icon = 'Flag',
-}: ConfirmDialogProps): React.ReactElement {
+}: ConfirmDialogProps): React.ReactElement | null {
+  const isNativeApp = useIsNativeApp(false);
+
+  // 네이티브 쉘에서는 웹 다이얼로그 대신 OS 다이얼로그로 위임한다.
+  // LoginRequiredDialog 와 같은 패턴 — 설정의 로그아웃/회원탈퇴만 웹
+  // 다이얼로그로 남아 앱 안에서 혼자 웹 UI 로 보였다.
+  //
+  // dismiss(밖 클릭/시스템 백) 는 취소로 읽는다.
+  useEffect(() => {
+    if (!isNativeApp || !open) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const result = await openNativeModal({
+        title,
+        message: description,
+        buttons: [
+          { label: '취소', value: 'cancel', style: 'cancel' },
+          {
+            label: confirmLabel,
+            value: 'confirm',
+            style: tone === 'danger' ? 'destructive' : 'default',
+          },
+        ],
+      });
+      if (cancelled) {
+        return;
+      }
+      if (result === 'confirm' && !isPending && !isDisabled) {
+        onConfirm();
+        return;
+      }
+      onCancel();
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // open/isNativeApp 만 본다. isPending 은 확인을 누른 직후 바뀌는데,
+    // 의존성에 넣으면 요청 중에 effect 가 다시 돌아 다이얼로그가 두 번
+    // 뜬다. 나머지(title/label/핸들러)는 이 다이얼로그가 열려 있는 동안
+    // 바뀌지 않는다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isNativeApp, open]);
+
+  // 네이티브에서는 Flutter 가 다이얼로그를 직접 그린다.
+  if (isNativeApp) {
+    return null;
+  }
+
   return (
     <DSConfirmDialog
       open={open}

--- a/src/app.feature/member/settings/screen/ProfileSettingsScreen.tsx
+++ b/src/app.feature/member/settings/screen/ProfileSettingsScreen.tsx
@@ -205,7 +205,7 @@ export default function ProfileSettingsScreen(): React.ReactElement {
                     isSameAsCurrent ||
                     !isVerified
                   }
-                  className="shrink-0 whitespace-nowrap"
+                  className="h-auto shrink-0 self-stretch whitespace-nowrap"
                 >
                   {updateNickname.isPending ? '저장 중...' : '저장'}
                 </Button>
@@ -268,7 +268,7 @@ export default function ProfileSettingsScreen(): React.ReactElement {
                     Boolean(phoneError) ||
                     isSamePhone
                   }
-                  className="shrink-0 whitespace-nowrap"
+                  className="h-auto shrink-0 self-stretch whitespace-nowrap"
                 >
                   {updatePhoneNumber.isPending ? '저장 중...' : '저장'}
                 </Button>

--- a/src/app.feature/notification/screen/NotificationScreen.tsx
+++ b/src/app.feature/notification/screen/NotificationScreen.tsx
@@ -67,6 +67,12 @@ export function NotificationScreen(): React.JSX.Element {
       headerAction={markAllAction}
       onBack={handleBack}
     >
+      {/* 네이티브 쉘에서는 SubPageShell 의 웹 헤더(와 headerAction 의
+          "모두 읽음")가 통째로 숨는다. 같은 액션을 본문 상단에 native-only
+          로 한 번 더 그려 네이티브에서도 모두 읽음이 가능하게 한다. */}
+      {hasUnread ? (
+        <div className="native-only mb-3 text-right">{markAllAction}</div>
+      ) : null}
       {showSkeleton ? (
         <NotificationListSkeleton count={6} />
       ) : !hasNotifications ? (

--- a/src/app.feature/stories/components/Stories.tsx
+++ b/src/app.feature/stories/components/Stories.tsx
@@ -3,14 +3,19 @@
 import { Text } from '@1d1s/design-system';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { cn } from '@module/utils/cn';
+import {
+  onNativeStoryViewed,
+  openNativeStoryViewer,
+} from '@module/utils/nativeBridge';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import { ArrowRight, Lock } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useViewStory } from '../hooks/useStoryMutations';
 import { useStories } from '../hooks/useStoryQueries';
-import { sortStoryGroups } from '../utils/storyHelpers';
+import { formatStoryDate, sortStoryGroups } from '../utils/storyHelpers';
 import StoryRing from './StoryRing';
 import StoryRingSkeleton from './StoryRingSkeleton';
 
@@ -141,6 +146,39 @@ export default function Stories({
   // 인라인 핸들러는 매 렌더마다 새로 생성돼 뷰어의 콜백 안정성과
   // React.memo(StoryRing) 를 깬다.
   const handleCloseViewer = useCallback(() => setOpenIndex(-1), []);
+  const viewStory = useViewStory();
+
+  // 네이티브 뷰어가 보내는 읽음 이벤트. 웹 뷰어의 useViewStory 호출과 같은
+  // 처리 — 판단(무엇을 읽음으로 칠지)은 네이티브가, 기록은 웹이 한다.
+  useEffect(
+    () => onNativeStoryViewed((diaryId) => viewStory.mutate(diaryId)),
+    [viewStory]
+  );
+
+  // 네이티브 쉘에서는 뷰어를 Flutter 가 그린다. 웹 오버레이는 WebView 안에
+  // 갇혀 네이티브 헤더/바텀바를 덮지 못한다 — 팝업/이미지 뷰어와 같은 제약.
+  const handleSelect = useCallback(
+    (index: number) => {
+      const delegated = openNativeStoryViewer({
+        startGroup: index,
+        groups: groups.map((group) => ({
+          userName: group.userName ?? `친구 ${group.userId}`,
+          profileImage: group.profileImage,
+          stories: group.stories.map((story) => ({
+            diaryId: story.diaryId,
+            title: story.diaryTitle,
+            thumbnail: story.diaryThumbnail,
+            timeLabel: formatStoryDate(story.createdAt),
+            unread: story.hasUnreadJournal,
+          })),
+        })),
+      });
+      if (!delegated) {
+        setOpenIndex(index);
+      }
+    },
+    [groups]
+  );
   const handleAddStory = useCallback(() => {
     router.push('/diary/create');
   }, [router]);
@@ -161,7 +199,7 @@ export default function Stories({
       <div className="data-fade-in">
         <StoryRing
           groups={groups}
-          onSelect={setOpenIndex}
+          onSelect={handleSelect}
           myProfileImage={sidebar?.profileUrl ?? null}
           onAddStory={handleAddStory}
         />

--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -47,9 +47,9 @@ function pickStoryMood(userId: number): StoryMood {
   return STORY_MOODS[Math.abs(userId) % STORY_MOODS.length];
 }
 
-// 사각형 스토리 카드(144x180). 무드 이미지를 크게 중앙에 두고 그 아래
+// 사각형 스토리 카드(112x140). 무드 이미지를 크게 중앙에 두고 그 아래
 // 프로필 썸네일만 노출한다(닉네임/시간/제목/개수 미표시). 읽음 여부는
-// 카드 테두리 색으로 표현한다(안읽음 border-main-500, 읽음 border-gray-200).
+// 카드 테두리로 표현한다(안읽음 3px border-main-500, 읽음 2px border-gray-200).
 function StoryRing({
   groups,
   onSelect,
@@ -77,24 +77,24 @@ function StoryRing({
           onClick={onAddStory}
           aria-label="오늘 일지 올리기"
           className={cn(
-            'flex h-[180px] w-[144px] shrink-0 flex-col items-center',
-            'justify-center gap-3 overflow-hidden rounded-[20px]',
+            'flex h-[140px] w-[112px] shrink-0 flex-col items-center',
+            'justify-center gap-2.5 overflow-hidden rounded-[16px]',
             'border-main-200 border-2 border-dashed bg-white',
             'hover:shadow-warm transition-all duration-300 ease-out'
           )}
         >
           <span
             className={cn(
-              'bg-main-500 shadow-warm flex h-14 w-14 items-center',
+              'bg-main-500 shadow-warm flex h-11 w-11 items-center',
               'justify-center rounded-full text-white'
             )}
             aria-hidden
           >
-            <Icon name="Plus" size={24} />
+            <Icon name="Plus" size={20} />
           </span>
           <span
             className={cn(
-              'flex h-11 w-11 items-center justify-center overflow-hidden',
+              'flex h-9 w-9 items-center justify-center overflow-hidden',
               'rounded-full border-2 border-white bg-[#ffe1a8]'
             )}
             aria-hidden
@@ -105,7 +105,7 @@ function StoryRing({
                   src={myImageUrl}
                   alt=""
                   fill
-                  sizes="44px"
+                  sizes="36px"
                   className="object-cover"
                 />
               </span>
@@ -129,10 +129,12 @@ function StoryRing({
             onClick={() => onSelect(index)}
             aria-label={`${name} 스토리 열기`}
             className={cn(
-              'flex h-[180px] w-[144px] shrink-0 flex-col items-center',
-              'justify-center gap-3 overflow-hidden rounded-[20px] border-2',
+              'flex h-[140px] w-[112px] shrink-0 flex-col items-center',
+              'justify-center gap-2.5 overflow-hidden rounded-[16px]',
               'hover:shadow-warm transition-all duration-300 ease-out',
-              seen ? 'border-gray-200' : 'border-main-500',
+              seen
+                ? 'border-2 border-gray-200'
+                : 'border-main-500 border-[3px]',
               mood.tint
             )}
           >
@@ -140,14 +142,14 @@ function StoryRing({
             <Image
               src={mood.src}
               alt={mood.alt}
-              width={56}
-              height={56}
-              className="h-14 w-14"
+              width={44}
+              height={44}
+              className="h-11 w-11"
               unoptimized
             />
             <span
               className={cn(
-                'relative flex h-11 w-11 items-center justify-center',
+                'relative flex h-9 w-9 items-center justify-center',
                 'overflow-hidden rounded-full border-2 border-white bg-white'
               )}
               aria-hidden
@@ -157,7 +159,7 @@ function StoryRing({
                   src={profileUrl}
                   alt=""
                   fill
-                  sizes="44px"
+                  sizes="36px"
                   className="object-cover"
                 />
               ) : (

--- a/src/app.feature/stories/components/StoryRingSkeleton.tsx
+++ b/src/app.feature/stories/components/StoryRingSkeleton.tsx
@@ -9,7 +9,7 @@ interface StoryRingSkeletonProps {
 }
 
 // 실제 StoryRing 과 동일한 사각 카드 크기/간격을 두고 내용만 pulse 로
-// 채운다. (h-[180px] w-[144px] + gap-3 + py-3.5 → 레이아웃 시프트 없이
+// 채운다. (h-[140px] w-[112px] + gap-3 + py-3.5 → 레이아웃 시프트 없이
 // 데이터로 전환)
 export default function StoryRingSkeleton({
   count = 6,
@@ -27,7 +27,7 @@ export default function StoryRingSkeleton({
         <div
           key={index}
           className={cn(
-            'skeleton-pulse h-[180px] w-[144px] shrink-0 rounded-[20px]',
+            'skeleton-pulse h-[140px] w-[112px] shrink-0 rounded-[16px]',
             'bg-gray-100'
           )}
         />

--- a/src/app.lib/font.ts
+++ b/src/app.lib/font.ts
@@ -3,11 +3,6 @@ import localFont from 'next/font/local';
 const pretendard = localFont({
   src: [
     {
-      path: '../../public/fonts/pretendard/Pretendard-Light.woff2',
-      weight: '300',
-      style: 'normal',
-    },
-    {
       path: '../../public/fonts/pretendard/Pretendard-Regular.woff2',
       weight: '400',
       style: 'normal',
@@ -18,8 +13,12 @@ const pretendard = localFont({
       style: 'normal',
     },
     {
+      // Pretendard-Bold 는 700 페이스다. 과거 '600' 으로 잘못 선언돼
+      // font-bold(700)/font-extrabold(800) 요청이 근사/합성으로 처리됐다.
+      // ExtraBold(800) woff2 는 assets 에 없으므로 별도 선언하지 않는다.
+      // font-extrabold 는 CSS 매칭상 가장 가까운 700(실제 Bold)로 렌더된다.
       path: '../../public/fonts/pretendard/Pretendard-Bold.woff2',
-      weight: '600',
+      weight: '700',
       style: 'normal',
     },
   ],

--- a/src/app.module/api/tokenRefresh.ts
+++ b/src/app.module/api/tokenRefresh.ts
@@ -1,4 +1,5 @@
 import { authStorage } from '@module/utils/auth';
+import { requestNativeTokenRefresh } from '@module/utils/nativeBridge';
 import axios from 'axios';
 
 import { API_BASE_URL } from './config';
@@ -21,8 +22,11 @@ let inFlight: Promise<void> | null = null;
  */
 export function refreshAccessTokenOnce(): Promise<void> {
   if (!inFlight) {
-    inFlight = axios
-      .get(`${API_BASE_URL}/auth/token`, { withCredentials: true })
+    const nativeRefresh = requestNativeTokenRefresh();
+    const refreshRequest =
+      nativeRefresh ??
+      axios.get(`${API_BASE_URL}/auth/token`, { withCredentials: true });
+    inFlight = refreshRequest
       .then(() => {
         // 갱신 성공 = 세션 생존 확정. 일시적 401 로 지워졌을 수 있는
         // 로그인 힌트(쿠키/localStorage)를 복구한다.

--- a/src/app.module/middleware/headers.ts
+++ b/src/app.module/middleware/headers.ts
@@ -33,19 +33,26 @@ export function headersMiddleware(res: NextResponse): void {
   );
   // 카카오 공유(JS SDK) 도메인 — SDK 스크립트 + API 호출 허용에 사용한다.
   const kakaoOrigins = 'https://t1.kakaocdn.net https://*.kakao.com';
+  // Sign in with Apple(웹) — SDK 스크립트는 cdn-apple, 인증 호출/프레임은
+  // appleid.apple.com. (팝업 자체는 top-level 이라 CSP 대상 아님)
+  const appleScriptOrigin = 'https://appleid.cdn-apple.com';
+  const appleAuthOrigin = 'https://appleid.apple.com';
   const connectSrcValue =
     allowedOrigins.length > 0
-      ? `connect-src 'self' ${allowedOrigins.join(' ')} ${kakaoOrigins} https://vercel.live https://*.vercel.live;`
-      : `connect-src 'self' ${kakaoOrigins} https://vercel.live https://*.vercel.live;`;
+      ? `connect-src 'self' ${allowedOrigins.join(' ')} ${kakaoOrigins} ${appleAuthOrigin} https://vercel.live https://*.vercel.live;`
+      : `connect-src 'self' ${kakaoOrigins} ${appleAuthOrigin} https://vercel.live https://*.vercel.live;`;
   const imgSrcValue = "img-src 'self' blob: data: https: http:;";
   const scriptSrcValue =
-    "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://t1.kakaocdn.net https://vercel.live https://*.vercel.live;";
+    `script-src 'self' 'unsafe-eval' 'unsafe-inline' https://t1.kakaocdn.net ${appleScriptOrigin} https://vercel.live https://*.vercel.live;`;
+  // 애플 SDK 가 인증 처리에 iframe 을 쓰는 경우가 있어 frame-src 를 명시한다.
+  const frameSrcValue = `frame-src 'self' ${appleAuthOrigin};`;
 
   // const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
   const cspHeader = `
     default-src 'self';
     ${connectSrcValue}
     ${scriptSrcValue}
+    ${frameSrcValue}
     style-src 'self' 'unsafe-inline';
     ${imgSrcValue}
     font-src 'self';

--- a/src/app.module/providers/PostHogProvider.tsx
+++ b/src/app.module/providers/PostHogProvider.tsx
@@ -2,30 +2,54 @@
 
 import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { usePathname, useSearchParams } from 'next/navigation';
-import posthog from 'posthog-js';
+import type { PostHog } from 'posthog-js';
 import React, { Suspense, useEffect } from 'react';
 
 import { useSidebar } from '@/app.feature/member/hooks/useMemberQueries';
 
 const DEFAULT_HOST = 'https://us.i.posthog.com';
 
-// 초기화 여부를 자체 플래그로 추적한다(posthog 내부 필드 의존 회피).
-let initialized = false;
+// 로드 상태: pending(동적 import 전) → ready(init 완료) | disabled(키 없음).
+type LoadState = 'pending' | 'ready' | 'disabled';
+
+let posthog: PostHog | null = null;
+let loadState: LoadState = 'pending';
+let bootstrapStarted = false;
+
+// init 완료 전에 발생한 capture/identify 를 순서대로 큐잉했다가 flush 한다.
+// 첫 페이지뷰가 lazy import 완료 이전에 발생해도 유실되지 않는다.
+const pendingCalls: Array<(ph: PostHog) => void> = [];
+
+/** posthog 준비 시 즉시 실행, 아직이면 큐잉(키 없음이면 조용히 무시). */
+function withPostHog(fn: (ph: PostHog) => void): void {
+  if (loadState === 'ready' && posthog) {
+    fn(posthog);
+    return;
+  }
+  if (loadState === 'pending') {
+    pendingCalls.push(fn);
+  }
+}
 
 /**
- * PostHog 클라이언트 1회 초기화. 키가 없으면(로컬/프리뷰) 스킵해 에러를 막는다.
- * 모듈 로드 시점(클라이언트)에 호출되어 이후 pageview/identify 이펙트가
- * 초기화 완료 상태를 볼 수 있게 한다.
+ * posthog-js 를 동적 import 해 초기 번들에서 제외한다. 마운트 직후 1회 실행.
+ * 키가 없으면(로컬/프리뷰) import 자체를 건너뛰어 에러를 막는다.
  */
-function initPostHog(): void {
-  if (initialized || typeof window === 'undefined') {
+async function bootstrapPostHog(): Promise<void> {
+  if (bootstrapStarted || typeof window === 'undefined') {
     return;
   }
+  bootstrapStarted = true;
+
   const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
   if (!key) {
+    loadState = 'disabled';
+    pendingCalls.length = 0;
     return;
   }
-  posthog.init(key, {
+
+  const { default: ph } = await import('posthog-js');
+  ph.init(key, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_HOST,
     // App Router 는 자동 pageview 가 오동작하므로 수동 캡처한다.
     capture_pageview: false,
@@ -33,11 +57,14 @@ function initPostHog(): void {
     disable_session_recording: true,
     person_profiles: 'identified_only',
   });
-  initialized = true;
-}
 
-if (typeof window !== 'undefined') {
-  initPostHog();
+  posthog = ph;
+  loadState = 'ready';
+  // init 전 큐잉된 호출을 발생 순서대로 flush.
+  for (const call of pendingCalls) {
+    call(ph);
+  }
+  pendingCalls.length = 0;
 }
 
 /**
@@ -49,10 +76,12 @@ function PostHogPageView(): null {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (!initialized || !pathname) {
+    if (!pathname) {
       return;
     }
-    posthog.capture('$pageview', { $current_url: window.location.href });
+    withPostHog((ph) =>
+      ph.capture('$pageview', { $current_url: window.location.href })
+    );
   }, [pathname, searchParams]);
 
   return null;
@@ -69,13 +98,10 @@ function PostHogIdentify(): null {
   const nickname = sidebar?.nickname;
 
   useEffect(() => {
-    if (!initialized) {
-      return;
-    }
     if (status === 'authenticated' && nickname) {
-      posthog.identify(nickname, { nickname });
+      withPostHog((ph) => ph.identify(nickname, { nickname }));
     } else if (status === 'guest') {
-      posthog.reset();
+      withPostHog((ph) => ph.reset());
     }
   }, [status, nickname]);
 
@@ -87,6 +113,11 @@ export function PostHogProvider({
 }: {
   children: React.ReactNode;
 }): React.ReactElement {
+  // 마운트 직후 posthog-js 를 lazy load + init. 초기 번들엔 포함되지 않는다.
+  useEffect(() => {
+    void bootstrapPostHog();
+  }, []);
+
   return (
     <>
       <Suspense fallback={null}>

--- a/src/app.module/utils/nativeAppScript.ts
+++ b/src/app.module/utils/nativeAppScript.ts
@@ -1,0 +1,15 @@
+// RootLayout <head> 에 blocking inline script 로 주입되는 판정 코드.
+// 첫 페인트 이전에 <html data-native-app> 을 확정해, 네이티브 쉘에서
+// 웹 chrome(헤더/바텀바)이 한 프레임 보였다 사라지는 레이아웃 시프트를
+// 없앤다. headers() 를 쓰지 않으므로 라우트는 정적 prefetch 가능 상태를
+// 유지한다.
+//
+// 판정 신호는 `useIsNativeApp` 의 detect() 와 동일하다. 한쪽을 바꾸면
+// 다른 쪽도 함께 맞춰야 한다.
+export const NATIVE_APP_INIT_SCRIPT =
+  '(function(){try{var w=window;' +
+  'var n=w.__IS_NATIVE_APP__===true||' +
+  "typeof w.OneDayOneStreakNative!=='undefined'||" +
+  '/1D1S-App/i.test(navigator.userAgent);' +
+  'if(n){w.__IS_NATIVE_APP__=true;' +
+  "document.documentElement.dataset.nativeApp='true';}}catch(e){}})();";

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -8,6 +8,8 @@
 const CHANNEL_NAME = 'OneDayOneStreakNative';
 const NAVIGATE_EVENT = 'native:navigate';
 const MODAL_RESULT_EVENT = 'native:modal_result';
+const TOKEN_REFRESH_RESULT_EVENT = 'native:token_refresh_result';
+const NATIVE_OAUTH_MARKER = '1d1s:native-oauth';
 
 export interface NativeAuthPayload {
   isLoggedIn: boolean;
@@ -55,6 +57,9 @@ export type NativeMessage =
   // collapse/expand 하는 용도. 매 프레임 보내는 대신 방향 전환에만 발화해
   // JS 채널 트래픽을 최소화한다.
   | { type: 'scroll_dir'; payload: NativeScrollDirPayload }
+  | { type: 'oauth_open'; payload: { url: string } }
+  | { type: 'token_refresh'; payload: { id: string } }
+  | { type: 'logout' }
   // 네이티브 다이얼로그 노출 요청. 응답은 native:modal_result CustomEvent
   // 로 비동기 도착. openNativeModal() 헬퍼가 id 매칭으로 Promise 화 한다.
   | { type: 'modal_open'; payload: NativeModalOpenPayload };
@@ -90,6 +95,90 @@ export function postNativeMessage(message: NativeMessage): void {
   } catch {
     // 네이티브 쉘이 응답하지 못하더라도 웹 흐름을 멈추지 않는다.
   }
+}
+
+export function isNativeBridgeAvailable(): boolean {
+  return getNativeWindow()?.[CHANNEL_NAME] != null;
+}
+
+export function markNativeOAuth(codeChallenge: string): void {
+  window.sessionStorage.setItem(NATIVE_OAUTH_MARKER, codeChallenge);
+}
+
+export function consumeNativeOAuth(): string | null {
+  const codeChallenge = window.sessionStorage.getItem(NATIVE_OAUTH_MARKER);
+  if (codeChallenge) {
+    window.sessionStorage.removeItem(NATIVE_OAUTH_MARKER);
+  }
+  return codeChallenge;
+}
+
+export function peekNativeOAuth(): string | null {
+  return window.sessionStorage.getItem(NATIVE_OAUTH_MARKER);
+}
+
+interface PendingTokenRefresh {
+  resolve(): void;
+  reject(): void;
+  timeout: number;
+}
+
+const pendingTokenRefreshes = new Map<string, PendingTokenRefresh>();
+let tokenRefreshListenerAttached = false;
+
+function ensureTokenRefreshListener(): void {
+  if (tokenRefreshListenerAttached) {
+    return;
+  }
+  const win = getNativeWindow();
+  if (!win) {
+    return;
+  }
+  win.addEventListener(TOKEN_REFRESH_RESULT_EVENT, (event: Event) => {
+    const detail = (event as CustomEvent<{ id?: string; ok?: boolean }>).detail;
+    if (!detail?.id) {
+      return;
+    }
+    const pending = pendingTokenRefreshes.get(detail.id);
+    if (!pending) {
+      return;
+    }
+    pendingTokenRefreshes.delete(detail.id);
+    window.clearTimeout(pending.timeout);
+    if (detail.ok) {
+      pending.resolve();
+    } else {
+      pending.reject();
+    }
+  });
+  tokenRefreshListenerAttached = true;
+}
+
+export function requestNativeTokenRefresh(): Promise<void> | null {
+  const channel = getNativeWindow()?.[CHANNEL_NAME];
+  if (!channel) {
+    return null;
+  }
+  ensureTokenRefreshListener();
+  const id = `refresh_${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+  return new Promise<void>((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      pendingTokenRefreshes.delete(id);
+      reject();
+    }, 15_000);
+    pendingTokenRefreshes.set(id, { resolve, reject, timeout });
+    try {
+      channel.postMessage(
+        JSON.stringify({ type: 'token_refresh', payload: { id } })
+      );
+    } catch {
+      window.clearTimeout(timeout);
+      pendingTokenRefreshes.delete(id);
+      reject();
+    }
+  });
 }
 
 export function onNativeNavigateRequest(

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -8,6 +8,7 @@
 const CHANNEL_NAME = 'OneDayOneStreakNative';
 const NAVIGATE_EVENT = 'native:navigate';
 const MODAL_RESULT_EVENT = 'native:modal_result';
+const POPUP_RESULT_EVENT = 'native:popup_result';
 const TOKEN_REFRESH_RESULT_EVENT = 'native:token_refresh_result';
 const NATIVE_OAUTH_MARKER = '1d1s:native-oauth';
 
@@ -46,6 +47,30 @@ export interface NativeModalOpenPayload {
   buttons: NativeModalButton[];
 }
 
+// 메인 이벤트 팝업 한 장. 서버 ActivePopup 과 같은 모양.
+export interface NativePopupSpec {
+  popupKey: string;
+  imageUrl: string;
+  ctaText: string;
+  linkUrl: string;
+}
+
+export interface NativePopupOpenPayload {
+  id: string;
+  // 노출 대상 전체를 한 번에 넘긴다. 2장 이상이면 네이티브가 3초 간격으로
+  // 순환시킨다 (웹 HomePopup 과 같은 규칙).
+  popups: NativePopupSpec[];
+}
+
+// 사용자가 팝업에서 무엇을 했는지. dismiss(밖 클릭/시스템 백) 는 'close'.
+export type NativePopupAction = 'cta' | 'dismissForever' | 'close';
+
+export interface NativePopupOutcome {
+  action: NativePopupAction;
+  // 액션 시점에 보이던 팝업. 캐러셀이 돌므로 첫 장과 다를 수 있다.
+  popupKey: string;
+}
+
 export type NativeMessage =
   | { type: 'auth_state'; payload: NativeAuthPayload }
   | { type: 'nav_state'; payload: NativeNavPayload }
@@ -62,7 +87,9 @@ export type NativeMessage =
   | { type: 'logout' }
   // 네이티브 다이얼로그 노출 요청. 응답은 native:modal_result CustomEvent
   // 로 비동기 도착. openNativeModal() 헬퍼가 id 매칭으로 Promise 화 한다.
-  | { type: 'modal_open'; payload: NativeModalOpenPayload };
+  | { type: 'modal_open'; payload: NativeModalOpenPayload }
+  // 네이티브 이벤트 팝업 노출 요청. 응답은 native:popup_result CustomEvent.
+  | { type: 'popup_open'; payload: NativePopupOpenPayload };
 
 interface NativeChannel {
   postMessage(payload: string): void;
@@ -246,6 +273,71 @@ function generateModalId(): string {
  * resolve 된다. 네이티브 쉘이 아닌 일반 브라우저에서는 즉시 `null` 을
  * resolve 해, 호출자는 자체 fallback 다이얼로그를 띄우면 된다.
  */
+// 메인 이벤트 팝업을 네이티브 쉘에 위임한다. 웹 다이얼로그는 WebView 안에
+// 갇혀 네이티브 헤더/바텀바를 덮지 못하므로, 앱에서는 네이티브가 그린다.
+//
+// 네이티브 쉘이 아니거나(브라우저) 쉘이 이 메시지를 모르는 구버전이면
+// null 을 resolve 한다 → 호출자는 웹 팝업을 그대로 띄우면 된다.
+const pendingNativePopups = new Map<
+  string,
+  (value: NativePopupOutcome | null) => void
+>();
+let popupResultListenerAttached = false;
+
+function ensurePopupResultListener(): void {
+  if (popupResultListenerAttached) {
+    return;
+  }
+  const win = getNativeWindow();
+  if (!win) {
+    return;
+  }
+  win.addEventListener(POPUP_RESULT_EVENT, (event: Event) => {
+    const detail = (
+      event as CustomEvent<{
+        id?: string;
+        action?: NativePopupAction | null;
+        popupKey?: string | null;
+      }>
+    ).detail;
+    if (!detail?.id) {
+      return;
+    }
+    const resolver = pendingNativePopups.get(detail.id);
+    if (!resolver) {
+      return;
+    }
+    pendingNativePopups.delete(detail.id);
+    // action 이 없으면 dismiss — 그냥 닫기로 읽는다.
+    resolver(
+      detail.action && detail.popupKey
+        ? { action: detail.action, popupKey: detail.popupKey }
+        : { action: 'close', popupKey: '' }
+    );
+  });
+  popupResultListenerAttached = true;
+}
+
+// 타임아웃은 두지 않는다. 결과는 사용자가 버튼을 누를 때 오므로 몇 초 안에
+// 온다는 보장이 없고, 성급히 null 로 떨어뜨리면 네이티브 팝업이 떠 있는 채로
+// 웹 팝업까지 겹쳐 뜬다. popup_open 을 모르는 구버전 쉘에서는 이벤트 팝업이
+// 뜨지 않는데(기능 손실이지 오동작은 아니다), 웹과 앱을 같이 배포하면 된다.
+// openNativeModal 도 같은 약속이다.
+export function openNativePopup(
+  popups: NativePopupSpec[]
+): Promise<NativePopupOutcome | null> {
+  const win = getNativeWindow();
+  if (!win?.[CHANNEL_NAME]) {
+    return Promise.resolve(null);
+  }
+  ensurePopupResultListener();
+  const id = generateModalId();
+  return new Promise<NativePopupOutcome | null>((resolve) => {
+    pendingNativePopups.set(id, resolve);
+    postNativeMessage({ type: 'popup_open', payload: { id, popups } });
+  });
+}
+
 export function openNativeModal(
   options: Omit<NativeModalOpenPayload, 'id'>
 ): Promise<string | null> {

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -83,6 +83,27 @@ export interface NativeDatePickerPayload {
   disabled?: string[];
 }
 
+// 스토리 한 장. 시간 라벨은 웹이 미리 계산해 보낸다 — 상대 시간 규칙을
+// 네이티브에 복제하지 않기 위해.
+export interface NativeStoryItem {
+  diaryId: number;
+  title: string;
+  thumbnail: string | null;
+  timeLabel: string;
+  unread: boolean;
+}
+
+export interface NativeStoryGroup {
+  userName: string;
+  profileImage: string | null;
+  stories: NativeStoryItem[];
+}
+
+export interface NativeStoryOpenPayload {
+  startGroup: number;
+  groups: NativeStoryGroup[];
+}
+
 export type NativeMessage =
   | { type: 'auth_state'; payload: NativeAuthPayload }
   | { type: 'nav_state'; payload: NativeNavPayload }
@@ -105,7 +126,10 @@ export type NativeMessage =
   // 네이티브 이미지 뷰어(라이트박스). 결과 회신 없음 — fire-and-forget.
   | { type: 'image_viewer_open'; payload: { urls: string[]; index: number } }
   // 네이티브 날짜 피커. 응답은 native:date_result CustomEvent.
-  | { type: 'date_picker_open'; payload: NativeDatePickerPayload };
+  | { type: 'date_picker_open'; payload: NativeDatePickerPayload }
+  // 네이티브 스토리 뷰어. 진행/이동/닫기는 네이티브가 처리하고, 읽음
+  // 처리용 native:story_viewed 이벤트만 웹으로 돌아온다.
+  | { type: 'story_open'; payload: NativeStoryOpenPayload };
 
 interface NativeChannel {
   postMessage(payload: string): void;
@@ -376,6 +400,41 @@ function ensureDateResultListener(): void {
  * 잘리고 네이티브 헤더도 못 가린다. 선택하면 'YYYY-MM-DD', dismiss 면
  * null. 네이티브 쉘이 아니면(브라우저) null — 호출자가 웹 피커로 폴백.
  */
+/**
+ * 스토리 뷰어를 네이티브 쉘에 위임한다. 뷰어 UI(진행바/자동 전환/이동/
+ * 일지 보기)는 전부 네이티브가 그리고, 웹은 읽음 처리 이벤트만 받는다.
+ * 채널이 없거나 구버전 쉘이면 false — 호출자는 웹 뷰어로 폴백.
+ */
+export function openNativeStoryViewer(
+  payload: NativeStoryOpenPayload
+): boolean {
+  const win = getNativeWindow();
+  if (!win?.[CHANNEL_NAME] || !hasNativeFeature('storyViewer')) {
+    return false;
+  }
+  postNativeMessage({ type: 'story_open', payload });
+  return true;
+}
+
+/** 네이티브 스토리 뷰어가 보내는 "이 일지를 봤다" 이벤트 구독. */
+export function onNativeStoryViewed(
+  handler: (diaryId: number) => void
+): () => void {
+  const win = getNativeWindow();
+  if (!win) {
+    return () => {};
+  }
+  const listener = (event: Event): void => {
+    const detail = (event as CustomEvent<{ diaryId?: number }>).detail;
+    if (typeof detail?.diaryId === 'number') {
+      handler(detail.diaryId);
+    }
+  };
+  win.addEventListener('native:story_viewed', listener);
+  return () => win.removeEventListener('native:story_viewed', listener);
+}
+
+
 /** 현재 쉘이 날짜 피커 위임을 지원하는지. 오버레이 렌더 여부 판정용. */
 export function isNativeDatePickerAvailable(): boolean {
   return (

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -89,7 +89,9 @@ export type NativeMessage =
   // 로 비동기 도착. openNativeModal() 헬퍼가 id 매칭으로 Promise 화 한다.
   | { type: 'modal_open'; payload: NativeModalOpenPayload }
   // 네이티브 이벤트 팝업 노출 요청. 응답은 native:popup_result CustomEvent.
-  | { type: 'popup_open'; payload: NativePopupOpenPayload };
+  | { type: 'popup_open'; payload: NativePopupOpenPayload }
+  // 네이티브 이미지 뷰어(라이트박스). 결과 회신 없음 — fire-and-forget.
+  | { type: 'image_viewer_open'; payload: { urls: string[]; index: number } };
 
 interface NativeChannel {
   postMessage(payload: string): void;
@@ -316,6 +318,19 @@ function ensurePopupResultListener(): void {
     );
   });
   popupResultListenerAttached = true;
+}
+
+/**
+ * 이미지 뷰어(라이트박스)를 네이티브 쉘에 위임한다. 웹 오버레이는 WebView
+ * 안에 갇혀 네이티브 헤더를 덮지 못한다. 채널이 없으면(브라우저) false 를
+ * 반환하고, 호출자는 자체 웹 오버레이를 연다.
+ */
+export function openNativeImageViewer(urls: string[], index: number): boolean {
+  if (!getNativeWindow()?.[CHANNEL_NAME]) {
+    return false;
+  }
+  postNativeMessage({ type: 'image_viewer_open', payload: { urls, index } });
+  return true;
 }
 
 // 타임아웃은 두지 않는다. 결과는 사용자가 버튼을 누를 때 오므로 몇 초 안에

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -9,6 +9,7 @@ const CHANNEL_NAME = 'OneDayOneStreakNative';
 const NAVIGATE_EVENT = 'native:navigate';
 const MODAL_RESULT_EVENT = 'native:modal_result';
 const POPUP_RESULT_EVENT = 'native:popup_result';
+const DATE_RESULT_EVENT = 'native:date_result';
 const TOKEN_REFRESH_RESULT_EVENT = 'native:token_refresh_result';
 const NATIVE_OAUTH_MARKER = '1d1s:native-oauth';
 
@@ -71,6 +72,17 @@ export interface NativePopupOutcome {
   popupKey: string;
 }
 
+// 날짜는 전부 'YYYY-MM-DD' 로컬 날짜 문자열. Date 를 직렬화하면 타임존에
+// 따라 하루가 밀린다.
+export interface NativeDatePickerPayload {
+  id: string;
+  value?: string;
+  min?: string;
+  max?: string;
+  // [min, max] 안에서 개별적으로 막을 날짜 (예: 이미 일지를 쓴 날).
+  disabled?: string[];
+}
+
 export type NativeMessage =
   | { type: 'auth_state'; payload: NativeAuthPayload }
   | { type: 'nav_state'; payload: NativeNavPayload }
@@ -91,7 +103,9 @@ export type NativeMessage =
   // 네이티브 이벤트 팝업 노출 요청. 응답은 native:popup_result CustomEvent.
   | { type: 'popup_open'; payload: NativePopupOpenPayload }
   // 네이티브 이미지 뷰어(라이트박스). 결과 회신 없음 — fire-and-forget.
-  | { type: 'image_viewer_open'; payload: { urls: string[]; index: number } };
+  | { type: 'image_viewer_open'; payload: { urls: string[]; index: number } }
+  // 네이티브 날짜 피커. 응답은 native:date_result CustomEvent.
+  | { type: 'date_picker_open'; payload: NativeDatePickerPayload };
 
 interface NativeChannel {
   postMessage(payload: string): void;
@@ -101,7 +115,10 @@ interface NativeWindow extends Window {
   [CHANNEL_NAME]?: NativeChannel;
   __IS_NATIVE_APP__?: boolean;
   __NATIVE_NAV__?(path: string): void;
+  // 쉘 빌드가 처리 가능한 브릿지 메시지 플래그. injectHandshake 가 세운다.
+  __1D1S_FEATURES__?: Partial<Record<string, boolean>>;
 }
+
 
 function getNativeWindow(): NativeWindow | null {
   if (typeof window === 'undefined') {
@@ -109,6 +126,12 @@ function getNativeWindow(): NativeWindow | null {
   }
   return window as NativeWindow;
 }
+// 메시지를 모르는 구버전 쉘에 요청을 보내면 응답을 영영 기다리는 죽은
+// 컨트롤이 된다. 응답이 필요한 새 위임은 이 플래그를 먼저 확인한다.
+function hasNativeFeature(name: string): boolean {
+  return getNativeWindow()?.__1D1S_FEATURES__?.[name] === true;
+}
+
 
 export function postNativeMessage(message: NativeMessage): void {
   const win = getNativeWindow();
@@ -318,6 +341,61 @@ function ensurePopupResultListener(): void {
     );
   });
   popupResultListenerAttached = true;
+}
+
+// 날짜 피커 응답 대기 큐. modal/popup 과 같은 pending-Map 패턴.
+const pendingNativeDates = new Map<string, (value: string | null) => void>();
+let dateResultListenerAttached = false;
+
+function ensureDateResultListener(): void {
+  if (dateResultListenerAttached) {
+    return;
+  }
+  const win = getNativeWindow();
+  if (!win) {
+    return;
+  }
+  win.addEventListener(DATE_RESULT_EVENT, (event: Event) => {
+    const detail = (
+      event as CustomEvent<{ id?: string; value?: string | null }>
+    ).detail;
+    if (!detail?.id) {
+      return;
+    }
+    const resolver = pendingNativeDates.get(detail.id);
+    if (resolver) {
+      pendingNativeDates.delete(detail.id);
+      resolver(detail.value ?? null);
+    }
+  });
+  dateResultListenerAttached = true;
+}
+
+/**
+ * 날짜 피커를 네이티브 쉘에 위임한다. 웹 캘린더 시트는 WebView 안에 갇혀
+ * 잘리고 네이티브 헤더도 못 가린다. 선택하면 'YYYY-MM-DD', dismiss 면
+ * null. 네이티브 쉘이 아니면(브라우저) null — 호출자가 웹 피커로 폴백.
+ */
+/** 현재 쉘이 날짜 피커 위임을 지원하는지. 오버레이 렌더 여부 판정용. */
+export function isNativeDatePickerAvailable(): boolean {
+  return (
+    getNativeWindow()?.[CHANNEL_NAME] != null && hasNativeFeature('datePicker')
+  );
+}
+
+export function openNativeDatePicker(
+  options: Omit<NativeDatePickerPayload, 'id'>
+): Promise<string | null> | null {
+  const win = getNativeWindow();
+  if (!win?.[CHANNEL_NAME] || !hasNativeFeature('datePicker')) {
+    return null;
+  }
+  ensureDateResultListener();
+  const id = generateModalId();
+  return new Promise<string | null>((resolve) => {
+    pendingNativeDates.set(id, resolve);
+    postNativeMessage({ type: 'date_picker_open', payload: { id, ...options } });
+  });
 }
 
 /**

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -135,6 +135,22 @@
   html[data-native-app='true'] .native-only {
     display: revert !important;
   }
+
+  /* 숨겨진 웹 헤더를 전제로 잡혀 있던 상단 여백 제거. 네이티브 헤더가
+     이미 그 공간을 차지하므로 py-*/mt-* 의 top 만 0 으로 누른다. */
+  html[data-native-app='true']
+    :is([data-native-flush-top], .native-flush-top) {
+    padding-top: 0 !important;
+    margin-top: 0 !important;
+  }
+
+  /* 챌린지 보드: 네이티브 검색 바(58px)가 body 최상단에 오버레이로 얹힌다.
+     kept sticky 래퍼(필터)를 그 아래로 내리고, 스크롤 시에도 바 아래에
+     붙게 sticky 오프셋을 같이 민다. Flutter kBoardSearchRowHeight 와 짝. */
+  html[data-native-app='true'] [data-native-search-offset] {
+    margin-top: 58px;
+    top: 58px !important;
+  }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */
   .h-14-safe {
     height: calc(3.5rem + env(safe-area-inset-top));

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -125,6 +125,16 @@
   html[data-native-app='true'] [data-native-top-0] {
     top: 0 !important;
   }
+
+  /* 네이티브 쉘에서만 보이는 요소. 숨겨지는 웹 헤더 안의 액션(알림의
+     "모두 읽음" 등) 을 본문으로 옮겨 네이티브에서만 노출할 때 쓴다.
+     revert 는 UA 기본 display 로 되돌린다 (div→block, button→inline-block). */
+  .native-only {
+    display: none !important;
+  }
+  html[data-native-app='true'] .native-only {
+    display: revert !important;
+  }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */
   .h-14-safe {
     height: calc(3.5rem + env(safe-area-inset-top));

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -137,7 +137,7 @@
   }
 
   /* 숨겨진 웹 헤더를 전제로 잡혀 있던 상단 여백 제거. 네이티브 헤더가
-     이미 그 공간을 차지하므로 py-*/mt-* 의 top 만 0 으로 누른다. */
+     이미 그 공간을 차지하므로 py-* / mt-* 의 top 만 0 으로 누른다. */
   html[data-native-app='true']
     :is([data-native-flush-top], .native-flush-top) {
     padding-top: 0 !important;

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -144,12 +144,11 @@
     margin-top: 0 !important;
   }
 
-  /* 챌린지 보드: 네이티브 검색 바(58px)가 body 최상단에 오버레이로 얹힌다.
-     kept sticky 래퍼(필터)를 그 아래로 내리고, 스크롤 시에도 바 아래에
-     붙게 sticky 오프셋을 같이 민다. Flutter kBoardSearchRowHeight 와 짝. */
-  html[data-native-app='true'] [data-native-search-offset] {
-    margin-top: 58px;
-    top: 58px !important;
+  /* 챌린지 보드: 네이티브 툴바(검색+필터, 194px)가 body 최상단 오버레이로
+     얹힌다. 첫 콘텐츠를 그 아래로 내린다. Flutter
+     kChallengeToolbarHeight 와 짝 — 바꾸면 같이 바꿀 것. */
+  html[data-native-app='true'] [data-native-toolbar-offset] {
+    margin-top: 194px !important;
   }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */
   .h-14-safe {

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -111,8 +111,10 @@
   }
 
   /* 네이티브에서 강제 숨김 마커. 헤더 외 임의 요소(인라인 버튼, 푸터,
-     PWA 프롬프트 등) 에 부착해 isNativeApp 분기를 JS 없이도 처리한다. */
-  html[data-native-app='true'] [data-native-hide] {
+     PWA 프롬프트 등) 에 부착해 isNativeApp 분기를 JS 없이도 처리한다.
+     data 속성을 못 받는 컴포넌트(className 만 뚫려 있는 경우) 는
+     `.native-hide` 클래스를 쓴다. */
+  html[data-native-app='true'] :is([data-native-hide], .native-hide) {
     display: none !important;
   }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -117,6 +117,14 @@
   html[data-native-app='true'] :is([data-native-hide], .native-hide) {
     display: none !important;
   }
+
+  /* 숨겨진 웹 헤더 높이를 보정하던 sticky 오프셋 마커. `top-14` 처럼 자기
+     위의 모바일 헤더(h-14, data-native-hide) 높이만큼 내려 붙는 요소는
+     네이티브에서 그 헤더가 사라지므로 56px 아래 허공에 붙는다 — 챌린지
+     상세 탭바가 그랬다. 이 마커를 달면 네이티브에서 top:0 으로 당겨진다. */
+  html[data-native-app='true'] [data-native-top-0] {
+    top: 0 !important;
+  }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */
   .h-14-safe {
     height: calc(3.5rem + env(safe-area-inset-top));

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -145,10 +145,11 @@
   }
 
   /* 챌린지 보드: 네이티브 툴바(검색+필터, 194px)가 body 최상단 오버레이로
-     얹힌다. 첫 콘텐츠를 그 아래로 내린다. Flutter
-     kChallengeToolbarHeight 와 짝 — 바꾸면 같이 바꿀 것. */
+     얹힌다. 첫 콘텐츠를 그 아래로 내린다. 불변식:
+     offset = 툴바높이(Flutter kChallengeToolbarHeight = 194) + 12 clearance
+     = 206. 툴바 높이가 바뀌면 이 값도 같이 바꿀 것. */
   html[data-native-app='true'] [data-native-toolbar-offset] {
-    margin-top: 194px !important;
+    margin-top: 206px !important;
   }
   /* h-14 (3.5rem) 컨텐츠 높이는 유지하면서 노치 영역만큼 위로 확장 */
   .h-14-safe {

--- a/src/app/(auth)/login/oauth2/code/[provider]/page.tsx
+++ b/src/app/(auth)/login/oauth2/code/[provider]/page.tsx
@@ -5,6 +5,7 @@ import { OAuthProvider } from '@feature/auth/type/auth';
 import { MEMBER_QUERY_KEYS } from '@feature/member/consts/queryKeys';
 import { NotificationOptInPrompt } from '@feature/notification/components/NotificationOptInPrompt';
 import { authStorage } from '@module/utils/auth';
+import { consumeNativeOAuth } from '@module/utils/nativeBridge';
 import { RETURN_TO_PARAM, returnToStorage } from '@module/utils/returnTo';
 import { useQueryClient } from '@tanstack/react-query';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
@@ -50,6 +51,20 @@ function OAuthCallbackContent(): React.ReactElement {
 
     if (isSuccess) {
       processed.current = true;
+      const nativeCodeChallenge = consumeNativeOAuth();
+      if (nativeCodeChallenge) {
+        const nativeLoginCode = data?.data?.nativeLoginCode;
+        if (!nativeLoginCode) {
+          processed.current = false;
+          console.error('[OAuth] 앱 로그인 코드가 응답에 없습니다.');
+          router.replace('/login');
+          return;
+        }
+        const callback = new URL('onedayonestreak://auth/callback');
+        callback.searchParams.set('code', nativeLoginCode);
+        window.location.replace(callback.toString());
+        return;
+      }
       authStorage.markAuthenticated();
       returnToRef.current = returnToStorage.consume();
       // 로그인 전 null로 캐시된 사이드바 무효화 → 홈에서 즉시 리페치

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import {
 } from '@module/metadata/seo';
 import { AppProviders } from '@module/providers';
 import { cn } from '@module/utils/cn';
+import { NATIVE_APP_INIT_SCRIPT } from '@module/utils/nativeAppScript';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata, Viewport } from 'next';
 
@@ -81,22 +82,17 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }): React.ReactElement {
-  // 네이티브 앱 감지는 클라이언트 `useIsNativeApp`(AppLayoutShell) 이
-  // 단독으로 수행한다: window.__IS_NATIVE_APP__ / JS 채널 / navigator.userAgent
-  // (서버와 동일한 `1D1S-App` UA 토큰) 를 읽어 correctness 를 완결한다.
-  //
-  // 과거엔 SSR 에서 headers() 로 UA 를 읽어 `data-native-app` 을 미리 세팅했지만,
-  // headers() 는 Dynamic API 라 루트 레이아웃이 앱 전체 route 를 dynamic 렌더로
-  // 강제했다 → `<Link>` 가 데이터까지 prefetch 하지 못하고 이동마다 RSC 를
-  // 다시 받아오는 "매번 로딩" 의 근본 원인. 이를 제거해 route 를 정적
-  // prefetch 가능 상태로 되돌린다.
-  //
-  // 트레이드오프: `data-native-app` 초기값이 항상 "false" 라, 네이티브 쉘
-  // 사용자는 하드 로드(콜드) 첫 페인트에서 웹 chrome(sticky 헤더 등)을 한
-  // 프레임 볼 수 있다. 하이드레이션 직후 AppLayoutShell 의 useEffect 가
-  // 속성을 다시 세팅해 즉시 사라진다(SPA 이동에는 영향 없음).
+  // 네이티브 앱 감지는 <head> 의 blocking inline script 가 첫 페인트 전에
+  // 확정한다. headers() 를 쓰면 루트 레이아웃이 dynamic 렌더로 강제돼
+  // `<Link>` prefetch 가 죽으므로(= "이동마다 로딩") 서버 UA 판정은 쓰지
+  // 않는다. 스크립트는 정적 HTML 에 그대로 실려 나가므로 route 는 정적
+  // prefetch 가능 상태를 유지하면서도 chrome 가시성은 페인트 시점에 이미
+  // 결정돼 있다. 하이드레이션 이후 토글되는 값이 아니라 시프트가 없다.
   return (
     <html lang="ko" data-native-app="false">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: NATIVE_APP_INIT_SCRIPT }} />
+      </head>
       <body
         className={cn(
           pretendard.variable,


### PR DESCRIPTION
develop → main 프로덕션 승격. (BRANCH_RELEASE_POLICY: Create a merge commit)

## 포함 커밋 (develop에만 있고 prod엔 없던 전체)
- a5fd9d9 fix: 타인 일지 상세에서 달성한 목표가 미달성으로 표시되는 문제 수정
- ad4d1d5 fix: 애플 웹 로그인 요청 body를 확정 서버 계약에 정합
- cd8e891 feat: Sign in with Apple(웹) 로그인 추가
- 1e7d65c chore: ws 8.21.1 업데이트로 메모리 고갈 DoS 취약점 해결 (dependabot #124)
- bbd4463 feat: 스토리 카드 축소(112x140) 및 읽음/안읽음 테두리 대비 강화
- 7a48042 fix: 챌린지 보드 필터 툴바와 카드 겹침 해소 (offset 194->206)
- 0618ef4 fix: 게스트 홈 로딩 시 로그인 스켈레톤 대신 게스트 CTA 표시
- e9a6c74 fix: 주석 내 '*/' 조기 종료로 인한 Turbopack CSS 파싱 오류 수정
- e48c52b refactor: 렌더 최적화 및 오해 주석 정정 (동작 불변)
- b689b53 chore: 미사용 react-day-picker 직접 의존성 제거 및 lockfile 동기화
- 9ea5cc6 fix: Pretendard 폰트 굵기 매핑 정정 및 미사용 Light(300) 제거
- 1732f00 perf: posthog-js 지연 로드 + 초기 이벤트 큐잉으로 초기 번들 축소
- d82f1fe perf: 일지 카드 화면 밖 content-visibility 로 스크롤 렌더 비용 절감
- 878b31a fix: 마이페이지 skeleton 의 액션 행도 네이티브에서 숨김
- f889c59 feat: 챌린지 보드 검색/필터를 네이티브 툴바로 통합
- 62ac5b0 feat: 스토리 뷰어 네이티브 위임, 네이티브 쉘 상단 여백/검색 오프셋 정리
- 697cec9 feat: 챌린지 검색 브릿지 연결, 알림 모두 읽음 네이티브 노출
- e8c264d feat: 날짜 피커를 네이티브 쉘에 위임
- 2aacd8a fix: 네이티브 쉘의 스켈레톤 백버튼/이미지 뷰어/저장 버튼 정리
- ac5bc39 fix: 네이티브 앱에서 챌린지 상세 탭바가 56px 아래에 붙던 문제
- cb67a1c fix: 네이티브 쉘의 로그아웃/팝업/헤더/필터 어긋남 정리
- 2edbb50 fix: 챌린지 일지 목록의 게스트 처리
- 37d95ef fix: 네이티브 쉘 chrome 가시성을 첫 페인트 전에 확정 (#234)
- bc24401 Merge pull request #233 (hybrid-native-auth)
- 1812ae3 feat: support hybrid app authentication
- 94f2b87 Merge pull request #232 from 1D1S/main

## 주의: Sign in with Apple(웹)은 prod에서 dormant
- NEXT_PUBLIC_APPLE_CLIENT_ID / _REDIRECT_URI 미설정 시 getAppleAuthConfig()가 null → AppleLoginButton이 null 렌더(버튼 숨김).
- Apple SDK는 버튼 클릭 시에만 lazy 로드 → 버튼이 없으면 SDK도 로드 안 됨. env 값 주입 전까지 완전 비활성.

develop CI green 확인 후 승격.
