### PR TITLE
release: 알림 딥링크 읽음 처리(notifId) 상용 반영

### DIFF
--- a/.github/workflows/discord-deploy-notify.yml
+++ b/.github/workflows/discord-deploy-notify.yml
@@ -1,96 +1,84 @@
 name: Discord Deploy Notify
 
-# 웹은 Vercel Git 연동으로 배포된다(서버처럼 GitHub Actions 배포 잡이 아님).
-# Vercel[bot] 이 배포마다 GitHub Deployments + deployment_status 를 생성하므로,
-# 그 이벤트를 트리거로 삼아 디스코드 봇(웹훅 아님)으로 배포 완료/실패를 알린다.
+# 웹은 Vercel Git 연동으로 배포된다. 이전엔 on: deployment_status 로 배포 완료를
+# 잡으려 했으나, Vercel 이 GitHub Deployment 이벤트를 뿌리지 않아 워크플로가
+# 절대 발화하지 않았다. → PR 알림(discord-pr-notification)과 동일하게 push 이벤트
+# + 봇 토큰 직접 POST 로 바꾼다. push 는 Vercel 의존 없이 항상 발화한다.
 #
-# ⚠️ 기본 브랜치 제약: deployment_status 워크플로는 GitHub 규칙상 "레포 기본
-#    브랜치"의 워크플로 정의로만 실행된다. 이 레포 기본 브랜치는 develop 이므로
-#    이 파일이 develop 에 있으면 발화한다. (기본 브랜치가 main 으로 바뀌면 main
-#    에도 이 파일을 반영해야 발화한다.)
+# push = "Vercel 배포 트리거" 시점이라(완료/성공 개념 없음), 문구는 "배포 트리거"
+# 로 정직하게 쓴다. develop push → WEB(DEV), main push → WEB(PROD) 로 구분.
 #
-# ⚠️ 필요 시크릿: DISCORD_BOT_TOKEN — 현재 server-v2 레포에만 있다. 이 client
-#    레포의 Settings > Secrets and variables > Actions 에 **동일 값**으로 추가해야
-#    동작한다. (봇이 아래 채널에 메시지 쓰기 권한을 가져야 함)
+# ⚠️ on: push 워크플로는 "푸시된 브랜치/커밋에 있는 정의"로 실행된다. 따라서
+#    main 라벨 알림은 이 파일이 main 에 반영된 이후(다음 승격)부터 동작한다.
+#    develop 은 이 파일이 있는 즉시 동작.
+#
+# ⚠️ 필요 시크릿: DISCORD_BOT_TOKEN — 이 client 레포의
+#    Settings > Secrets and variables > Actions 에 등록돼 있어야 한다(서버 레포의
+#    값과 동일). 레포 간 시크릿은 공유되지 않으므로 별도 등록 필요. 봇은 아래
+#    채널에 메시지 쓰기 권한이 있어야 한다.
 
 on:
-  deployment_status:
+  push:
+    branches: [develop, main]
 
 permissions:
   contents: read
 
 jobs:
   notify:
-    # 성공/실패/에러 상태에서만 알림(pending·in_progress·queued 는 무시).
-    if: >-
-      github.event.deployment_status.state == 'success' ||
-      github.event.deployment_status.state == 'failure' ||
-      github.event.deployment_status.state == 'error'
     runs-on: ubuntu-latest
     steps:
       - name: Notify Discord
         uses: actions/github-script@v7
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          # 알림 채널 ID(server-dev/PR 알림과 공유). WEB(ENV) 접두어로 구분한다.
-          # 별도 채널을 원하면 이 값만 교체하면 된다.
+          # 알림 채널 ID(PR 알림/서버 알림과 공유). WEB(ENV) 접두어로 구분.
+          # 별도 채널을 원하면 이 값만 교체.
           CHANNEL_ID: '1351796500279197757'
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const token = process.env.DISCORD_BOT_TOKEN;
             const channelId = process.env.CHANNEL_ID;
             if (!token) {
               core.setFailed(
-                'DISCORD_BOT_TOKEN 시크릿이 없습니다. client 레포에 동일 값 등록 필요.'
+                'DISCORD_BOT_TOKEN 시크릿이 없습니다. client 레포에 등록 필요.'
               );
               return;
             }
 
