### PR TITLE
release: 계정 삭제 안내 페이지 상용 배포

### DIFF
--- a/src/app.feature/legal/components/LegalPageShell.tsx
+++ b/src/app.feature/legal/components/LegalPageShell.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 interface LegalSection {
   heading: string;
-  body: string;
+  body: React.ReactNode;
 }
 
 interface LegalPageShellProps {

--- a/src/app.feature/legal/screen/AccountDeletionScreen.tsx
+++ b/src/app.feature/legal/screen/AccountDeletionScreen.tsx
@@ -4,6 +4,10 @@ import { LegalPageShell } from '../components/LegalPageShell';
 
 const EFFECTIVE_DATE = '2026년 7월 29일';
 const SUPPORT_EMAIL = 'onedayonestreak@gmail.com';
+const ACCOUNT_DELETION_FOOTER = [
+  'Account deletion requests are also accepted by email at',
+  `${SUPPORT_EMAIL}.`,
+].join(' ');
 
 const ACCOUNT_DELETION_SECTIONS: Array<{
   heading: string;
@@ -61,7 +65,7 @@ export default function AccountDeletionScreen(): React.ReactElement {
       description="1D1S 계정과 관련 데이터의 삭제를 요청하는 방법입니다."
       effectiveDate={EFFECTIVE_DATE}
       sections={ACCOUNT_DELETION_SECTIONS}
-      footer="Account deletion requests are also accepted by email at onedayonestreak@gmail.com."
+      footer={ACCOUNT_DELETION_FOOTER}
     />
   );
 }

--- a/src/app.feature/legal/screen/AccountDeletionScreen.tsx
+++ b/src/app.feature/legal/screen/AccountDeletionScreen.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { LegalPageShell } from '../components/LegalPageShell';
+
+const EFFECTIVE_DATE = '2026년 7월 29일';
+const SUPPORT_EMAIL = 'onedayonestreak@gmail.com';
+
+const ACCOUNT_DELETION_SECTIONS: Array<{
+  heading: string;
+  body: React.ReactNode;
+}> = [
+  {
+    heading: '앱에서 계정 삭제하기',
+    body: `1. 1D1S 앱에서 소셜 계정으로 로그인합니다.
+2. 마이페이지에서 설정을 선택합니다.
+3. 화면 아래의 회원 탈퇴를 선택합니다.
+4. 안내 내용을 확인한 뒤 회원 탈퇴를 확정합니다.`,
+  },
+  {
+    heading: '앱을 이용할 수 없는 경우',
+    body: (
+      <>
+        가입한 소셜 계정의 이메일 주소와 함께 아래 이메일로 계정 삭제를 요청해
+        주세요.{'\n'}
+        <a
+          href={`mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+            '[1D1S] 계정 삭제 요청'
+          )}`}
+          className="font-semibold text-orange-500 underline underline-offset-2"
+        >
+          {SUPPORT_EMAIL}
+        </a>
+      </>
+    ),
+  },
+  {
+    heading: '삭제되는 데이터',
+    body: (
+      <>
+        계정 정보, 프로필, 일지, 챌린지, 댓글 등 계정과 연결된 데이터가
+        삭제됩니다. 회원 탈퇴 요청 후 계정 삭제는 7일 뒤 처리됩니다.
+      </>
+    ),
+  },
+  {
+    heading: '보관될 수 있는 데이터',
+    body: (
+      <>
+        관련 법령에 따라 보관이 필요한 데이터는 법정 기간 동안 분리하여 보관한
+        뒤 안전하게 삭제합니다. 자세한 내용은 개인정보 처리방침에서 확인할 수
+        있습니다.
+      </>
+    ),
+  },
+];
+
+export default function AccountDeletionScreen(): React.ReactElement {
+  return (
+    <LegalPageShell
+      title="1D1S 계정 삭제 안내"
+      description="1D1S 계정과 관련 데이터의 삭제를 요청하는 방법입니다."
+      effectiveDate={EFFECTIVE_DATE}
+      sections={ACCOUNT_DELETION_SECTIONS}
+      footer="Account deletion requests are also accepted by email at onedayonestreak@gmail.com."
+    />
+  );
+}

--- a/src/app.feature/legal/screen/PrivacyScreen.tsx
+++ b/src/app.feature/legal/screen/PrivacyScreen.tsx
@@ -4,6 +4,11 @@ import { LegalPageShell } from '../components/LegalPageShell';
 
 const EFFECTIVE_DATE = '2026년 5월 20일';
 const SUPPORT_EMAIL = 'onedayonestreak@gmail.com';
+const PRIVACY_RIGHTS_GUIDANCE = [
+  '권리 행사는 서비스 내 설정 메뉴 또는',
+  `고객센터(${SUPPORT_EMAIL})를 통해 가능하며,`,
+  '운영자는 지체 없이 조치합니다.',
+].join(' ');
 
 const PRIVACY_SECTIONS: Array<{ heading: string; body: string }> = [
   {
@@ -65,7 +70,7 @@ const PRIVACY_SECTIONS: Array<{ heading: string; body: string }> = [
 다. 개인정보 처리 정지 요구
 라. 회원 탈퇴
 
-권리 행사는 서비스 내 설정 메뉴 또는 고객센터(${SUPPORT_EMAIL})를 통해 가능하며, 운영자는 지체 없이 조치합니다.`,
+${PRIVACY_RIGHTS_GUIDANCE}`,
   },
   {
     heading: '7. 개인정보의 파기 절차 및 방법',

--- a/src/app.feature/legal/screen/PrivacyScreen.tsx
+++ b/src/app.feature/legal/screen/PrivacyScreen.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { LegalPageShell } from '../components/LegalPageShell';
 
 const EFFECTIVE_DATE = '2026년 5월 20일';
+const SUPPORT_EMAIL = 'onedayonestreak@gmail.com';
 
 const PRIVACY_SECTIONS: Array<{ heading: string; body: string }> = [
   {
@@ -64,7 +65,7 @@ const PRIVACY_SECTIONS: Array<{ heading: string; body: string }> = [
 다. 개인정보 처리 정지 요구
 라. 회원 탈퇴
 
-권리 행사는 서비스 내 설정 메뉴 또는 고객센터(support@1day1streak.com)를 통해 가능하며, 운영자는 지체 없이 조치합니다.`,
+권리 행사는 서비스 내 설정 메뉴 또는 고객센터(${SUPPORT_EMAIL})를 통해 가능하며, 운영자는 지체 없이 조치합니다.`,
   },
   {
     heading: '7. 개인정보의 파기 절차 및 방법',
@@ -88,7 +89,7 @@ const PRIVACY_SECTIONS: Array<{ heading: string; body: string }> = [
     body: `운영자는 개인정보 처리에 관한 업무를 총괄해서 책임지고, 개인정보 처리와 관련한 정보주체의 불만 처리 및 피해 구제 등을 위하여 아래와 같이 개인정보 보호책임자를 지정하고 있습니다.
 
 - 개인정보 보호책임자: 1Day 1Streak 운영팀
-- 연락처: support@1day1streak.com`,
+- 연락처: ${SUPPORT_EMAIL}`,
   },
   {
     heading: '10. 권익침해 구제방법',

--- a/src/app/account-deletion/page.tsx
+++ b/src/app/account-deletion/page.tsx
@@ -1,0 +1,13 @@
+import AccountDeletionScreen from '@feature/legal/screen/AccountDeletionScreen';
+import type { Metadata } from 'next';
+import React from 'react';
+
+export const metadata: Metadata = {
+  title: '계정 삭제 안내 | 1Day 1Streak',
+  description:
+    '1Day 1Streak 계정과 관련 데이터의 삭제를 요청하는 방법을 안내합니다.',
+};
+
+export default function AccountDeletionPage(): React.ReactElement {
+  return <AccountDeletionScreen />;
+}


### PR DESCRIPTION
## Summary

Google Play 계정 삭제 정책 대응 변경만 상용 환경에 배포합니다.

## Scope

- `/account-deletion` 공개 페이지
- `onedayonestreak@gmail.com` 이메일 삭제 요청 링크
- 개인정보 처리방침 연락처 정정
- 기존 `develop`의 다른 미출시 변경은 포함하지 않음

## Validation

- 대상 파일 ESLint
- `pnpm exec tsc --noEmit`
- `pnpm test` (176 passed on main baseline)
- `pnpm build`