### PR TITLE
[ODS-260] feat: 로그인 사용자용 투표 플로팅 위젯 추가

### DIFF
--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -4,6 +4,7 @@ import { Button } from '@1d1s/design-system';
 import { AddToHomeScreenPrompt } from '@feature/install/components/AddToHomeScreenPrompt';
 import { usePhoneNumberMissing } from '@feature/member/hooks/usePhoneNumberMissing';
 import { BrowserPermissionPrompt } from '@feature/notification/components/BrowserPermissionPrompt';
+import VoteFloatingScreen from '@feature/vote/screen/VoteFloatingScreen';
 import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
 import { useServiceWorkerNavigation } from '@module/hooks/useServiceWorkerNavigation';
 import { useTokenRefreshOnResume } from '@module/hooks/useTokenRefreshOnResume';
@@ -259,6 +260,10 @@ export default function AppLayoutShell({
 
       {!isLoginPage && !isNativeApp ? <BrowserPermissionPrompt /> : null}
       {!isLoginPage && !isNativeApp ? <AddToHomeScreenPrompt /> : null}
+      <VoteFloatingScreen
+        enabled={isLoggedIn && !isLoginPage}
+        hasBottomNav={showBottomNav && !isNativeApp}
+      />
       {isNativeApp ? <NativeBridge authState={authState} /> : null}
     </div>
   );

--- a/src/app.feature/vote/api/voteApi.ts
+++ b/src/app.feature/vote/api/voteApi.ts
@@ -1,0 +1,32 @@
+import { apiClient } from '@module/api/client';
+import { requestData } from '@module/api/request';
+
+import type {
+  VoteDetail,
+  VoteSubmitRequest,
+  VoteSummary,
+} from '../type/vote';
+
+export const voteApi = {
+  getTodayVotes: (): Promise<VoteSummary[]> =>
+    requestData<VoteSummary[]>(apiClient, {
+      url: '/votes/today',
+      method: 'GET',
+    }),
+
+  getVoteDetail: (voteId: number): Promise<VoteDetail> =>
+    requestData<VoteDetail>(apiClient, {
+      url: `/votes/${voteId}`,
+      method: 'GET',
+    }),
+
+  submitVote: (
+    voteId: number,
+    data: VoteSubmitRequest
+  ): Promise<VoteDetail> =>
+    requestData<VoteDetail, VoteSubmitRequest>(apiClient, {
+      url: `/votes/${voteId}/responses`,
+      method: 'POST',
+      data,
+    }),
+};

--- a/src/app.feature/vote/components/VoteFloatingWidget.tsx
+++ b/src/app.feature/vote/components/VoteFloatingWidget.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import { Button } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { Check, RotateCcw, Vote, X } from 'lucide-react';
+import React, { useCallback, useState } from 'react';
+
+import { useSubmitVote } from '../hooks/useVoteMutations';
+import {
+  useTodayVotes,
+  useVoteDetail,
+} from '../hooks/useVoteQueries';
+import type {
+  VoteDetail,
+  VoteOption,
+  VoteSelectionType,
+} from '../type/vote';
+
+interface VoteFloatingWidgetProps {
+  enabled: boolean;
+  hasBottomNav: boolean;
+}
+
+interface VotePanelProps {
+  vote?: VoteDetail;
+  isLoading: boolean;
+  isError: boolean;
+  isSubmitting: boolean;
+  isSubmitted: boolean;
+  selectedOptionIds: number[];
+  onOptionClick(optionId: number): void;
+  onSubmit(): void;
+  onRetry(): void;
+  onClose(): void;
+}
+
+interface VoteOptionButtonProps {
+  option: VoteOption;
+  selectionType: VoteSelectionType;
+  isSelected: boolean;
+  isSubmitted: boolean;
+  onClick(): void;
+}
+
+function VoteOptionButton({
+  option,
+  selectionType,
+  isSelected,
+  isSubmitted,
+  onClick,
+}: VoteOptionButtonProps): React.ReactElement {
+  const percentage =
+    typeof option.percentage === 'number'
+      ? Math.min(100, Math.max(0, option.percentage))
+      : undefined;
+
+  return (
+    <button
+      type="button"
+      role={selectionType === 'SINGLE' ? 'radio' : 'checkbox'}
+      aria-checked={isSelected}
+      disabled={isSubmitted}
+      onClick={onClick}
+      className={cn(
+        'relative flex min-h-12 w-full items-center gap-3 overflow-hidden',
+        'rounded-3 border px-3.5 py-3 text-left transition',
+        isSelected
+          ? 'border-main-700 bg-main-200'
+          : 'hover:border-main-500 border-gray-200 bg-white',
+        isSubmitted && 'cursor-default'
+      )}
+    >
+      {isSubmitted && percentage !== undefined ? (
+        <span
+          aria-hidden
+          className="bg-main-200 absolute inset-y-0 left-0"
+          style={{ width: `${percentage}%` }}
+        />
+      ) : null}
+      <span
+        aria-hidden
+        className={cn(
+          'relative flex h-5 w-5 shrink-0 items-center justify-center',
+          'border-2 transition',
+          selectionType === 'SINGLE' ? 'rounded-full' : 'rounded-1.5',
+          isSelected
+            ? 'border-main-800 bg-main-800 text-white'
+            : 'border-gray-400 bg-white'
+        )}
+      >
+        {isSelected ? <Check className="h-3 w-3" strokeWidth={3} /> : null}
+      </span>
+      <span className="relative min-w-0 flex-1 text-sm font-semibold">
+        {option.text}
+      </span>
+      {isSubmitted && percentage !== undefined ? (
+        <span className="relative text-xs font-bold text-gray-700">
+          {Math.round(percentage)}%
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function VotePanel({
+  vote,
+  isLoading,
+  isError,
+  isSubmitting,
+  isSubmitted,
+  selectedOptionIds,
+  onOptionClick,
+  onSubmit,
+  onRetry,
+  onClose,
+}: VotePanelProps): React.ReactElement {
+  const hasSelection = selectedOptionIds.length > 0;
+  const selectionGuide =
+    vote?.selectionType === 'MULTIPLE'
+      ? '원하는 항목을 모두 선택해 주세요.'
+      : '하나의 항목을 선택해 주세요.';
+
+  return (
+    <section
+      aria-label="오늘의 투표"
+      className={cn(
+        'animate-in fade-in zoom-in-95 w-[min(360px,calc(100vw-40px))]',
+        'max-h-[min(580px,calc(100vh-120px))] overflow-y-auto',
+        'rounded-5 border border-gray-200 bg-white p-5 shadow-2xl',
+        'duration-200'
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div
+            className={cn(
+              'text-main-800 mb-2 flex items-center gap-1.5',
+              'text-xs font-extrabold'
+            )}
+          >
+            <Vote className="h-4 w-4" aria-hidden />
+            오늘의 투표
+          </div>
+          <h2 className="text-lg leading-snug font-extrabold text-gray-900">
+            {isLoading ? '투표를 불러오고 있어요' : vote?.title}
+          </h2>
+        </div>
+        <button
+          type="button"
+          aria-label="투표 팝업 접기"
+          onClick={onClose}
+          className={cn(
+            '-mt-1 -mr-1 flex h-8 w-8 shrink-0 items-center justify-center',
+            'rounded-full text-gray-500 transition hover:bg-gray-100'
+          )}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="mt-5 flex flex-col gap-2.5" aria-busy="true">
+          <div className="rounded-3 h-12 animate-pulse bg-gray-100" />
+          <div className="rounded-3 h-12 animate-pulse bg-gray-100" />
+          <div className="rounded-3 h-12 animate-pulse bg-gray-100" />
+        </div>
+      ) : null}
+
+      {isError ? (
+        <div className="rounded-3 mt-5 bg-gray-50 p-4 text-center">
+          <p className="text-sm text-gray-600">
+            투표 내용을 불러오지 못했어요.
+          </p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className={cn(
+              'text-main-800 mt-2 inline-flex items-center gap-1',
+              'text-xs font-bold'
+            )}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            다시 시도
+          </button>
+        </div>
+      ) : null}
+
+      {vote && !isError ? (
+        <>
+          <p className="mt-2 text-xs text-gray-500">
+            {isSubmitted
+              ? '소중한 의견을 남겨주셔서 감사해요.'
+              : selectionGuide}
+          </p>
+          <div
+            role={vote.selectionType === 'SINGLE' ? 'radiogroup' : 'group'}
+            aria-label={vote.title}
+            className="mt-4 flex flex-col gap-2.5"
+          >
+            {vote.options.map((option) => (
+              <VoteOptionButton
+                key={option.optionId}
+                option={option}
+                selectionType={vote.selectionType}
+                isSelected={selectedOptionIds.includes(option.optionId)}
+                isSubmitted={isSubmitted}
+                onClick={() => onOptionClick(option.optionId)}
+              />
+            ))}
+          </div>
+          <Button
+            type="button"
+            size="lg"
+            fullWidth
+            disabled={!isSubmitted && (!hasSelection || isSubmitting)}
+            onClick={isSubmitted ? onClose : onSubmit}
+            className="mt-5"
+          >
+            {isSubmitted
+              ? '확인'
+              : isSubmitting
+                ? '투표 중...'
+                : '투표하기'}
+          </Button>
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function VoteFab({
+  onClick,
+}: {
+  onClick(): void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      aria-label="오늘의 투표 열기"
+      onClick={onClick}
+      className={cn(
+        'bg-main-800 relative flex h-14 w-14 items-center justify-center',
+        'animate-in fade-in zoom-in-95 rounded-full text-white shadow-xl',
+        'transition hover:-translate-y-0.5 hover:brightness-105'
+      )}
+    >
+      <Vote className="h-6 w-6" aria-hidden />
+      <span
+        aria-hidden
+        className={cn(
+          'absolute top-0.5 right-0.5 h-3 w-3 rounded-full',
+          'border-2 border-white bg-red-500'
+        )}
+      />
+    </button>
+  );
+}
+
+export default function VoteFloatingWidget({
+  enabled,
+  hasBottomNav,
+}: VoteFloatingWidgetProps): React.ReactElement | null {
+  const [isDesktopOpen, setIsDesktopOpen] = useState(true);
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const [selectedOptionIds, setSelectedOptionIds] = useState<number[]>([]);
+  const [submittedVote, setSubmittedVote] = useState<VoteDetail | null>(null);
+
+  const { data: todayVotes = [] } = useTodayVotes(enabled);
+  const activeVote = todayVotes.find((vote) => !vote.voted);
+  const voteId = submittedVote?.id ?? activeVote?.id ?? null;
+  const {
+    data: queriedVote,
+    isPending: isDetailLoading,
+    isError: isDetailError,
+    refetch,
+  } = useVoteDetail(voteId, enabled);
+  const submitVote = useSubmitVote();
+  const vote = submittedVote ?? queriedVote;
+
+  const handleOptionClick = useCallback(
+    (optionId: number): void => {
+      if (!vote || submittedVote) {
+        return;
+      }
+      setSelectedOptionIds((current) => {
+        if (vote.selectionType === 'SINGLE') {
+          return [optionId];
+        }
+        return current.includes(optionId)
+          ? current.filter((id) => id !== optionId)
+          : [...current, optionId];
+      });
+    },
+    [submittedVote, vote]
+  );
+
+  const handleSubmit = useCallback((): void => {
+    if (!vote || selectedOptionIds.length === 0) {
+      return;
+    }
+    submitVote.mutate(
+      {
+        voteId: vote.id,
+        data: { optionIds: selectedOptionIds },
+      },
+      {
+        onSuccess: (detail) => setSubmittedVote(detail),
+      }
+    );
+  }, [selectedOptionIds, submitVote, vote]);
+
+  const resetCompletedVote = useCallback((): void => {
+    if (!submittedVote) {
+      return;
+    }
+    setSubmittedVote(null);
+    setSelectedOptionIds([]);
+  }, [submittedVote]);
+
+  const handleDesktopClose = useCallback((): void => {
+    setIsDesktopOpen(false);
+    resetCompletedVote();
+  }, [resetCompletedVote]);
+
+  const handleMobileClose = useCallback((): void => {
+    setIsMobileOpen(false);
+    resetCompletedVote();
+  }, [resetCompletedVote]);
+
+  if (!enabled || voteId === null) {
+    return null;
+  }
+
+  const panelProps: VotePanelProps = {
+    vote,
+    isLoading: isDetailLoading,
+    isError: isDetailError,
+    isSubmitting: submitVote.isPending,
+    isSubmitted: submittedVote !== null,
+    selectedOptionIds,
+    onOptionClick: handleOptionClick,
+    onSubmit: handleSubmit,
+    onRetry: () => {
+      void refetch();
+    },
+    onClose: handleDesktopClose,
+  };
+
+  return (
+    <>
+      <div className="fixed right-6 bottom-6 z-40 hidden lg:block">
+        {isDesktopOpen ? (
+          <VotePanel {...panelProps} />
+        ) : (
+          <VoteFab onClick={() => setIsDesktopOpen(true)} />
+        )}
+      </div>
+      <div
+        className={cn(
+          'fixed right-5 z-40 lg:hidden',
+          hasBottomNav
+            ? 'bottom-[calc(5.5rem+env(safe-area-inset-bottom))]'
+            : 'bottom-[calc(1.25rem+env(safe-area-inset-bottom))]'
+        )}
+      >
+        {isMobileOpen ? (
+          <VotePanel {...panelProps} onClose={handleMobileClose} />
+        ) : (
+          <VoteFab onClick={() => setIsMobileOpen(true)} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/app.feature/vote/consts/queryKeys.ts
+++ b/src/app.feature/vote/consts/queryKeys.ts
@@ -1,0 +1,7 @@
+export const VOTE_QUERY_KEYS = {
+  all: ['votes'] as const,
+  today: () => [...VOTE_QUERY_KEYS.all, 'today'] as const,
+  details: () => [...VOTE_QUERY_KEYS.all, 'detail'] as const,
+  detail: (voteId: number) =>
+    [...VOTE_QUERY_KEYS.details(), voteId] as const,
+};

--- a/src/app.feature/vote/hooks/useVoteMutations.ts
+++ b/src/app.feature/vote/hooks/useVoteMutations.ts
@@ -1,0 +1,40 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { voteApi } from '../api/voteApi';
+import { VOTE_QUERY_KEYS } from '../consts/queryKeys';
+import type {
+  VoteDetail,
+  VoteSubmitRequest,
+  VoteSummary,
+} from '../type/vote';
+
+interface SubmitVoteVariables {
+  voteId: number;
+  data: VoteSubmitRequest;
+}
+
+export function useSubmitVote(): UseMutationResult<
+  VoteDetail,
+  Error,
+  SubmitVoteVariables
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ voteId, data }) => voteApi.submitVote(voteId, data),
+    onSuccess: (detail, { voteId }) => {
+      queryClient.setQueryData(VOTE_QUERY_KEYS.detail(voteId), detail);
+      queryClient.setQueryData<VoteSummary[]>(
+        VOTE_QUERY_KEYS.today(),
+        (votes) =>
+          votes?.map((vote) =>
+            vote.id === voteId ? { ...vote, voted: true } : vote
+          )
+      );
+    },
+  });
+}

--- a/src/app.feature/vote/hooks/useVoteQueries.ts
+++ b/src/app.feature/vote/hooks/useVoteQueries.ts
@@ -1,0 +1,33 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+
+import { voteApi } from '../api/voteApi';
+import { VOTE_QUERY_KEYS } from '../consts/queryKeys';
+import type { VoteDetail, VoteSummary } from '../type/vote';
+
+export function useTodayVotes(
+  enabled: boolean
+): UseQueryResult<VoteSummary[], Error> {
+  return useQuery({
+    queryKey: VOTE_QUERY_KEYS.today(),
+    queryFn: async () => {
+      try {
+        return await voteApi.getTodayVotes();
+      } catch {
+        return [] as VoteSummary[];
+      }
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useVoteDetail(
+  voteId: number | null,
+  enabled: boolean
+): UseQueryResult<VoteDetail, Error> {
+  return useQuery({
+    queryKey: VOTE_QUERY_KEYS.detail(voteId ?? 0),
+    queryFn: () => voteApi.getVoteDetail(voteId ?? 0),
+    enabled: enabled && voteId !== null,
+  });
+}

--- a/src/app.feature/vote/screen/VoteFloatingScreen.tsx
+++ b/src/app.feature/vote/screen/VoteFloatingScreen.tsx
@@ -1,0 +1,15 @@
+import VoteFloatingWidget from '../components/VoteFloatingWidget';
+
+interface VoteFloatingScreenProps {
+  enabled: boolean;
+  hasBottomNav: boolean;
+}
+
+export default function VoteFloatingScreen({
+  enabled,
+  hasBottomNav,
+}: VoteFloatingScreenProps): React.ReactElement {
+  return (
+    <VoteFloatingWidget enabled={enabled} hasBottomNav={hasBottomNav} />
+  );
+}

--- a/src/app.feature/vote/type/vote.ts
+++ b/src/app.feature/vote/type/vote.ts
@@ -1,0 +1,26 @@
+export type VoteSelectionType = 'SINGLE' | 'MULTIPLE';
+export type VoteType = 'PUBLIC' | 'ADMIN_SURVEY';
+
+export interface VoteSummary {
+  id: number;
+  title: string;
+  selectionType: VoteSelectionType;
+  voteType: VoteType;
+  startDate: string;
+  endDate: string;
+  voted: boolean;
+}
+
+export interface VoteOption {
+  optionId: number;
+  text: string;
+  percentage?: number;
+}
+
+export interface VoteDetail extends VoteSummary {
+  options: VoteOption[];
+}
+
+export interface VoteSubmitRequest {
+  optionIds: number[];
+}


### PR DESCRIPTION
## 배경

진행 중인 투표를 사용자가 별도 페이지 이동 없이 확인하고 참여할 수 있는
전역 진입점이 필요했습니다.

완료된 서버 투표 API를 기반으로 로그인 사용자에게 오늘의 미참여 투표를
노출합니다.

## 변경 사항

### 투표 API 연동

- `GET /votes/today`: 오늘 진행 중인 투표 조회
- `GET /votes/{voteId}`: 투표 상세 및 선택 항목 조회
- `POST /votes/{voteId}/responses`: 선택 항목 제출
- 투표 타입, 선택 방식, 항목 및 제출 요청 타입 정의
- Query Key Factory와 TanStack Query 훅 추가
- 제출 성공 시 상세·오늘의 투표 캐시 동기화

### 플로팅 투표 UI

- 로그인 사용자에게 미참여 투표가 있을 때만 노출
- 데스크톱에서는 우측 하단 팝업을 기본 노출
- 모바일에서는 우측 하단 FAB로 노출하고 클릭 시 확장
- 모바일 하단 내비게이션과 safe area를 고려한 위치 적용
- 단일 선택과 복수 선택 지원
- 공개 투표는 제출 후 항목별 결과 비율 표시
- 관리자 설문은 결과 비율을 노출하지 않고 참여 완료 상태만 표시
- 투표 완료 후 확인하면 해당 투표를 다시 노출하지 않음

## 노출 조건

- 인증 상태가 `authenticated`인 사용자
- 오늘 날짜가 투표 시작일과 종료일 사이인 경우
- `/votes/today` 응답에 `voted: false`인 투표가 존재하는 경우

오늘 진행 중인 투표가 없거나 이미 참여한 경우 위젯을 렌더링하지 않습니다.

## 검증

- 신규 변경 범위 ESLint 통과
- `git diff --check` 통과
- `/votes/today`가 빈 배열인 경우 위젯 미노출 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating voting widget for signed-in users.
  * View today’s active votes and vote details.
  * Supports single- and multiple-choice voting.
  * Displays submission results with option percentages.
  * Includes loading, error, retry, close, reopen, and reset states.
  * Adapts its placement for desktop, mobile navigation, and native app layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->