-            const ds = context.payload.deployment_status || {};
-            const deployment = context.payload.deployment || {};
-            const state = ds.state; // success | failure | error
-            const rawEnv = ds.environment || deployment.environment || '';
-            const targetUrl = ds.target_url || ds.environment_url || '';
-            const sha = deployment.sha || context.sha;
+            // push 페이로드의 tip 커밋. 브랜치 삭제/특수 push 로 없으면 스킵.
+            const head = context.payload.head_commit;
+            if (!head) {
+              core.info('head_commit 없음 — 알림 스킵');
+              return;
+            }
+
+            const branch = context.ref.replace('refs/heads/', '');
+            const envLabel =
+              branch === 'main'
+                ? 'PROD'
+                : branch === 'develop'
+                  ? 'DEV'
+                  : branch.toUpperCase();
+
+            const sha = head.id || context.sha;
             const shortSha = sha ? sha.slice(0, 7) : '(unknown)';
+            const title = (head.message || '').split('\n')[0];
+            const actor =
+              context.actor ||
+              (head.author && (head.author.username || head.author.name)) ||
+              '';
+            const url =
+              head.url ||
+              `https://github.com/${context.repo.owner}/` +
+                `${context.repo.repo}/commit/${sha}`;
 
-            // 환경 라벨: Production→PROD, Preview→DEV, 그 외(staging 등)는 대문자.
-            let envLabel;
-            if (rawEnv === 'Production') {
-              envLabel = 'PROD';
-            } else if (rawEnv === 'Preview') {
-              envLabel = 'DEV';
-            } else {
-              envLabel = (rawEnv || 'UNKNOWN').toUpperCase();
-            }
-
-            // 커밋 메시지 첫 줄 + 작성자 — 이벤트 payload 엔 없어 API 로 조회.
-            let commitTitle = '';
-            let actor = '';
-            try {
-              const { data: commit } = await github.rest.repos.getCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: sha,
-              });
-              commitTitle = (commit.commit.message || '').split('\n')[0];
-              actor =
-                (commit.author && commit.author.login) ||
-                (commit.commit.author && commit.commit.author.name) ||
-                '';
-            } catch (error) {
-              core.warning(`커밋 조회 실패: ${error.message}`);
-            }
-
-            // 서버 메시지와 동일한 4줄 형식(성공 ✅ / 실패·에러 ❌).
-            const icon = state === 'success' ? '✅' : '❌';
-            const verb = state === 'success' ? '배포 완료' : '배포 실패';
+            // push=배포 트리거 시점(완료 아님) → "배포 트리거" 로 정직하게.
             const content = [
-              `${icon} WEB(${envLabel}) ${verb}`,
+              `🚀 WEB(${envLabel}) 배포 트리거`,
               `\`${shortSha}\`${actor ? ` by ${actor}` : ''}`,
-              commitTitle,
-              targetUrl,
+              title,
+              url,
             ]
               .filter(Boolean)
               .join('\n');

--- a/public/sw.js
+++ b/public/sw.js
@@ -31,6 +31,16 @@ function resolveNotificationUrl(data) {
   return '/notification';
 }
 
