### PR TITLE
fix: use banner dim overlay

### DIFF
--- a/src/app.feature/home/components/HomeWarmBanner.tsx
+++ b/src/app.feature/home/components/HomeWarmBanner.tsx
@@ -48,8 +48,7 @@ function fromServerBanner(banner: ServerBanner): CarouselBanner {
     subtitle: banner.subtitle,
     // imageUrl → 배경 이미지(cover). DS Banner 는 bg 를 background 로 적용한다.
     bg:
-      'linear-gradient(90deg, rgba(17,24,39,.62) 0%, ' +
-      'rgba(17,24,39,.20) 62%, rgba(17,24,39,.34) 100%), ' +
+      'linear-gradient(rgba(17,24,39,.36), rgba(17,24,39,.36)), ' +
       `url('${banner.imageUrl}') center/cover no-repeat`,
     href: banner.linkUrl,
   };
@@ -173,8 +172,7 @@ export default function HomeWarmBanner({
         onClick={handleClick}
         className={cn(
           'shadow-warm h-full cursor-pointer transition',
-          'data-fade-in px-12 hover:brightness-105',
-          '[&_*]:drop-shadow-[0_1px_2px_rgba(0,0,0,0.65)]'
+          'data-fade-in px-12 hover:brightness-105'
         )}
       />
 


### PR DESCRIPTION
## Summary
- 홈 서버 이미지 배너의 텍스트 drop-shadow를 제거했습니다.
- 이미지 전체에 36%의 균일한 dim을 적용했습니다.

## Root cause
이전 가독성 보완에서 모든 배너 텍스트에 강한 그림자가 적용되어 기존 디자인과 어울리지 않았습니다.

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm run lint` (0 errors, 59 existing warnings)
- `pnpm test` (174 passed)
- `pnpm run build`