### PR TITLE
release: develop → main 승격 (스토리 감정 표시 수정)

### DIFF
--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -5,11 +5,13 @@ import EmptyState from '@component/EmptyState';
 import FadeInImage from '@component/FadeInImage';
 import { cn } from '@module/utils/cn';
 import { resolveDiaryImageUrl } from '@module/utils/diaryImageUrl';
-import Image from 'next/image';
 import React from 'react';
 
 import { StoryGroup } from '../type/story';
-import { isGroupAllSeen } from '../utils/storyHelpers';
+import {
+  getStoryPreviewThumbnail,
+  isGroupAllSeen,
+} from '../utils/storyHelpers';
 
 interface StoryRingProps {
   groups: StoryGroup[];
@@ -18,19 +20,15 @@ interface StoryRingProps {
   onAddStory?(): void;
 }
 
-interface StoryMood {
-  src: string;
-  alt: string;
-  tint: string;
-}
+// 카드 배경 틴트 — 감정과 무관한 장식(사용자별 고정 파스텔).
+// 과거엔 userId 해시로 감정 얼굴(happy/soso/sad)까지 임의 배정해, 작성자가
+// 고른 실제 감정(상세는 정상)과 어긋나 보였다. 스토리 응답엔 feeling 이 없어
+// 실제 감정을 그릴 수 없으므로, 감정 얼굴을 제거하고 실제 일지 썸네일을 쓴다.
+const CARD_TINTS = ['bg-[#c9f1e7]', 'bg-[#e6f1ff]', 'bg-[#fff1c8]'] as const;
 
-// 감정(무드) 아이콘은 API 에 실제 감정 필드가 없어 userId 로 고정 배정한다.
-// 같은 사용자는 항상 같은 무드/틴트를 받는다(장식 목적).
-const STORY_MOODS: StoryMood[] = [
-  { src: '/images/mood-happy.svg', alt: '행복한 얼굴', tint: 'bg-[#c9f1e7]' },
-  { src: '/images/mood-soso.svg', alt: '무표정 얼굴', tint: 'bg-[#e6f1ff]' },
-  { src: '/images/mood-sad.svg', alt: '슬픈 얼굴', tint: 'bg-[#fff1c8]' },
-];
+function pickCardTint(userId: number): string {
+  return CARD_TINTS[Math.abs(userId) % CARD_TINTS.length];
+}
 
 // next/image 는 절대 URL 또는 / 시작 상대 경로만 허용한다.
 function isValidNextImageSrc(src: string | undefined): src is string {
@@ -41,10 +39,6 @@ function isValidNextImageSrc(src: string | undefined): src is string {
     return true;
   }
   return /^(https?:|data:|blob:)/i.test(src);
-}
-
-function pickStoryMood(userId: number): StoryMood {
-  return STORY_MOODS[Math.abs(userId) % STORY_MOODS.length];
 }
 
 // 사각형 스토리 카드(112x140). 무드 이미지를 크게 중앙에 두고 그 아래
@@ -120,7 +114,9 @@ function StoryRing({
         const profileUrl =
           resolveDiaryImageUrl(group.profileImage) ?? undefined;
         const name = group.userName?.trim() || `친구 ${group.userId}`;
-        const mood = pickStoryMood(group.userId);
+        const tint = pickCardTint(group.userId);
+        const previewUrl =
+          resolveDiaryImageUrl(getStoryPreviewThumbnail(group)) ?? undefined;
 
         return (
           <button
@@ -135,18 +131,28 @@ function StoryRing({
               seen
                 ? 'border-2 border-gray-200'
                 : 'border-main-500 border-[3px]',
-              mood.tint
+              tint
             )}
           >
-            {/* 무드 SVG는 정적 에셋이라 Next 이미지 최적화 없이 서빙한다. */}
-            <Image
-              src={mood.src}
-              alt={mood.alt}
-              width={44}
-              height={44}
-              className="h-11 w-11"
-              unoptimized
-            />
+            {/* 실제 일지 썸네일(감정과 무관한 실제 콘텐츠). 없으면 중립
+                placeholder — 잘못된 감정 얼굴을 그리지 않는다. */}
+            <span
+              className={cn(
+                'relative flex h-11 w-11 items-center justify-center',
+                'overflow-hidden rounded-[12px] bg-white/70'
+              )}
+              aria-hidden
+            >
+              {isValidNextImageSrc(previewUrl) ? (
+                <FadeInImage
+                  src={previewUrl}
+                  alt=""
+                  fill
+                  sizes="44px"
+                  className="object-cover"
+                />
+              ) : null}
+            </span>
             <span
               className={cn(
                 'relative flex h-9 w-9 items-center justify-center',

--- a/src/app.feature/stories/utils/storyHelpers.test.ts
+++ b/src/app.feature/stories/utils/storyHelpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StoryGroup } from '../type/story';
+import { getStoryPreviewThumbnail } from './storyHelpers';
+
+function makeGroup(overrides: Partial<StoryGroup>): StoryGroup {
+  return {
+    userId: 3,
+    userName: '친구',
+    profileImage: null,
+    stories: [],
+    ...overrides,
+  };
+}
+
+describe('getStoryPreviewThumbnail', () => {
+  it('그룹 최신 스토리의 실제 일지 썸네일을 돌려준다(감정/유저 해시 아님)', () => {
+    const group = makeGroup({
+      userId: 3, // 과거엔 이 값 % 3 으로 감정 얼굴을 임의 배정했다.
+      stories: [
+        {
+          diaryId: 10,
+          diaryTitle: '오늘의 일지',
+          diaryThumbnail: 'https://cdn.example.com/thumb.jpg',
+          createdAt: '2026-07-21T09:00:00',
+          hasUnreadJournal: true,
+        },
+      ],
+    });
+
+    expect(getStoryPreviewThumbnail(group)).toBe(
+      'https://cdn.example.com/thumb.jpg'
+    );
+  });
+
+  it('썸네일이 없거나 스토리가 비면 null (감정 얼굴로 대체하지 않는다)', () => {
+    expect(getStoryPreviewThumbnail(makeGroup({ stories: [] }))).toBeNull();
+    expect(
+      getStoryPreviewThumbnail(
+        makeGroup({
+          stories: [
+            {
+              diaryId: 1,
+              diaryTitle: '',
+              diaryThumbnail: null,
+              createdAt: '2026-07-21T09:00:00',
+              hasUnreadJournal: false,
+            },
+          ],
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/src/app.feature/stories/utils/storyHelpers.ts
+++ b/src/app.feature/stories/utils/storyHelpers.ts
@@ -17,6 +17,18 @@ export function isGroupAllSeen(group: StoryGroup): boolean {
   return group.stories.every((story) => !story.hasUnreadJournal);
 }
 
+// 스토리 카드 미리보기 이미지 = 그룹의 (정렬 후) 최신 스토리의 실제 일지
+// 썸네일. 감정과 무관한 실제 콘텐츠다.
+//
+// 과거 StoryRing 은 스토리 응답에 feeling 이 없다는 이유로 userId 해시로
+// 감정 얼굴(happy/soso/sad)을 임의 배정했다. 그 결과 작성자가 고른 실제
+// 감정(상세 화면은 정상)과 스토리의 감정 얼굴이 어긋나 "아주 좋음으로 썼는데
+// 스토리엔 안좋음"처럼 보였다. 스토리 응답엔 feeling 이 없어 실제 감정을 그릴
+// 수 없으므로, 잘못된 감정 대신 실제 썸네일을 노출한다.
+export function getStoryPreviewThumbnail(group: StoryGroup): string | null {
+  return group.stories[0]?.diaryThumbnail ?? null;
+}
+
 // createdAt(ISO) → epoch ms. 파싱 불가 시 0.
 // raw new Date(iso) 는 백엔드의 공백구분('YYYY-MM-DD HH:mm:ss')/마이크로초
 // 타임스탬프를 Safari/Firefox 에서 Invalid Date 로 만들어 정렬이 전부 0으로


### PR DESCRIPTION
develop → main 프로덕션 승격. (BRANCH_RELEASE_POLICY: Create a merge commit)

## 포함 커밋 (지난 승격 #235 / main=6787d20 이후 develop 신규분)
- 27fe871 fix: 스토리 카드가 userId 해시 감정 얼굴을 표시해 실제 감정과 어긋나던 문제 수정

스토리 링(StoryRing)이 스토리 응답에 feeling 이 없다는 이유로 userId % 3 해시로 감정 얼굴을 임의 배정해, 작성자가 고른 실제 감정(일지 상세는 정상)과 어긋나 보이던 문제를 수정. 감정 얼굴 대신 실제 일지 썸네일을 노출(없으면 중립 placeholder). 회귀 테스트 포함.

develop CI green(27fe871) 확인 후 승격.
