### PR TITLE
fix: improve native app QA flows

### DIFF
--- a/src/app.component/ImageCropDialog.tsx
+++ b/src/app.component/ImageCropDialog.tsx
@@ -10,10 +10,14 @@ import {
   Text,
 } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
+import {
+  isNativeModalAvailable,
+  openNativeModal,
+} from '@module/utils/nativeBridge';
 import { ImageIcon, Maximize2, Minimize2 } from 'lucide-react';
 import Image from 'next/image';
 import type { ReactElement, ReactNode } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   cropImageFile,
@@ -117,7 +121,7 @@ export function ImageCropDialog({
   outputSize,
   onOpenChange,
   onApply,
-}: ImageCropDialogProps): ReactElement {
+}: ImageCropDialogProps): ReactElement | null {
   const [previewUrl, setPreviewUrl] = useState('');
   const [mode, setMode] = useState<ImageCropMode>('cover');
   const [zoom, setZoom] = useState(1);
@@ -126,6 +130,8 @@ export function ImageCropDialog({
   const [backgroundColor, setBackgroundColor] = useState('#ffffff');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
+  const nativeRequestInFlight = useRef(false);
+  const nativeModalAvailable = isNativeModalAvailable();
   const previewOffsetFactor = mode === 'cover' ? 1 : zoom - 1;
   const imageTransform =
     `translate(${offsetX * 18 * previewOffsetFactor}%, ` +
@@ -156,6 +162,72 @@ export function ImageCropDialog({
     };
   }, [file]);
 
+  useEffect(() => {
+    if (!open) {
+      nativeRequestInFlight.current = false;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (
+      !open ||
+      !file ||
+      !nativeModalAvailable ||
+      nativeRequestInFlight.current
+    ) {
+      return;
+    }
+    nativeRequestInFlight.current = true;
+
+    void openNativeModal({
+      title,
+      message: '사진을 배너 비율에 맞추는 방식을 선택해 주세요.',
+      buttons: [
+        { label: '화면 채우기', value: 'cover' },
+        { label: '사진 전체 보기', value: 'contain' },
+        { label: '취소', value: 'cancel', style: 'cancel' },
+      ],
+    }).then(async (value) => {
+      if (value !== 'cover' && value !== 'contain') {
+        onOpenChange(false);
+        return;
+      }
+      setIsProcessing(true);
+      try {
+        const croppedFile = await cropImageFile(file, {
+          mode: value,
+          outputSize,
+          zoom: 1,
+          offsetX: 0,
+          offsetY: 0,
+          backgroundColor: '#ffffff',
+        });
+        onApply(croppedFile);
+        onOpenChange(false);
+      } catch {
+        setErrorMessage(
+          '이미지를 편집하지 못했습니다. 다른 사진을 선택해주세요.'
+        );
+        nativeRequestInFlight.current = false;
+        onOpenChange(false);
+      } finally {
+        setIsProcessing(false);
+      }
+    });
+  }, [
+    file,
+    nativeModalAvailable,
+    onApply,
+    onOpenChange,
+    open,
+    outputSize,
+    title,
+  ]);
+
+  if (nativeModalAvailable) {
+    return null;
+  }
+
   const handleApply = async (): Promise<void> => {
     if (!file || isProcessing) {
       return;
@@ -176,7 +248,9 @@ export function ImageCropDialog({
       onApply(croppedFile);
       onOpenChange(false);
     } catch {
-      setErrorMessage('이미지를 편집하지 못했습니다. 다른 사진을 선택해주세요.');
+      setErrorMessage(
+        '이미지를 편집하지 못했습니다. 다른 사진을 선택해주세요.'
+      );
     } finally {
       setIsProcessing(false);
     }

--- a/src/app.component/layout/SubPageShell.tsx
+++ b/src/app.component/layout/SubPageShell.tsx
@@ -38,13 +38,12 @@ export function SubPageShell({
   const handleBack = onBack ?? ((): void => router.back());
   return (
     <div className="min-h-screen w-full">
-      <MobileHeader
-        title={title}
-        onBack={handleBack}
-        right={headerAction}
-      />
+      <MobileHeader title={title} onBack={handleBack} right={headerAction} />
 
-      <section className="mx-auto w-full max-w-[980px] p-4 lg:p-6">
+      <section
+        data-native-subpage-content
+        className="mx-auto w-full max-w-[980px] p-4 lg:p-6"
+      >
         {/* 데스크탑 헤더 */}
         <header
           className={cn(
@@ -69,7 +68,9 @@ export function SubPageShell({
           {headerAction ? <div className="shrink-0">{headerAction}</div> : null}
         </header>
 
-        <div className="mt-6">{children}</div>
+        <div data-native-subpage-body className="mt-6">
+          {children}
+        </div>
       </section>
     </div>
   );

--- a/src/app.component/skeletons/SubPageRouteSkeleton.tsx
+++ b/src/app.component/skeletons/SubPageRouteSkeleton.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from '@component/Skeleton';
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+export function SubPageRouteSkeleton(): React.ReactElement {
+  return (
+    <div className="min-h-screen w-full bg-white">
+      <div
+        data-native-subpage-content
+        className="mx-auto w-full max-w-[980px] p-4 lg:p-6"
+      >
+        <div className="hidden border-b border-gray-200 pb-5 lg:block">
+          <Skeleton shape="text" className="h-8 w-36" />
+          <Skeleton shape="text" className="mt-2 h-4 w-60" />
+        </div>
+        <div
+          data-native-subpage-body
+          className={cn('mt-6 flex flex-col gap-3')}
+        >
+          <Skeleton shape="rounded" className="rounded-4 h-[88px] w-full" />
+          <Skeleton shape="rounded" className="rounded-4 h-[220px] w-full" />
+          <Skeleton shape="rounded" className="rounded-4 h-[160px] w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -15,6 +15,7 @@ import { useSafeBack } from '@module/hooks/useSafeBack';
 import { toast } from '@module/providers/toast';
 import { cn } from '@module/utils/cn';
 import { formatDateISO } from '@module/utils/date';
+import { requestNativePushRoute } from '@module/utils/nativeBridge';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import {
   ArrowLeft,
@@ -237,7 +238,6 @@ export function ChallengeDetailScreen({
     Math.round(
       Math.min(100, Math.max(0, detail?.participationRate ?? 0)) * 10
     ) / 10;
-
 
   const myStatus = detail?.myStatus ?? 'NONE';
   const isHost = myStatus === 'HOST';
@@ -757,8 +757,8 @@ export function ChallengeDetailScreen({
             {/* 메인 콘텐츠: 탭(소개 / 일지 / 참여자) */}
             <div className="flex min-w-0 flex-col">
               {/* 모바일에선 compact 헤더(h-14) 아래에 sticky 로 붙인다.
-                  네이티브 앱은 그 헤더를 숨기므로(data-native-hide) top-14
-                  가 허공을 가리킨다 — data-native-top-0 이 top:0 으로 보정. */}
+                  네이티브 앱은 웹 헤더 대신 Flutter compact 헤더를 오버레이하므로
+                  data-native-top-0 이 같은 56px 오프셋을 유지한다. */}
               <div
                 data-native-top-0
                 className={cn(
@@ -983,9 +983,12 @@ export function ChallengeDetailScreen({
                               goals={
                                 isFreeChallenge ? participant.goals : undefined
                               }
-                              onProfileClick={() =>
-                                router.push(`/member/${participant.memberId}`)
-                              }
+                              onProfileClick={() => {
+                                const path = `/member/${participant.memberId}`;
+                                if (!requestNativePushRoute(path)) {
+                                  router.push(path);
+                                }
+                              }}
                               onAccept={() =>
                                 handleAcceptParticipant(
                                   participant.participantId
@@ -1007,33 +1010,36 @@ export function ChallengeDetailScreen({
                     ) : null}
 
                     <ChallengeLeaderboardCard
-                    maxRows={PARTICIPANT_PREVIEW_SIZE}
-                    entries={previewParticipants.map((participant) => ({
-                      participantId: participant.participantId,
-                      memberId: participant.memberId,
-                      nickname: participant.nickname,
-                      profileImg: participant.profileImg,
-                      isHost: participant.status === 'HOST',
-                      // 고정 목표는 전원 공통이라 참여자별로 볼 의미가 없다.
-                      goals: isFreeChallenge ? participant.goals : undefined,
-                      rank: participant.rank,
-                      streak: participant.streak,
-                      completedGoalCount: participant.completedGoalCount,
-                    }))}
-                    totalCount={summaryParticipantCnt}
-                    onShowAll={() =>
-                      router.push(`/challenge/${id}/participants`)
-                    }
-                    onMemberClick={(memberId) =>
-                      router.push(`/member/${memberId}`)
-                    }
-                    canPoke={canPokeMembers}
-                    currentMemberId={currentMemberId}
-                    currentNickname={currentNickname}
-                    onPoke={handlePokeMember}
-                    pokingMemberId={pokingMemberId}
-                    pokedMemberIds={pokedMemberIds}
-                  />
+                      maxRows={PARTICIPANT_PREVIEW_SIZE}
+                      entries={previewParticipants.map((participant) => ({
+                        participantId: participant.participantId,
+                        memberId: participant.memberId,
+                        nickname: participant.nickname,
+                        profileImg: participant.profileImg,
+                        isHost: participant.status === 'HOST',
+                        // 고정 목표는 전원 공통이라 참여자별로 볼 의미가 없다.
+                        goals: isFreeChallenge ? participant.goals : undefined,
+                        rank: participant.rank,
+                        streak: participant.streak,
+                        completedGoalCount: participant.completedGoalCount,
+                      }))}
+                      totalCount={summaryParticipantCnt}
+                      onShowAll={() =>
+                        router.push(`/challenge/${id}/participants`)
+                      }
+                      onMemberClick={(memberId) => {
+                        const path = `/member/${memberId}`;
+                        if (!requestNativePushRoute(path)) {
+                          router.push(path);
+                        }
+                      }}
+                      canPoke={canPokeMembers}
+                      currentMemberId={currentMemberId}
+                      currentNickname={currentNickname}
+                      onPoke={handlePokeMember}
+                      pokingMemberId={pokingMemberId}
+                      pokedMemberIds={pokedMemberIds}
+                    />
                   </>
                 ) : null}
               </div>

--- a/src/app.feature/challenge/detail/screen/ChallengeParticipantListScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeParticipantListScreen.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  Card,
-  CircleAvatar,
-  MobileHeader,
-  Text,
-} from '@1d1s/design-system';
+import { Card, CircleAvatar, MobileHeader, Text } from '@1d1s/design-system';
 import EmptyState from '@component/EmptyState';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
@@ -13,6 +8,7 @@ import { normalizeApiError } from '@module/api/error';
 import { useInfiniteScroll } from '@module/hooks/useInfiniteScroll';
 import { useSafeBack } from '@module/hooks/useSafeBack';
 import { cn } from '@module/utils/cn';
+import { requestNativePushRoute } from '@module/utils/nativeBridge';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import { useRouter } from 'next/navigation';
 import React, { useMemo, useState } from 'react';
@@ -38,8 +34,7 @@ function ParticipantRow({
   participant: Participant;
   onClick(): void;
 }): React.ReactElement {
-  const hasRank =
-    typeof participant.rank === 'number' && participant.rank > 0;
+  const hasRank = typeof participant.rank === 'number' && participant.rank > 0;
   const isHost = participant.status === 'HOST';
 
   return (
@@ -73,11 +68,7 @@ function ParticipantRow({
       />
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="flex items-center gap-1.5">
-          <Text
-            size="body2"
-            weight="bold"
-            className="truncate text-gray-800"
-          >
+          <Text size="body2" weight="bold" className="truncate text-gray-800">
             {participant.nickname}
           </Text>
           {isHost ? (
@@ -218,9 +209,12 @@ export function ChallengeParticipantListScreen({
                 <li key={participant.participantId}>
                   <ParticipantRow
                     participant={participant}
-                    onClick={() =>
-                      router.push(`/member/${participant.memberId}`)
-                    }
+                    onClick={() => {
+                      const path = `/member/${participant.memberId}`;
+                      if (!requestNativePushRoute(path)) {
+                        router.push(path);
+                      }
+                    }}
                   />
                 </li>
               ))}

--- a/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
@@ -30,9 +30,16 @@ import {
 } from '@feature/challenge/write/hooks/useChallengeCreateForm';
 import { formatFormValues } from '@feature/challenge/write/utils/challengeCreatePayload';
 import { cn } from '@module/utils/cn';
-import { Check, Lightbulb, Loader2 } from 'lucide-react';
+import {
+  hideNativeProgress,
+  isNativeModalAvailable,
+  isNativeProgressAvailable,
+  openNativeModal,
+  showNativeProgress,
+} from '@module/utils/nativeBridge';
+import { Check, Lightbulb } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function ChallengeCreateScreen(): React.ReactElement {
   const router = useRouter();
@@ -44,6 +51,17 @@ export default function ChallengeCreateScreen(): React.ReactElement {
   const [createdIsPrivate, setCreatedIsPrivate] = useState(false);
   const [createdPassword, setCreatedPassword] = useState<string>();
   const [isErrorOpen, setIsErrorOpen] = useState(false);
+  const nativeModalAvailable = isNativeModalAvailable();
+  const nativeProgressAvailable = isNativeProgressAvailable();
+
+  useEffect(() => {
+    if (!createChallenge.isPending || !nativeProgressAvailable) {
+      hideNativeProgress();
+      return;
+    }
+    showNativeProgress('챌린지를 만들고 있어요...');
+    return hideNativeProgress;
+  }, [createChallenge.isPending, nativeProgressAvailable]);
 
   const onSubmit = (values: ChallengeCreateFormValues): void => {
     const payload = formatFormValues(values);
@@ -52,7 +70,24 @@ export default function ChallengeCreateScreen(): React.ReactElement {
         setCreatedChallengeId(data.challengeId);
         setCreatedIsPrivate(payload.challengeType === 'PRIVATE');
         setCreatedPassword(payload.password);
-        setIsSuccessOpen(true);
+        if (nativeModalAvailable) {
+          void openNativeModal({
+            title: '챌린지가 완성됐어요!',
+            message: '새 챌린지를 바로 확인하거나 홈으로 이동할 수 있어요.',
+            buttons: [
+              { label: '홈으로', value: 'home', style: 'cancel' },
+              { label: '챌린지 보기', value: 'detail' },
+            ],
+          }).then((value) => {
+            if (value === 'home') {
+              router.push('/');
+            } else if (value === 'detail') {
+              router.push(`/challenge/${data.challengeId}`);
+            }
+          });
+        } else {
+          setIsSuccessOpen(true);
+        }
       },
       onError: () => {
         setIsErrorOpen(true);
@@ -61,6 +96,23 @@ export default function ChallengeCreateScreen(): React.ReactElement {
   };
 
   const canSubmit = form.formState.isValid && !createChallenge.isPending;
+  const handleCreateRequest = async (): Promise<void> => {
+    if (!nativeModalAvailable) {
+      form.handleSubmit(onSubmit)();
+      return;
+    }
+    const result = await openNativeModal({
+      title: '이 챌린지를 만들까요?',
+      message: '입력한 내용으로 챌린지를 생성합니다.',
+      buttons: [
+        { label: '취소', value: 'cancel', style: 'cancel' },
+        { label: '만들기', value: 'confirm' },
+      ],
+    });
+    if (result === 'confirm') {
+      form.handleSubmit(onSubmit)();
+    }
+  };
 
   return (
     <div className={cn('pb-mobile-action-bar min-h-screen w-full')}>
@@ -170,20 +222,35 @@ export default function ChallengeCreateScreen(): React.ReactElement {
               )}
             </Text>
             <div className="w-full lg:ml-auto lg:w-auto">
-              <ChallengeCreateDialog
-                onConfirm={() => form.handleSubmit(onSubmit)()}
-                disabled={!canSubmit}
-                triggerText={
-                  canSubmit ? '챌린지 만들기' : '제목 · 내 목표를 입력해 주세요'
-                }
-                triggerClassName="w-full lg:w-auto"
-              />
+              {nativeModalAvailable ? (
+                <Button
+                  type="button"
+                  disabled={!canSubmit}
+                  className="w-full lg:w-auto"
+                  onClick={() => void handleCreateRequest()}
+                >
+                  {canSubmit
+                    ? '챌린지 만들기'
+                    : '제목 · 내 목표를 입력해 주세요'}
+                </Button>
+              ) : (
+                <ChallengeCreateDialog
+                  onConfirm={() => form.handleSubmit(onSubmit)()}
+                  disabled={!canSubmit}
+                  triggerText={
+                    canSubmit
+                      ? '챌린지 만들기'
+                      : '제목 · 내 목표를 입력해 주세요'
+                  }
+                  triggerClassName="w-full lg:w-auto"
+                />
+              )}
             </div>
           </div>
         </MobileBottomActionBar>
       </Form>
 
-      {createChallenge.isPending && (
+      {createChallenge.isPending && !nativeProgressAvailable && (
         <div
           className={cn(
             'fixed inset-0 z-[60] flex items-center justify-center',
@@ -198,7 +265,12 @@ export default function ChallengeCreateScreen(): React.ReactElement {
               'px-8 py-7 shadow-xl'
             )}
           >
-            <Loader2 className="text-main-700 h-8 w-8 animate-spin" />
+            <span
+              className={cn(
+                'border-main-700 h-8 w-8 animate-spin rounded-full',
+                'border-2 border-t-transparent'
+              )}
+            />
             <Text size="body2" weight="medium" className="text-gray-600">
               챌린지를 만들고 있어요...
             </Text>
@@ -207,7 +279,7 @@ export default function ChallengeCreateScreen(): React.ReactElement {
       )}
 
       <ChallengeCreateSuccessDialog
-        open={isSuccessOpen}
+        open={isSuccessOpen && !nativeModalAvailable}
         onOpenChange={setIsSuccessOpen}
         challengeId={createdChallengeId}
         isPrivate={createdIsPrivate}

--- a/src/app.feature/diary/board/screen/DiaryListScreen.tsx
+++ b/src/app.feature/diary/board/screen/DiaryListScreen.tsx
@@ -199,8 +199,7 @@ export default function DiaryListScreen(): React.ReactElement {
   }, []);
 
   const handleLikeToggle = useCallback(
-    (diary: DiaryItem): void =>
-      toggleLike(diary.id, diary.likeInfo.likedByMe),
+    (diary: DiaryItem): void => toggleLike(diary.id, diary.likeInfo.likedByMe),
     [toggleLike]
   );
 
@@ -262,11 +261,11 @@ export default function DiaryListScreen(): React.ReactElement {
       />
 
       {showSkeleton ? (
-        <DiaryCardSkeletonGrid count={12} className="data-fade-in native-flush-top mt-6" />
+        <DiaryCardSkeletonGrid count={12} className="data-fade-in mt-6" />
       ) : null}
 
       {isError && !hasLoadedDiaries ? (
-        <div className="native-flush-top mt-10 flex w-full justify-center py-10">
+        <div className="mt-10 flex w-full justify-center py-10">
           <Text size="body1" weight="medium" className="text-red-600">
             {error
               ? normalizeApiError(error).message
@@ -276,7 +275,7 @@ export default function DiaryListScreen(): React.ReactElement {
       ) : null}
 
       {!showSkeleton && hasLoadedDiaries ? (
-        <MasonryColumns className="data-fade-in native-flush-top mt-6">
+        <MasonryColumns className="data-fade-in mt-6">
           {sortedDiaries.map((item) => (
             <DiaryListItem
               key={item.id}

--- a/src/app.feature/diary/detail/components/DiaryAuthorRow.tsx
+++ b/src/app.feature/diary/detail/components/DiaryAuthorRow.tsx
@@ -2,6 +2,7 @@
 
 import { CircleAvatar, Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
+import { requestNativePushRoute } from '@module/utils/nativeBridge';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -21,7 +22,10 @@ export function DiaryAuthorRow({
   const router = useRouter();
   const handleClick = (): void => {
     if (authorId) {
-      router.push(`/member/${authorId}`);
+      const path = `/member/${authorId}`;
+      if (!requestNativePushRoute(path)) {
+        router.push(path);
+      }
     }
   };
 

--- a/src/app.feature/diary/detail/hooks/useCommentThreadDelegation.ts
+++ b/src/app.feature/diary/detail/hooks/useCommentThreadDelegation.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { requestNativePushRoute } from '@module/utils/nativeBridge';
 import { useRouter } from 'next/navigation';
 import React, { useRef } from 'react';
 
@@ -56,7 +57,10 @@ export function useCommentThreadDelegation({
       }
       event.stopPropagation();
       event.preventDefault();
-      router.push(`/member/${memberId}`);
+      const path = `/member/${memberId}`;
+      if (!requestNativePushRoute(path)) {
+        router.push(path);
+      }
       return;
     }
 

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -7,6 +7,7 @@ import { DiaryDetailSkeleton } from '@component/skeletons/DiaryDetailSkeleton';
 import { normalizeApiError } from '@module/api/error';
 import { useSafeBack } from '@module/hooks/useSafeBack';
 import { cn } from '@module/utils/cn';
+import { requestNativePushRoute } from '@module/utils/nativeBridge';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import {
   Edit3,
@@ -352,9 +353,12 @@ function DiaryDetailView({
             diaryData.connectedChallengeId ? (
               <DiaryConnectedChallengeCard
                 summary={diaryData.connectedChallengeSummary}
-                onClick={() =>
-                  router.push(`/challenge/${diaryData.connectedChallengeId}`)
-                }
+                onClick={() => {
+                  const path = `/challenge/${diaryData.connectedChallengeId}`;
+                  if (!requestNativePushRoute(path)) {
+                    router.push(path);
+                  }
+                }}
               />
             ) : (
               <DiaryConnectedChallengeFallback

--- a/src/app.feature/diary/write/components/ChallengePicker.tsx
+++ b/src/app.feature/diary/write/components/ChallengePicker.tsx
@@ -22,6 +22,11 @@ import {
 import { ChallengeListItem } from '@feature/challenge/shared/components/ChallengeListItem';
 import { formatChallengeTypeLabel } from '@feature/challenge/shared/utils/challengeDisplay';
 import { cn } from '@module/utils/cn';
+import {
+  isNativeModalAvailable,
+  openNativeModal,
+} from '@module/utils/nativeBridge';
+import { useEffect, useMemo, useRef } from 'react';
 
 import type { ChallengeListItem as ChallengeListItemType } from '../../../challenge/board/type/challenge';
 
@@ -39,10 +44,73 @@ export function ChallengePicker({
   challenges,
   isLoading = false,
   onSelect,
-}: ChallengePickerProps): React.ReactElement {
-  const ongoingChallenges = challenges.filter((challenge) =>
-    isChallengeOngoing(challenge.startDate, challenge.endDate)
+}: ChallengePickerProps): React.ReactElement | null {
+  const ongoingChallenges = useMemo(
+    () =>
+      challenges.filter((challenge) =>
+        isChallengeOngoing(challenge.startDate, challenge.endDate)
+      ),
+    [challenges]
   );
+  const nativeModalAvailable = isNativeModalAvailable();
+  const nativeRequestInFlight = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      nativeRequestInFlight.current = false;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (
+      !open ||
+      isLoading ||
+      !nativeModalAvailable ||
+      nativeRequestInFlight.current
+    ) {
+      return;
+    }
+    nativeRequestInFlight.current = true;
+    const buttons =
+      ongoingChallenges.length === 0
+        ? [{ label: '확인', value: 'cancel', style: 'cancel' as const }]
+        : [
+            ...ongoingChallenges.map((challenge) => ({
+              label: challenge.title,
+              value: String(challenge.challengeId),
+              style: 'default' as const,
+            })),
+            { label: '취소', value: 'cancel', style: 'cancel' as const },
+          ];
+
+    void openNativeModal({
+      title: '챌린지 선택',
+      message:
+        ongoingChallenges.length === 0
+          ? '작성 가능한 진행 중 챌린지가 없어요.'
+          : '일지를 기록할 챌린지를 선택해 주세요.',
+      buttons,
+    }).then((value) => {
+      const selected = ongoingChallenges.find(
+        (challenge) => String(challenge.challengeId) === value
+      );
+      if (selected) {
+        onSelect?.(selected);
+      }
+      onOpenChange(false);
+    });
+  }, [
+    isLoading,
+    nativeModalAvailable,
+    onOpenChange,
+    onSelect,
+    ongoingChallenges,
+    open,
+  ]);
+
+  if (nativeModalAvailable) {
+    return null;
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -93,9 +161,7 @@ export function ChallengePicker({
                   challengeTitle={challenge.title}
                   challengeType={formatChallengeTypeLabel(challenge.goalType)}
                   challengeCategory={getCategoryLabel(challenge.category)}
-                  categoryIcon={
-                    <CategoryIcon category={challenge.category} />
-                  }
+                  categoryIcon={<CategoryIcon category={challenge.category} />}
                   imageUrl={challenge.thumbnailImage}
                   currentUserCount={challenge.participantCnt}
                   maxUserCount={challenge.maxParticipantCnt}

--- a/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
+++ b/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import {
-  Button,
-  MobileHeader,
-  Text,
-} from '@1d1s/design-system';
+import { Button, MobileHeader, Text } from '@1d1s/design-system';
 import { AlertDialog } from '@component/AlertDialog';
 import { MobileBottomActionBar } from '@component/layout/MobileBottomActionBar';
 import { NativeDatePicker } from '@component/NativeDatePicker';
 import { cn } from '@module/utils/cn';
+import {
+  hideNativeProgress,
+  isNativeProgressAvailable,
+  showNativeProgress,
+} from '@module/utils/nativeBridge';
 import { startOfToday, subDays } from 'date-fns';
-import { Loader2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useMemo } from 'react';
@@ -80,6 +80,7 @@ export default function DiaryCreateScreen(): React.ReactElement {
     closeCreateUnavailableDialog,
     handleSubmit,
   } = useDiaryCreateForm();
+  const nativeProgressAvailable = isNativeProgressAvailable();
 
   // 저장 중 오버레이가 떠 있는 동안 뒤 화면 스크롤을 잠근다.
   useEffect(() => {
@@ -93,6 +94,17 @@ export default function DiaryCreateScreen(): React.ReactElement {
       document.body.style.overflow = prevOverflow;
     };
   }, [isSubmitting]);
+
+  useEffect(() => {
+    if (!isSubmitting || !nativeProgressAvailable) {
+      hideNativeProgress();
+      return;
+    }
+    showNativeProgress(
+      isEditMode ? '일지를 수정하고 있어요...' : '일지를 올리고 있어요...'
+    );
+    return hideNativeProgress;
+  }, [isEditMode, isSubmitting, nativeProgressAvailable]);
 
   const totalGoalCount = isSelectedChallengeConfirmed ? goals.length : 0;
   const achievedGoalCount = isSelectedChallengeConfirmed
@@ -298,7 +310,7 @@ export default function DiaryCreateScreen(): React.ReactElement {
         </div>
       </MobileBottomActionBar>
 
-      {isSubmitting && (
+      {isSubmitting && !nativeProgressAvailable && (
         <div
           className={cn(
             'fixed inset-0 z-[60] flex items-center justify-center',
@@ -313,7 +325,12 @@ export default function DiaryCreateScreen(): React.ReactElement {
               'px-8 py-7 shadow-xl'
             )}
           >
-            <Loader2 className="text-main-700 h-8 w-8 animate-spin" />
+            <span
+              className={cn(
+                'border-main-700 h-8 w-8 animate-spin rounded-full',
+                'border-2 border-t-transparent'
+              )}
+            />
             <Text size="body2" weight="medium" className="text-gray-600">
               {isEditMode
                 ? '일지를 수정하고 있어요...'

--- a/src/app.feature/friend/components/FriendListItem.tsx
+++ b/src/app.feature/friend/components/FriendListItem.tsx
@@ -2,6 +2,7 @@
 
 import { CircleAvatar, Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
+import { requestNativePushRoute } from '@module/utils/nativeBridge';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -18,7 +19,10 @@ export function FriendListItem({
 }: FriendListItemProps): React.ReactElement {
   const router = useRouter();
   const handleOpenProfile = (): void => {
-    router.push(`/member/${friend.memberId}`);
+    const path = `/member/${friend.memberId}`;
+    if (!requestNativePushRoute(path)) {
+      router.push(path);
+    }
   };
 
   return (

--- a/src/app.feature/friend/components/FriendRequestListItem.tsx
+++ b/src/app.feature/friend/components/FriendRequestListItem.tsx
@@ -3,6 +3,7 @@
 import { CircleAvatar, Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import { getDateTimestamp } from '@module/utils/date';
+import { requestNativePushRoute } from '@module/utils/nativeBridge';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 
@@ -28,7 +29,12 @@ export function FriendRequestListItem({
     >
       <button
         type="button"
-        onClick={() => router.push(`/member/${request.memberId}`)}
+        onClick={() => {
+          const path = `/member/${request.memberId}`;
+          if (!requestNativePushRoute(path)) {
+            router.push(path);
+          }
+        }}
         className="flex flex-1 items-center gap-3 text-left"
       >
         <CircleAvatar size="md" imageUrl={request.profileUrl} tone="peach" />
@@ -38,9 +44,9 @@ export function FriendRequestListItem({
           </Text>
           {request.createdAt ? (
             <Text size="caption2" className="text-gray-400">
-              {new Date(
-                getDateTimestamp(request.createdAt)
-              ).toLocaleDateString('ko-KR')}
+              {new Date(getDateTimestamp(request.createdAt)).toLocaleDateString(
+                'ko-KR'
+              )}
             </Text>
           ) : null}
         </div>

--- a/src/app.feature/friend/components/MyPageFriendsEntry.tsx
+++ b/src/app.feature/friend/components/MyPageFriendsEntry.tsx
@@ -3,7 +3,7 @@
 import { Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import { ChevronRight, Users } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import React from 'react';
 
 import {
@@ -16,7 +16,6 @@ import {
  * 친구 수와 받은 신청 건수를 함께 노출한다.
  */
 export function MyPageFriendsEntry(): React.ReactElement {
-  const router = useRouter();
   const { data: friends } = useFriendList();
   const { data: received } = useReceivedFriendRequests();
 
@@ -24,9 +23,9 @@ export function MyPageFriendsEntry(): React.ReactElement {
   const receivedCount = received?.length ?? 0;
 
   return (
-    <button
-      type="button"
-      onClick={() => router.push('/mypage/friend')}
+    <Link
+      href="/mypage/friend"
+      prefetch
       className={cn(
         'group flex w-full items-center gap-3 rounded-[14px]',
         'border border-gray-200 bg-white px-4 py-4 text-left',
@@ -63,6 +62,6 @@ export function MyPageFriendsEntry(): React.ReactElement {
         </span>
       ) : null}
       <ChevronRight className="h-4 w-4 shrink-0 text-gray-400" aria-hidden />
-    </button>
+    </Link>
   );
 }

--- a/src/app.feature/home/components/HomeWarmBanner.tsx
+++ b/src/app.feature/home/components/HomeWarmBanner.tsx
@@ -47,7 +47,10 @@ function fromServerBanner(banner: ServerBanner): CarouselBanner {
     title: banner.title,
     subtitle: banner.subtitle,
     // imageUrl → 배경 이미지(cover). DS Banner 는 bg 를 background 로 적용한다.
-    bg: `url('${banner.imageUrl}') center/cover no-repeat`,
+    bg:
+      'linear-gradient(90deg, rgba(17,24,39,.62) 0%, ' +
+      'rgba(17,24,39,.20) 62%, rgba(17,24,39,.34) 100%), ' +
+      `url('${banner.imageUrl}') center/cover no-repeat`,
     href: banner.linkUrl,
   };
 }
@@ -144,7 +147,7 @@ export default function HomeWarmBanner({
   };
 
   const arrowClass = cn(
-    'absolute top-1/2 z-10 flex h-8 w-8 -translate-y-1/2 items-center',
+    'absolute top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center',
     'justify-center rounded-full border-0 bg-black/25 text-white',
     'backdrop-blur transition hover:bg-black/40'
   );
@@ -170,7 +173,8 @@ export default function HomeWarmBanner({
         onClick={handleClick}
         className={cn(
           'shadow-warm h-full cursor-pointer transition',
-          'data-fade-in hover:brightness-105'
+          'data-fade-in px-12 hover:brightness-105',
+          '[&_*]:drop-shadow-[0_1px_2px_rgba(0,0,0,0.65)]'
         )}
       />
 
@@ -183,7 +187,7 @@ export default function HomeWarmBanner({
               event.stopPropagation();
               goTo(safeIndex - 1);
             }}
-            className={cn(arrowClass, 'left-3')}
+            className={cn(arrowClass, 'left-2')}
           >
             <ChevronLeft className="h-4 w-4" />
           </button>
@@ -194,7 +198,7 @@ export default function HomeWarmBanner({
               event.stopPropagation();
               goTo(safeIndex + 1);
             }}
-            className={cn(arrowClass, 'right-3')}
+            className={cn(arrowClass, 'right-2')}
           >
             <ChevronRight className="h-4 w-4" />
           </button>

--- a/src/app.feature/home/screen/HomeScreen.tsx
+++ b/src/app.feature/home/screen/HomeScreen.tsx
@@ -91,7 +91,7 @@ export default function HomeScreen(): React.ReactElement {
     <>
       <HomePopup enabled={isLoggedIn} />
       <div
-        data-native-flush-top
+        data-native-home-content
         className={cn(
           'mx-auto flex w-full max-w-[1200px] flex-col gap-4 lg:gap-6',
           'px-5 py-7 lg:px-8 lg:py-10'

--- a/src/app.feature/inquiry/screen/InquiryScreen.tsx
+++ b/src/app.feature/inquiry/screen/InquiryScreen.tsx
@@ -48,7 +48,7 @@ export function InquiryScreen(): React.ReactElement {
       title="문의하기"
       description="궁금한 점이 있으시면 언제든지 문의해주세요."
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-3 pb-8">
         <section className="rounded-4 border border-gray-200 bg-white">
           <div className="border-b border-gray-100 px-5 py-4">
             <Text size="body1" weight="bold" className="text-gray-500">
@@ -149,7 +149,11 @@ export function InquiryScreen(): React.ReactElement {
                 <Text size="body1" weight="bold" className="text-gray-900">
                   무엇을 도와드릴까요?
                 </Text>
-                <Text size="caption1" weight="regular" className="text-gray-500">
+                <Text
+                  size="caption1"
+                  weight="regular"
+                  className="text-gray-500"
+                >
                   문제가 발생하거나 추가됐으면 하는 기능이 있다면 아래 버튼을
                   통해 문의를 남겨주세요.
                 </Text>

--- a/src/app.feature/member/mypage/components/MyPageProfileCard.tsx
+++ b/src/app.feature/member/mypage/components/MyPageProfileCard.tsx
@@ -5,6 +5,7 @@ import { ProfileAlertBadge } from '@component/ProfileAlertBadge';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useUnreadCount } from '@feature/notification/hooks/useNotificationQueries';
 import { cn } from '@module/utils/cn';
+import { requestNativePushRoute } from '@module/utils/nativeBridge';
 import { Bell, Settings } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import React from 'react';
@@ -127,10 +128,15 @@ export function MyPageProfileCard({
 }: MyPageProfileCardProps): React.ReactElement {
   const router = useRouter();
   const isLoggedIn = useIsLoggedIn();
+  const navigate = (path: string): void => {
+    if (!requestNativePushRoute(path)) {
+      router.push(path);
+    }
+  };
   const goChallenges = challengeHref
-    ? () => router.push(challengeHref)
+    ? () => navigate(challengeHref)
     : undefined;
-  const goDiaries = diaryHref ? () => router.push(diaryHref) : undefined;
+  const goDiaries = diaryHref ? () => navigate(diaryHref) : undefined;
   const { data: unreadData } = useUnreadCount({ enabled: isLoggedIn });
   const hasUnread = isLoggedIn && (unreadData?.unreadCount ?? 0) > 0;
   const defaultActions = (

--- a/src/app.feature/member/statistics/components/MyPageStatisticsEntry.tsx
+++ b/src/app.feature/member/statistics/components/MyPageStatisticsEntry.tsx
@@ -4,19 +4,17 @@ import { Icon, Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 // BarChart3 는 DS Icon 에 대응 아이콘이 없어 lucide 유지.
 import { BarChart3 } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import React from 'react';
 
 /**
  * 마이페이지에서 통계 화면으로 진입하는 카드.
  */
 export function MyPageStatisticsEntry(): React.ReactElement {
-  const router = useRouter();
-
   return (
-    <button
-      type="button"
-      onClick={() => router.push('/mypage/statistics')}
+    <Link
+      href="/mypage/statistics"
+      prefetch
       className={cn(
         'group flex w-full items-center gap-3 rounded-[14px]',
         'border border-gray-200 bg-white px-4 py-4 text-left',
@@ -46,6 +44,6 @@ export function MyPageStatisticsEntry(): React.ReactElement {
         className="shrink-0 text-gray-400"
         aria-hidden
       />
-    </button>
+    </Link>
   );
 }

--- a/src/app.feature/notification/screen/NotificationScreen.tsx
+++ b/src/app.feature/notification/screen/NotificationScreen.tsx
@@ -44,17 +44,21 @@ export function NotificationScreen(): React.JSX.Element {
   const unreadCount = notifications.filter((notif) => !notif.isRead).length;
   const hasNotifications = notifications.length > 0;
 
-  const markAllAction = hasUnread ? (
+  const markAllAction = (
     <button
       type="button"
+      disabled={!hasUnread}
       onClick={() => markAllAsRead()}
-      className="text-main-800 hover:text-main-900 transition-colors"
+      className={cn(
+        'text-main-800 hover:text-main-900 transition-colors',
+        'disabled:cursor-default disabled:text-gray-300'
+      )}
     >
       <Text size="body2" weight="medium" className="text-inherit">
         모두 읽음
       </Text>
     </button>
-  ) : null;
+  );
 
   const description = hasUnread
     ? `읽지 않은 알림이 ${unreadCount}개 있어요.`
@@ -70,9 +74,7 @@ export function NotificationScreen(): React.JSX.Element {
       {/* 네이티브 쉘에서는 SubPageShell 의 웹 헤더(와 headerAction 의
           "모두 읽음")가 통째로 숨는다. 같은 액션을 본문 상단에 native-only
           로 한 번 더 그려 네이티브에서도 모두 읽음이 가능하게 한다. */}
-      {hasUnread ? (
-        <div className="native-only mb-3 text-right">{markAllAction}</div>
-      ) : null}
+      <div className="native-only mb-3 text-right">{markAllAction}</div>
       {showSkeleton ? (
         <NotificationListSkeleton count={6} />
       ) : !hasNotifications ? (

--- a/src/app.feature/notification/screen/NotificationSettingsScreen.tsx
+++ b/src/app.feature/notification/screen/NotificationSettingsScreen.tsx
@@ -125,6 +125,28 @@ export function NotificationSettingsScreen(): React.ReactElement {
   const { data, isLoading } = useNotificationPreferences();
   const { mutate: updatePreferences } = useUpdateNotificationPreferences();
   const { status, subscribe } = useWebPushSubscription();
+  const migratedLegacyPreference = React.useRef(false);
+
+  React.useEffect(() => {
+    if (
+      status !== 'subscribed' ||
+      !data ||
+      migratedLegacyPreference.current ||
+      data.pushEnabled ||
+      data.friendEnabled ||
+      data.diaryEnabled ||
+      data.challengeEnabled
+    ) {
+      return;
+    }
+    migratedLegacyPreference.current = true;
+    updatePreferences({
+      pushEnabled: true,
+      friendEnabled: true,
+      diaryEnabled: true,
+      challengeEnabled: true,
+    });
+  }, [data, status, updatePreferences]);
 
   function handleChange(
     key: keyof NotificationPreferences,

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -118,6 +118,12 @@ export type NativeMessage =
   | { type: 'oauth_open'; payload: { url: string } }
   | { type: 'token_refresh'; payload: { id: string } }
   | { type: 'logout' }
+  | {
+      type: 'progress_open';
+      payload: { message: string };
+    }
+  | { type: 'progress_close' }
+  | { type: 'push_route'; payload: { path: string } }
   // 네이티브 다이얼로그 노출 요청. 응답은 native:modal_result CustomEvent
   // 로 비동기 도착. openNativeModal() 헬퍼가 id 매칭으로 Promise 화 한다.
   | { type: 'modal_open'; payload: NativeModalOpenPayload }
@@ -143,7 +149,6 @@ interface NativeWindow extends Window {
   __1D1S_FEATURES__?: Partial<Record<string, boolean>>;
 }
 
-
 function getNativeWindow(): NativeWindow | null {
   if (typeof window === 'undefined') {
     return null;
@@ -155,7 +160,6 @@ function getNativeWindow(): NativeWindow | null {
 function hasNativeFeature(name: string): boolean {
   return getNativeWindow()?.__1D1S_FEATURES__?.[name] === true;
 }
-
 
 export function postNativeMessage(message: NativeMessage): void {
   const win = getNativeWindow();
@@ -175,6 +179,50 @@ export function postNativeMessage(message: NativeMessage): void {
 
 export function isNativeBridgeAvailable(): boolean {
   return getNativeWindow()?.[CHANNEL_NAME] != null;
+}
+
+export function isNativeModalAvailable(): boolean {
+  return getNativeWindow()?.[CHANNEL_NAME] != null && hasNativeFeature('modal');
+}
+
+/**
+ * SPA 데이터 요청이 끝나기 전에 네이티브 화면을 먼저 연다. 앱이 아닌
+ * 환경에서는 false를 반환하므로 호출자가 router.push로 폴백할 수 있다.
+ */
+export function requestNativePushRoute(path: string): boolean {
+  if (
+    !path.startsWith('/') ||
+    getNativeWindow()?.[CHANNEL_NAME] == null ||
+    !hasNativeFeature('pushRoute')
+  ) {
+    return false;
+  }
+  postNativeMessage({ type: 'push_route', payload: { path } });
+  return true;
+}
+
+export function showNativeProgress(message: string): boolean {
+  if (
+    getNativeWindow()?.[CHANNEL_NAME] == null ||
+    !hasNativeFeature('progress')
+  ) {
+    return false;
+  }
+  postNativeMessage({ type: 'progress_open', payload: { message } });
+  return true;
+}
+
+export function isNativeProgressAvailable(): boolean {
+  return (
+    getNativeWindow()?.[CHANNEL_NAME] != null && hasNativeFeature('progress')
+  );
+}
+
+export function hideNativeProgress(): void {
+  if (getNativeWindow()?.[CHANNEL_NAME] == null) {
+    return;
+  }
+  postNativeMessage({ type: 'progress_close' });
 }
 
 export function markNativeOAuth(codeChallenge: string): void {
@@ -434,7 +482,6 @@ export function onNativeStoryViewed(
   return () => win.removeEventListener('native:story_viewed', listener);
 }
 
-
 /** 현재 쉘이 날짜 피커 위임을 지원하는지. 오버레이 렌더 여부 판정용. */
 export function isNativeDatePickerAvailable(): boolean {
   return (
@@ -453,7 +500,10 @@ export function openNativeDatePicker(
   const id = generateModalId();
   return new Promise<string | null>((resolve) => {
     pendingNativeDates.set(id, resolve);
-    postNativeMessage({ type: 'date_picker_open', payload: { id, ...options } });
+    postNativeMessage({
+      type: 'date_picker_open',
+      payload: { id, ...options },
+    });
   });
 }
 

--- a/src/app.styles/globals.css
+++ b/src/app.styles/globals.css
@@ -123,7 +123,22 @@
      네이티브에서 그 헤더가 사라지므로 56px 아래 허공에 붙는다 — 챌린지
      상세 탭바가 그랬다. 이 마커를 달면 네이티브에서 top:0 으로 당겨진다. */
   html[data-native-app='true'] [data-native-top-0] {
-    top: 0 !important;
+    /* 챌린지 상세의 Flutter compact AppBackBar는 WebView 위에 56px로
+       오버레이되므로 탭이 그 바로 아래에 붙게 한다. */
+    top: 3.5rem !important;
+  }
+
+  html[data-native-app='true'] [data-native-home-content] {
+    padding-top: 0.875rem !important;
+  }
+
+  html[data-native-app='true'] [data-native-subpage-content] {
+    padding-top: 0.5rem !important;
+    padding-bottom: calc(1.5rem + env(safe-area-inset-bottom)) !important;
+  }
+
+  html[data-native-app='true'] [data-native-subpage-body] {
+    margin-top: 0.5rem !important;
   }
 
   /* 네이티브 쉘에서만 보이는 요소. 숨겨지는 웹 헤더 안의 액션(알림의
@@ -138,8 +153,7 @@
 
   /* 숨겨진 웹 헤더를 전제로 잡혀 있던 상단 여백 제거. 네이티브 헤더가
      이미 그 공간을 차지하므로 py-* / mt-* 의 top 만 0 으로 누른다. */
-  html[data-native-app='true']
-    :is([data-native-flush-top], .native-flush-top) {
+  html[data-native-app='true'] :is([data-native-flush-top], .native-flush-top) {
     padding-top: 0 !important;
     margin-top: 0 !important;
   }

--- a/src/app/inquiry/loading.tsx
+++ b/src/app/inquiry/loading.tsx
@@ -1,0 +1,5 @@
+import { SubPageRouteSkeleton } from '@component/skeletons/SubPageRouteSkeleton';
+
+export default function Loading(): React.ReactElement {
+  return <SubPageRouteSkeleton />;
+}

--- a/src/app/mypage/challenge/loading.tsx
+++ b/src/app/mypage/challenge/loading.tsx
@@ -1,0 +1,5 @@
+import { ChallengeBoardSkeleton } from '@component/skeletons/ChallengeBoardSkeleton';
+
+export default function Loading(): React.ReactElement {
+  return <ChallengeBoardSkeleton />;
+}

--- a/src/app/mypage/diary/loading.tsx
+++ b/src/app/mypage/diary/loading.tsx
@@ -1,0 +1,5 @@
+import { DiaryBoardSkeleton } from '@component/skeletons/DiaryBoardSkeleton';
+
+export default function Loading(): React.ReactElement {
+  return <DiaryBoardSkeleton />;
+}

--- a/src/app/mypage/friend/loading.tsx
+++ b/src/app/mypage/friend/loading.tsx
@@ -1,0 +1,5 @@
+import { SubPageRouteSkeleton } from '@component/skeletons/SubPageRouteSkeleton';
+
+export default function Loading(): React.ReactElement {
+  return <SubPageRouteSkeleton />;
+}

--- a/src/app/mypage/settings/profile/loading.tsx
+++ b/src/app/mypage/settings/profile/loading.tsx
@@ -1,0 +1,5 @@
+import { SubPageRouteSkeleton } from '@component/skeletons/SubPageRouteSkeleton';
+
+export default function Loading(): React.ReactElement {
+  return <SubPageRouteSkeleton />;
+}

--- a/src/app/mypage/statistics/loading.tsx
+++ b/src/app/mypage/statistics/loading.tsx
@@ -1,0 +1,5 @@
+import { SubPageRouteSkeleton } from '@component/skeletons/SubPageRouteSkeleton';
+
+export default function Loading(): React.ReactElement {
+  return <SubPageRouteSkeleton />;
+}


### PR DESCRIPTION
## 요약
- 일지 챌린지 선택, 사진 맞추기, 생성 확인/진행/완료 UI를 앱 네이티브 모달·진행 오버레이로 위임했습니다.
- 프로필·챌린지 상세 전환을 네이티브 push로 즉시 처리해 전환 전 대기와 돌아올 때 재로딩을 줄였습니다.
- 챌린지 상세 sticky 탭, 세이프 에리아, 배너 가독성/버튼 간격, 홈·알림·친구·문의 화면 여백을 조정했습니다.
- 마이페이지 하위 라우트 loading UI와 prefetch를 추가하고 일지 목록 간격 및 알림 모두 읽음 상태를 정리했습니다.
- 기존 알림 설정 레코드가 모두 비활성인 구독 사용자를 새 기본값으로 마이그레이션합니다.

## 셀프 리뷰
- 네이티브 모달 Promise가 리렌더 cleanup에 의해 무시될 수 있던 경합을 제거했습니다.
- Flutter 오버레이 헤더 높이와 sticky 탭 오프셋(56px)을 맞췄습니다.
- 중요도 높은 미해결 사항은 없습니다.

## 검증
- `pnpm exec tsc --noEmit`
- `pnpm run lint` (오류 0, 기존 경고 59)
- `pnpm test` (21 files / 174 tests)
- `pnpm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native image cropping, challenge selection, confirmation, success, and progress flows where supported.
  * Improved navigation to member profiles, challenges, and diary pages in native environments, with web fallback.
  * Added loading skeletons for several subpages and improved native page spacing.
* **Bug Fixes**
  * “Mark all as read” now remains visible and disabled when no notifications are unread.
  * Preserved notification preferences for eligible existing settings.
* **Style**
  * Refined home banner gradients, shadows, carousel controls, and mobile layout spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->