### PR TITLE
style: 법적 안내 문장 길이 정리

### DIFF
--- a/src/app.feature/legal/screen/AccountDeletionScreen.tsx
+++ b/src/app.feature/legal/screen/AccountDeletionScreen.tsx
@@ -4,6 +4,10 @@ import { LegalPageShell } from '../components/LegalPageShell';
 
 const EFFECTIVE_DATE = '2026년 7월 29일';
 const SUPPORT_EMAIL = 'onedayonestreak@gmail.com';
+const ACCOUNT_DELETION_FOOTER = [
+  'Account deletion requests are also accepted by email at',
+  `${SUPPORT_EMAIL}.`,
+].join(' ');
 
 const ACCOUNT_DELETION_SECTIONS: Array<{
   heading: string;
@@ -61,7 +65,7 @@ export default function AccountDeletionScreen(): React.ReactElement {
       description="1D1S 계정과 관련 데이터의 삭제를 요청하는 방법입니다."
       effectiveDate={EFFECTIVE_DATE}
       sections={ACCOUNT_DELETION_SECTIONS}
-      footer="Account deletion requests are also accepted by email at onedayonestreak@gmail.com."
+      footer={ACCOUNT_DELETION_FOOTER}
     />
   );
 }

--- a/src/app.feature/legal/screen/PrivacyScreen.tsx
+++ b/src/app.feature/legal/screen/PrivacyScreen.tsx
@@ -4,6 +4,11 @@ import { LegalPageShell } from '../components/LegalPageShell';
 
 const EFFECTIVE_DATE = '2026년 5월 20일';
 const SUPPORT_EMAIL = 'onedayonestreak@gmail.com';
+const PRIVACY_RIGHTS_GUIDANCE = [
+  '권리 행사는 서비스 내 설정 메뉴 또는',
+  `고객센터(${SUPPORT_EMAIL})를 통해 가능하며,`,
+  '운영자는 지체 없이 조치합니다.',
+].join(' ');
 
 const PRIVACY_SECTIONS: Array<{ heading: string; body: string }> = [
   {
@@ -65,7 +70,7 @@ const PRIVACY_SECTIONS: Array<{ heading: string; body: string }> = [
 다. 개인정보 처리 정지 요구
 라. 회원 탈퇴
 
-권리 행사는 서비스 내 설정 메뉴 또는 고객센터(${SUPPORT_EMAIL})를 통해 가능하며, 운영자는 지체 없이 조치합니다.`,
+${PRIVACY_RIGHTS_GUIDANCE}`,
   },
   {
     heading: '7. 개인정보의 파기 절차 및 방법',


### PR DESCRIPTION
## Summary

- CodeRabbit이 지적한 긴 법적 안내 문장을 출력 변경 없이 상수로 분리했습니다.
- `/account-deletion` 페이지와 개인정보 처리방침의 가독성 규칙을 맞췄습니다.

## Validation

- 대상 파일 ESLint
- `pnpm exec tsc --noEmit`
- `pnpm build`