+// 딥링크 URL 에 notifId 쿼리를 붙여, 웹 클라이언트가 진입 시 해당 알림을
+// 읽음 처리할 수 있게 한다(useMarkReadFromDeepLink). id 가 없으면 원본 URL 그대로.
+function appendNotifId(url, notifId) {
+  if (notifId === null || notifId === undefined) {
+    return url;
+  }
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}notifId=${notifId}`;
+}
+
 self.addEventListener('push', (event) => {
   console.log('[SW] push event received', event.data?.text());
 
@@ -53,7 +63,16 @@ self.addEventListener('push', (event) => {
     icon: '/images/logo.png',
     badge: '/images/logo.png',
     // 클릭 시 이동할 딥링크를 미리 계산해 저장한다.
-    data: { url: resolveNotificationUrl(data) },
+    data: {
+      url: resolveNotificationUrl(data),
+      // 서버가 알림 id 를 실어주면 클릭 시 읽음 처리에 사용한다(없으면 null).
+      notificationId:
+        typeof data.notificationId === 'number'
+          ? data.notificationId
+          : typeof data.id === 'number'
+            ? data.id
+            : null,
+    },
   };
 
   console.log('[SW] showNotification', title, options);
@@ -62,7 +81,9 @@ self.addEventListener('push', (event) => {
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const url = event.notification.data?.url ?? '/notification';
+  const baseUrl = event.notification.data?.url ?? '/notification';
+  // notifId 를 딥링크에 실어, 진입한 웹 클라이언트가 해당 알림을 읽음 처리한다.
+  const url = appendNotifId(baseUrl, event.notification.data?.notificationId);
 
   event.waitUntil(
     clients

--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -5,6 +5,7 @@ import { AddToHomeScreenPrompt } from '@feature/install/components/AddToHomeScre
 import { usePhoneNumberMissing } from '@feature/member/hooks/usePhoneNumberMissing';
 import { BrowserPermissionPrompt } from '@feature/notification/components/BrowserPermissionPrompt';
 import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
+import { useMarkReadFromDeepLink } from '@module/hooks/useMarkReadFromDeepLink';
 import { useServiceWorkerNavigation } from '@module/hooks/useServiceWorkerNavigation';
 import { useTokenRefreshOnResume } from '@module/hooks/useTokenRefreshOnResume';
 import { buildLoginUrl } from '@module/utils/returnTo';
@@ -136,6 +137,7 @@ export default function AppLayoutShell({
   useTokenRefreshOnResume();
   // 알림 클릭 시 서비스워커가 보낸 딥링크를 라우터 push 로 처리(뒤로가기 보존).
   useServiceWorkerNavigation();
+  useMarkReadFromDeepLink();
 
   // 인증/사이드바 상태는 별도 hook 으로 묶었다. shell 은 라우트 가시성 판단과
   // 핸들러 안정화에만 집중한다.

--- a/src/app.module/hooks/useMarkReadFromDeepLink.ts
+++ b/src/app.module/hooks/useMarkReadFromDeepLink.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useMarkAsRead } from '@feature/notification/hooks/useNotificationMutations';
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+/**
+ * 알림 딥링크(`...?notifId=<id>`)로 진입하면 해당 알림을 읽음 처리한다.
+ *
+ * 알림 리스트에서 항목을 탭하는 경로는 NotificationListItem 이 직접
+ * useMarkAsRead 를 호출해 이미 읽음 처리된다. 하지만 푸시 알림/딥링크로
+ * 대상 화면(예: /challenge/123)에 바로 들어오는 경로는 리스트를 거치지
+ * 않아 읽음 처리가 누락됐다. 서비스워커(sw.js)·네이티브 쉘이 딥링크에
+ * `notifId` 쿼리를 실어 주면, 진입한 클라이언트가 여기서 읽음 처리한다.
+ *
+ * 서버가 푸시 payload 에 알림 id 를 넣어줘야 sw.js 가 notifId 를 붙인다
+ * (없으면 이 훅은 no-op). useSearchParams 는 전체 트리를 CSR 로 떨구므로
+ * 쓰지 않고, 네비게이션(pathname 변화)마다 location.search 를 직접 읽는다.
+ */
+export function useMarkReadFromDeepLink(): void {
+  const pathname = usePathname();
+  const { mutate: markAsRead } = useMarkAsRead();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get('notifId');
+    if (!raw) {
+      return;
+    }
+    const id = Number(raw);
+    if (Number.isInteger(id) && id > 0) {
+      markAsRead(id);
+    }
+    // 새로고침/공유 시 재호출·URL 오염을 막도록 쿼리에서 제거한다.
+    params.delete('notifId');
+    const qs = params.toString();
+    const next = window.location.pathname + (qs ? `?${qs}` : '');
+    window.history.replaceState(window.history.state, '', next);
+  }, [pathname, markAsRead]);
+}


### PR DESCRIPTION
## 승격 대상 (#248 이후 develop 누적)

- `e97ba90` fix: 알림 딥링크(notifId) 진입 시 해당 알림 읽음 처리
- `694c6f4` ci: 배포 알림 push 트리거 전환(런타임 무관)

## 변경
- `public/sw.js` — 딥링크에 `?notifId=<id>` 부착(id 없으면 URL 그대로)
- `src/app.module/hooks/useMarkReadFromDeepLink.ts` (신규) — 진입 시 notifId 읽어 읽음 처리 후 쿼리 제거
- `src/app.component/layout/AppLayoutShell.tsx` — 훅 마운트

## breaking change 없음
- `appendNotifId`: notifId null/undefined → 원본 URL 그대로 → 기존 PWA/브라우저 푸시 네비게이션 동일(회귀 없음)
- 훅: `?notifId` 없으면 no-op
- 전제(이미 prod 존재): `PATCH /notifications/{id}/read`, FCM payload `notificationId`
- 신규 env/UI 없음

develop HEAD CI green(CI/build/tsc/knip/lint/vitest 181).