### PR TITLE
release: develop → main 상용 승격 (#250 이후 8건)

### DIFF
--- a/src/app.component/LoginRequiredDialog.tsx
+++ b/src/app.component/LoginRequiredDialog.tsx
@@ -40,6 +40,11 @@ interface LoginRequiredDialogProps {
   returnTo?: string | null;
 }
 
+// 네이티브 로그인 모달 중복 억제(모듈 스코프). 여러 화면/인스턴스(딥링크 상세
+// 등)가 동시에 로그인 모달을 요청해 앱 팝업이 겹치는 것을 막는다. 모달이 떠
+// 있는 동안 true, 사용자가 닫으면(응답) false 로 풀린다.
+let nativeLoginModalInFlight = false;
+
 export function LoginRequiredDialog({
   open,
   onOpenChange,
@@ -62,35 +67,42 @@ export function LoginRequiredDialog({
   // AlertDialog) 가 뜨도록 모달 브릿지로 위임한다. required 모드도
   // 같은 동작 — 사용자가 dismiss(밖 클릭/시스템 백) 하면 onClose 호출.
   useEffect(() => {
-    if (!isNativeApp || !open) {
+    // 이미 네이티브 로그인 모달이 떠 있으면(다른 화면/인스턴스가 요청) 중복
+    // 요청을 막아 앱 팝업이 겹치지 않게 한다.
+    if (!isNativeApp || !open || nativeLoginModalInFlight) {
       return;
     }
+    nativeLoginModalInFlight = true;
     let cancelled = false;
     void (async () => {
-      const result = await openNativeModal({
-        title,
-        message: description,
-        // 아래 웹 분기(ConfirmDialog / required 다이얼로그)와 같은 배지를
-        // 네이티브에도 실어 보낸다. 이걸 빼면 앱에서만 아이콘 없는 모달이
-        // 떠서, 같은 "로그인이 필요합니다"가 진입 경로에 따라 다르게 생긴다
-        // (네이티브 FAB 게이트는 배지가 있고, 웹 위임분은 없었다).
-        icon: 'LogIn',
-        tone: 'brand',
-        buttons: [
-          { label: '닫기', value: 'cancel', style: 'cancel' },
-          { label: '로그인', value: 'login' },
-        ],
-      });
-      if (cancelled) {
-        return;
-      }
-      onOpenChange(false);
-      if (result === 'login') {
-        router.push(
-          returnTo ? buildLoginUrl(returnTo) : loginUrlFromCurrentLocation()
-        );
-      } else if (required) {
-        onClose?.();
+      try {
+        const result = await openNativeModal({
+          title,
+          message: description,
+          // 아래 웹 분기(ConfirmDialog / required 다이얼로그)와 같은 배지를
+          // 네이티브에도 실어 보낸다. 이걸 빼면 앱에서만 아이콘 없는 모달이
+          // 떠서, 같은 "로그인이 필요합니다"가 진입 경로에 따라 다르게 생긴다
+          // (네이티브 FAB 게이트는 배지가 있고, 웹 위임분은 없었다).
+          icon: 'LogIn',
+          tone: 'brand',
+          buttons: [
+            { label: '닫기', value: 'cancel', style: 'cancel' },
+            { label: '로그인', value: 'login' },
+          ],
+        });
+        if (cancelled) {
+          return;
+        }
+        onOpenChange(false);
+        if (result === 'login') {
+          router.push(
+            returnTo ? buildLoginUrl(returnTo) : loginUrlFromCurrentLocation()
+          );
+        } else if (required) {
+          onClose?.();
+        }
+      } finally {
+        nativeLoginModalInFlight = false;
       }
     })();
     return () => {

--- a/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
@@ -29,6 +29,7 @@ import {
   useChallengeCreateForm,
 } from '@feature/challenge/write/hooks/useChallengeCreateForm';
 import { formatFormValues } from '@feature/challenge/write/utils/challengeCreatePayload';
+import { getChallengeCreateCtaHint } from '@feature/challenge/write/utils/challengeCtaHint';
 import { useNativeSubmitBar } from '@module/hooks/useNativeSubmitBar';
 import { cn } from '@module/utils/cn';
 import {
@@ -125,6 +126,17 @@ export default function ChallengeCreateScreen(): React.ReactElement {
   };
 
   const canSubmit = form.formState.isValid && !createChallenge.isPending;
+  // 완료 버튼이 왜 막혔는지 — 필수 항목을 화면 배치 순서대로 스캔해 첫 미충족
+  // 항목의 안내 문구. 충족되면 undefined(힌트 제거). 미충족인데 매칭 문구가
+  // 없으면(길이 초과 등 엣지) 일반 문구로 폴백해 항상 사유를 노출한다.
+  // 검증 실패(제출 중이 아니라 값 미충족)일 때만 힌트를 만든다 — 제출 중
+  // (값은 유효)에는 힌트를 보내지 않는다.
+  const ctaHint = form.formState.isValid
+    ? undefined
+    : (getChallengeCreateCtaHint(form.watch()) ??
+      '입력한 내용을 확인해주세요.');
+  // 버튼/다이얼로그 라벨용 — 항상 문자열(유효하면 실행 문구, 미충족이면 사유).
+  const ctaLabel = ctaHint ?? '챌린지 만들기';
   const handleCreateRequest = async (): Promise<void> => {
     if (!nativeModalAvailable) {
       form.handleSubmit(onSubmit)();
@@ -147,7 +159,8 @@ export default function ChallengeCreateScreen(): React.ReactElement {
   const nativeCtaDelegated = useNativeSubmitBar(
     '챌린지 만들기',
     !canSubmit,
-    () => void handleCreateRequest()
+    () => void handleCreateRequest(),
+    { disabledHint: ctaHint }
   );
 
   return (
@@ -260,7 +273,7 @@ export default function ChallengeCreateScreen(): React.ReactElement {
                   입력 완료 · 만들 준비가 됐어요
                 </>
               ) : (
-                '필수 항목을 입력해 주세요'
+                ctaHint
               )}
             </Text>
             <div className="w-full lg:ml-auto lg:w-auto">
@@ -271,19 +284,13 @@ export default function ChallengeCreateScreen(): React.ReactElement {
                   className="w-full lg:w-auto"
                   onClick={() => void handleCreateRequest()}
                 >
-                  {canSubmit
-                    ? '챌린지 만들기'
-                    : '제목 · 내 목표를 입력해 주세요'}
+                  {ctaLabel}
                 </Button>
               ) : (
                 <ChallengeCreateDialog
                   onConfirm={() => form.handleSubmit(onSubmit)()}
                   disabled={!canSubmit}
-                  triggerText={
-                    canSubmit
-                      ? '챌린지 만들기'
-                      : '제목 · 내 목표를 입력해 주세요'
-                  }
+                  triggerText={ctaLabel}
                   triggerClassName="w-full lg:w-auto"
                 />
               )}

--- a/src/app.feature/challenge/write/screen/ChallengeEditScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeEditScreen.tsx
@@ -29,6 +29,7 @@ import {
   type EditableChallengeCategory,
   useChallengeEditForm,
 } from '@feature/challenge/write/hooks/useChallengeEditForm';
+import { getChallengeEditCtaHint } from '@feature/challenge/write/utils/challengeCtaHint';
 import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { useNativeSubmitBar } from '@module/hooks/useNativeSubmitBar';
 import { cn } from '@module/utils/cn';
@@ -203,12 +204,21 @@ function ChallengeEditScreenContent({
   };
 
   const canSubmit = form.formState.isValid && !updateChallenge.isPending;
+  // 완료가 왜 막혔는지 — 필수 항목을 화면 배치 순서대로 스캔한 첫 미충족 문구.
+  // 검증 실패일 때만(제출 중 제외) 만든다. 라벨용은 항상 문자열로 보정.
+  const ctaHint = form.formState.isValid
+    ? undefined
+    : (getChallengeEditCtaHint(form.watch()) ?? '입력한 내용을 확인해주세요.');
+  const ctaLabel = updateChallenge.isPending
+    ? '저장 중...'
+    : (ctaHint ?? '수정 완료');
 
   // 앱(웹뷰)에선 하단 CTA 를 네이티브 고정 바로 위임한다(8-1).
   const nativeCtaDelegated = useNativeSubmitBar(
     '수정 완료',
     !canSubmit,
-    () => form.handleSubmit(onSubmit)()
+    () => form.handleSubmit(onSubmit)(),
+    { disabledHint: ctaHint }
   );
 
   return (
@@ -320,7 +330,7 @@ function ChallengeEditScreenContent({
                   변경 사항을 저장할 수 있어요
                 </>
               ) : (
-                '필수 항목을 확인해 주세요'
+                ctaHint
               )}
             </Text>
             <div className="w-full lg:ml-auto lg:w-auto">
@@ -329,9 +339,7 @@ function ChallengeEditScreenContent({
                 disabled={!canSubmit}
                 startDate={startDate}
                 endDate={endDate}
-                triggerText={
-                  updateChallenge.isPending ? '저장 중...' : '수정 완료'
-                }
+                triggerText={ctaLabel}
                 triggerClassName="w-full lg:w-auto"
               />
             </div>

--- a/src/app.feature/challenge/write/utils/challengeCtaHint.test.ts
+++ b/src/app.feature/challenge/write/utils/challengeCtaHint.test.ts
@@ -1,0 +1,122 @@
+import { addDays, startOfToday } from 'date-fns';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getChallengeCreateCtaHint,
+  getChallengeEditCtaHint,
+} from './challengeCtaHint';
+
+const tomorrow = addDays(startOfToday(), 1);
+
+// 개별참여·무기한·공개의 최소 유효 생성 값(필수 모두 충족).
+const validCreate = {
+  title: '매일 30분 책 읽기',
+  category: 'BOOK' as const,
+  participationType: 'INDIVIDUAL' as const,
+  periodType: 'ENDLESS' as const,
+  challengeType: 'PUBLIC' as const,
+  startDate: tomorrow,
+  goals: [{ value: '30분 독서' }],
+};
+
+describe('getChallengeCreateCtaHint — 배치 순서대로 첫 미충족만', () => {
+  it('모두 충족되면 null', () => {
+    expect(getChallengeCreateCtaHint(validCreate)).toBeNull();
+  });
+
+  it('제목·카테고리 미입력 → 제목 문구(첫 번째)', () => {
+    expect(
+      getChallengeCreateCtaHint({
+        ...validCreate,
+        title: '',
+        category: undefined,
+      })
+    ).toBe('챌린지 제목을 입력해주세요.');
+  });
+
+  it('제목은 됐고 카테고리·시작일 미입력 → 카테고리 문구', () => {
+    expect(
+      getChallengeCreateCtaHint({
+        ...validCreate,
+        category: undefined,
+        startDate: undefined,
+      })
+    ).toBe('카테고리를 선택해주세요.');
+  });
+
+  it('제목·카테고리 됐고 목표 없음 → 목표 문구', () => {
+    expect(
+      getChallengeCreateCtaHint({ ...validCreate, goals: [] })
+    ).toBe('목표를 하나 이상 입력해주세요.');
+  });
+
+  it('그룹인데 인원 미선택 → 목표보다 먼저 인원 문구', () => {
+    expect(
+      getChallengeCreateCtaHint({
+        ...validCreate,
+        participationType: 'GROUP',
+        memberCount: undefined,
+        goals: [],
+      })
+    ).toBe('챌린지 인원을 선택해주세요.');
+  });
+
+  it('기간 한정인데 기간 미선택 → 기간 문구', () => {
+    expect(
+      getChallengeCreateCtaHint({
+        ...validCreate,
+        periodType: 'LIMITED',
+        period: undefined,
+      })
+    ).toBe('챌린지 기간을 선택해주세요.');
+  });
+
+  it('비공개인데 비밀번호 미달 → 비밀번호 문구(마지막)', () => {
+    expect(
+      getChallengeCreateCtaHint({
+        ...validCreate,
+        challengeType: 'PRIVATE',
+        password: '12',
+      })
+    ).toBe('비밀번호를 4자 이상 20자 이하로 입력해주세요.');
+  });
+});
+
+describe('getChallengeEditCtaHint — 시작 후엔 인원·목표 검사 생략', () => {
+  const validEdit = {
+    title: '수정된 제목',
+    category: 'DEV' as const,
+    isGroup: true,
+    isFixedGoal: true,
+    isStarted: false,
+    memberCount: '5' as const,
+    goals: [{ value: '목표' }],
+  };
+
+  it('모두 충족되면 null', () => {
+    expect(getChallengeEditCtaHint(validEdit)).toBeNull();
+  });
+
+  it('제목 비우면 제목 문구', () => {
+    expect(getChallengeEditCtaHint({ ...validEdit, title: '' })).toBe(
+      '챌린지 제목을 입력해주세요.'
+    );
+  });
+
+  it('시작 전 그룹·인원 미선택 → 인원 문구', () => {
+    expect(
+      getChallengeEditCtaHint({ ...validEdit, memberCount: undefined })
+    ).toBeTruthy();
+  });
+
+  it('이미 시작됐으면 인원·목표 비어도 null(수정 불가 항목)', () => {
+    expect(
+      getChallengeEditCtaHint({
+        ...validEdit,
+        isStarted: true,
+        memberCount: undefined,
+        goals: [],
+      })
+    ).toBeNull();
+  });
+});

--- a/src/app.feature/challenge/write/utils/challengeCtaHint.ts
+++ b/src/app.feature/challenge/write/utils/challengeCtaHint.ts
@@ -1,0 +1,114 @@
+import { startOfToday } from 'date-fns';
+
+import type { ChallengeCreateFormValues } from '../hooks/useChallengeCreateForm';
+import type { ChallengeEditFormValues } from '../hooks/useChallengeEditForm';
+
+// 하단 CTA 가 왜 막혔는지 안내한다. 필수 항목을 "화면 배치 순서(위→아래)" 대로
+// 스캔해 처음 비어있는 항목 하나의 문구만 반환한다. 모두 충족되면 null.
+// 문구·조건은 zod 스키마(challengeCreateFormSchema/challengeEditFormSchema)와
+// 동일하게 맞춘다 — 힌트(null 여부)와 formState.isValid 가 어긋나지 않도록.
+
+function isWholeNumberInRange(
+  value: string | undefined,
+  min: number,
+  max: number
+): boolean {
+  if (!value || !/^\d+$/.test(value)) {
+    return false;
+  }
+  const n = Number(value);
+  return Number.isInteger(n) && n >= min && n <= max;
+}
+
+/**
+ * 챌린지 생성 폼의 첫 미충족 필수 항목 안내. 섹션 배치 순서:
+ * 제목 → 카테고리 → (그룹이면) 인원 → 목표 → (기간 한정이면) 기간 → 시작일 →
+ * (비공개면) 비밀번호.
+ */
+export function getChallengeCreateCtaHint(
+  v: Partial<ChallengeCreateFormValues>
+): string | null {
+  if (!v.title?.trim()) {
+    return '챌린지 제목을 입력해주세요.';
+  }
+  if (v.title.length > 50) {
+    return '챌린지 제목은 50자 이하로 입력해주세요.';
+  }
+  if (!v.category) {
+    return '카테고리를 선택해주세요.';
+  }
+  if (v.participationType === 'GROUP') {
+    if (!v.memberCount) {
+      return '챌린지 인원을 선택해주세요.';
+    }
+    if (v.memberCount === 'etc' && !isWholeNumberInRange(v.memberCountNumber, 2, 100)) {
+      return '인원을 2명부터 100명 사이로 입력해주세요.';
+    }
+  }
+  if (
+    !v.goals ||
+    v.goals.length === 0 ||
+    v.goals.some((goal) => !goal.value?.trim())
+  ) {
+    return '목표를 하나 이상 입력해주세요.';
+  }
+  if (v.periodType === 'LIMITED') {
+    if (!v.period) {
+      return '챌린지 기간을 선택해주세요.';
+    }
+    if (v.period === 'etc' && !isWholeNumberInRange(v.periodNumber, 7, 730)) {
+      return '기간을 7일부터 730일 사이로 입력해주세요.';
+    }
+  }
+  if (!v.startDate) {
+    return '시작일을 선택해주세요.';
+  }
+  if (v.startDate < startOfToday()) {
+    return '시작일은 오늘 이후로 선택해주세요.';
+  }
+  if (v.challengeType === 'PRIVATE') {
+    const password = v.password?.trim() ?? '';
+    if (password.length < 4 || password.length > 20) {
+      return '비밀번호를 4자 이상 20자 이하로 입력해주세요.';
+    }
+  }
+  return null;
+}
+
+/**
+ * 챌린지 수정 폼의 첫 미충족 필수 항목 안내. 시작 후에는 인원·목표를 수정할 수
+ * 없어 그 검사는 시작 전(그룹/고정목표)일 때만 적용한다. 기간·시작일·공개범위는
+ * 수정 대상이 아니다. 배치 순서: 제목 → 카테고리 → (그룹·시작전) 인원 →
+ * (고정목표·시작전) 목표.
+ */
+export function getChallengeEditCtaHint(
+  v: Partial<ChallengeEditFormValues>
+): string | null {
+  if (!v.title?.trim()) {
+    return '챌린지 제목을 입력해주세요.';
+  }
+  if (v.title.length > 50) {
+    return '챌린지 제목은 50자 이하로 입력해주세요.';
+  }
+  if (!v.category) {
+    return '카테고리를 선택해주세요.';
+  }
+  if (v.isGroup && !v.isStarted) {
+    if (!v.memberCount) {
+      return '챌린지 인원을 선택해주세요.';
+    }
+    if (v.memberCount === 'etc' && !isWholeNumberInRange(v.memberCountNumber, 2, 100)) {
+      return '인원을 2명부터 100명 사이로 입력해주세요.';
+    }
+  }
+  if (v.isFixedGoal && !v.isStarted) {
+    if (
+      !v.goals ||
+      v.goals.length === 0 ||
+      v.goals.some((goal) => !goal.value?.trim())
+    ) {
+      return '목표를 하나 이상 입력해주세요.';
+    }
+  }
+  return null;
+}

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -4,6 +4,7 @@ import { Button, MobileHeader, Text } from '@1d1s/design-system';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import { DiaryDetailSkeleton } from '@component/skeletons/DiaryDetailSkeleton';
 import { normalizeApiError } from '@module/api/error';
+import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { useNativeCapability } from '@module/hooks/useNativeCapability';
 import { useSafeBack } from '@module/hooks/useSafeBack';
 import { useSignalPageReady } from '@module/hooks/useSignalPageReady';
@@ -375,6 +376,7 @@ export function DiaryDetailScreen({
 }): React.ReactElement | null {
   const router = useRouter();
   const isLoggedIn = useIsLoggedIn();
+  const authStatus = useAuthStatus();
   const [isDeleting, setIsDeleting] = useState(false);
   const safeDiaryId = Number.isFinite(id) && id > 0 ? id : 0;
   const deleteDiary = useDeleteDiary();
@@ -425,7 +427,15 @@ export function DiaryDetailScreen({
     likeDiary.mutate(data.id);
   };
 
-  if (!isLoggedIn) {
+  // 인증 확인 중(unknown)에는 게스트/로그인 UI 를 렌더하지 않는다. 푸시 딥링크·
+  // resume 로 세션 재주입 전에 상세가 열리면 잠깐 게스트로 보여 로그인 팝업이
+  // 떴다(resume 과 동일 증상). runAuthBootProbe grace(native:auth_ready/유예)가
+  // 확정할 때까지 스켈레톤으로 대기하고, **확정된 게스트일 때만** 로그인을
+  // 띄운다(useIsLoggedIn 은 unknown 에도 false 라 여기선 쓰지 않는다).
+  if (authStatus === 'unknown') {
+    return nativeSkeleton ? null : <DiaryDetailSkeleton />;
+  }
+  if (authStatus === 'guest') {
     return (
       <LoginRequiredDialog
         open

--- a/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
+++ b/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
@@ -148,7 +148,12 @@ export default function DiaryCreateScreen(): React.ReactElement {
   return (
     <div
       className={cn(
-        'min-h-screen w-full',
+        // min-h-screen(100vh) 제거: 앱 시트 웹뷰는 키보드 시 웹뷰를 줄이는데,
+        // 100vh 플로어가 문서를 가시영역보다 크게 유지하면 텍스트 필드 포커스 시
+        // WebView 의 scroll-into-view 가 콘텐츠 아래 빈 영역으로 스크롤돼 폼이
+        // 흰 화면으로 덮였다(안드로이드). 작성 폼은 항상 화면을 채울 만큼 길어
+        // 플로어가 불필요하다 — 콘텐츠 높이로만 잡아 흰 여백을 없앤다.
+        'w-full',
         !nativeCtaDelegated && 'pb-mobile-action-bar'
       )}
     >

--- a/src/app.feature/home/components/HomeWarmGreeting.tsx
+++ b/src/app.feature/home/components/HomeWarmGreeting.tsx
@@ -2,6 +2,7 @@
 
 import { Text } from '@1d1s/design-system';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
+import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { useHasMounted } from '@module/hooks/useHasMounted';
 import { cn } from '@module/utils/cn';
 import React from 'react';
@@ -15,11 +16,23 @@ export default function HomeWarmGreeting({
   isLoading = false,
 }: HomeWarmGreetingProps): React.ReactElement {
   const hasMounted = useHasMounted();
-  const { data: sidebar } = useSidebar();
+  const status = useAuthStatus();
+  const { data: sidebar, isLoading: isSidebarLoading } = useSidebar();
+
+  // 이름(닉네임)이 확정되기 전 빈 이름으로 렌더하지 않는다. 가입 직후 앱이 탭을
+  // 리로드하면 member/sidebar 를 fresh 로 받기 전이라, 부모의 isLoading(streak
+  // 기준)이 이미 false 여도 닉네임이 비어 "안녕하세요"만 떴다가 이름이 팝인하거나
+  // 빈 줄(안 보임)이 노출됐다. 닉네임의 실제 소스(sidebar)+인증 상태로 직접
+  // 판정: 마운트 전·인증 확정 전(unknown)·인증됐는데 sidebar 로딩 중이면
+  // 스켈레톤. 게스트로 확정되면 이름 없는 일반 인사로 정착한다.
+  const isNameResolving =
+    !hasMounted ||
+    status === 'unknown' ||
+    (status === 'authenticated' && isSidebarLoading);
 
   // 로그인 셸 로딩 중에는 이름이 확정되기 전 "안녕하세요"만 떴다가 이름이
   // 붙는 팝인이 보였다 — 로딩 동안 이름 줄을 스켈레톤으로 예약한다.
-  if (isLoading) {
+  if (isLoading || isNameResolving) {
     return (
       <div className="w-full">
         <span

--- a/src/app.feature/home/utils/popupDismissal.test.ts
+++ b/src/app.feature/home/utils/popupDismissal.test.ts
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -5,8 +6,12 @@ import {
   sessionDismissPopupKeys,
 } from './popupDismissal';
 
+// 세션 차단은 이제 WebView 간 공유되는 세션 쿠키에 저장한다(sessionStorage 는
+// 인스턴스별로 갈려 다른 탭/리로드에서 재노출됐다).
+const SESSION_COOKIE = '1d1s:sessionDismissedPopups';
+
 afterEach(() => {
-  window.sessionStorage.clear();
+  Cookies.remove(SESSION_COOKIE);
 });
 
 describe('session popup dismissal', () => {
@@ -26,12 +31,12 @@ describe('session popup dismissal', () => {
   });
 
   it('손상된 값이면 빈 배열로 복구한다', () => {
-    window.sessionStorage.setItem('1d1s:sessionDismissedPopups', '{bad');
+    Cookies.set(SESSION_COOKIE, '{bad');
     expect(getSessionDismissedPopupKeys()).toEqual([]);
   });
 
   it('배열이 아닌 JSON 이면 빈 배열을 반환한다', () => {
-    window.sessionStorage.setItem('1d1s:sessionDismissedPopups', '"x"');
+    Cookies.set(SESSION_COOKIE, '"x"');
     expect(getSessionDismissedPopupKeys()).toEqual([]);
   });
 });

--- a/src/app.feature/home/utils/popupDismissal.ts
+++ b/src/app.feature/home/utils/popupDismissal.ts
@@ -34,19 +34,21 @@ export function dismissPopupKeys(keys: string[]): void {
   });
 }
 
-// 그냥 닫기로 이번 세션 동안만 차단할 팝업 key 목록을 담는 sessionStorage.
-// 탭/브라우저를 닫으면 사라지므로 다음 세션엔 다시 노출된다.
+// 그냥 닫기로 이번 세션 동안만 차단할 팝업 key 목록.
+//
+// 세션 "쿠키"(expires 없음)로 저장한다. 예전엔 sessionStorage 였는데, 앱은 탭마다
+// WebView 를 따로 띄우고 리로드/재생성 시 sessionStorage 가 인스턴스별로 갈려
+// 한 탭에서 닫아도 다른 탭·리로드된 WebView 는 몰라 팝업이 다시 떴다. 세션
+// 쿠키는 Android WebView 의 공용 CookieManager 에 올라가 앱 세션 동안 모든
+// WebView 가 공유하므로, 한 번 닫으면 세션 내 재노출을 막는다(앱 종료 시 소멸).
 const SESSION_DISMISSED_POPUPS_KEY = '1d1s:sessionDismissedPopups';
 
 export function getSessionDismissedPopupKeys(): string[] {
-  if (typeof window === 'undefined') {
+  const raw = Cookies.get(SESSION_DISMISSED_POPUPS_KEY);
+  if (!raw) {
     return [];
   }
   try {
-    const raw = window.sessionStorage.getItem(SESSION_DISMISSED_POPUPS_KEY);
-    if (!raw) {
-      return [];
-    }
     const parsed: unknown = JSON.parse(raw);
     return Array.isArray(parsed)
       ? parsed.filter((key): key is string => typeof key === 'string')
@@ -58,18 +60,14 @@ export function getSessionDismissedPopupKeys(): string[] {
 
 // 현재 노출된 모든 팝업 key 를 세션 차단 목록에 합쳐 기록한다.
 export function sessionDismissPopupKeys(keys: string[]): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
   const merged = Array.from(
     new Set([...getSessionDismissedPopupKeys(), ...keys])
   );
-  try {
-    window.sessionStorage.setItem(
-      SESSION_DISMISSED_POPUPS_KEY,
-      JSON.stringify(merged)
-    );
-  } catch {
-    // sessionStorage 접근 불가(프라이빗 모드 등)면 조용히 무시한다.
-  }
+  // expires 미지정 = 세션 쿠키. 앱 세션 동안 모든 WebView 가 공유한다.
+  Cookies.set(SESSION_DISMISSED_POPUPS_KEY, JSON.stringify(merged), {
+    sameSite: 'lax',
+    secure:
+      typeof window !== 'undefined' &&
+      window.location.protocol === 'https:',
+  });
 }

--- a/src/app.module/api/tokenRefresh.ts
+++ b/src/app.module/api/tokenRefresh.ts
@@ -1,5 +1,8 @@
 import { authStorage } from '@module/utils/auth';
-import { requestNativeTokenRefresh } from '@module/utils/nativeBridge';
+import {
+  isNativeBridgeAvailable,
+  requestNativeTokenRefresh,
+} from '@module/utils/nativeBridge';
 import axios from 'axios';
 
 import { API_BASE_URL } from './config';
@@ -54,14 +57,38 @@ export function refreshAccessTokenOnce(): Promise<void> {
  *
  * single-flight 라 인터셉터/resume 과 동시에 불려도 요청은 1발이다.
  */
+// 앱(웹뷰) resume 재시도 간격. 네이티브가 세션 쿠키를 재주입할 시간을 준다.
+// 앱이 native:auth_ready 이벤트를 확정하면 이 고정 지연 대신 그 신호를 기다리는
+// 방식으로 교체할 수 있다.
+const NATIVE_BOOT_RETRY_MS = 700;
+
 export function runAuthBootProbe(): Promise<void> {
-  return refreshAccessTokenOnce().catch((error: unknown) => {
+  return refreshAccessTokenOnce().catch(async (error: unknown) => {
     if (authStorage.getStatus() !== 'unknown') {
       return; // 다른 경로(사이드바/에러 핸들러)가 이미 확정함
     }
     if (!isUnauthorizedError(error) && authStorage.hasTokens()) {
       authStorage.markAuthenticated();
       return;
+    }
+    // 앱(웹뷰): resume 시 네이티브가 세션을 재주입하는 중이라 첫 refresh 가
+    // 일시 실패할 수 있다. 1회 실패로 guest 를 확정하면 로그인 세션인데도
+    // login 으로 튕긴다. 짧게 한 번 더 재시도(재주입 완료 대기)한 뒤에도
+    // 실패하면 그때 확정한다. 브라우저·비앱은 즉시 확정(기존 동작).
+    if (isNativeBridgeAvailable()) {
+      await new Promise((resolve) => setTimeout(resolve, NATIVE_BOOT_RETRY_MS));
+      if (authStorage.getStatus() !== 'unknown') {
+        return;
+      }
+      try {
+        await refreshAccessTokenOnce(); // 성공 시 markAuthenticated
+        return;
+      } catch {
+        // 재시도도 실패 → 아래에서 guest 확정
+      }
+      if (authStorage.getStatus() !== 'unknown') {
+        return;
+      }
     }
     authStorage.settleGuest();
   });

--- a/src/app.module/api/tokenRefresh.ts
+++ b/src/app.module/api/tokenRefresh.ts
@@ -1,4 +1,5 @@
 import { authStorage } from '@module/utils/auth';
+import { waitForNativeAuthReady } from '@module/utils/nativeAuthReady';
 import {
   isNativeBridgeAvailable,
   requestNativeTokenRefresh,
@@ -57,10 +58,9 @@ export function refreshAccessTokenOnce(): Promise<void> {
  *
  * single-flight 라 인터셉터/resume 과 동시에 불려도 요청은 1발이다.
  */
-// 앱(웹뷰) resume 재시도 간격. 네이티브가 세션 쿠키를 재주입할 시간을 준다.
-// 앱이 native:auth_ready 이벤트를 확정하면 이 고정 지연 대신 그 신호를 기다리는
-// 방식으로 교체할 수 있다.
-const NATIVE_BOOT_RETRY_MS = 700;
+// 앱(웹뷰) resume 시 세션 재주입 완료를 기다리는 최대 유예(계약: 1.5초).
+// native:auth_ready 가 그 전에 오면 즉시 진행한다.
+const NATIVE_AUTH_READY_TIMEOUT_MS = 1_500;
 
 export function runAuthBootProbe(): Promise<void> {
   return refreshAccessTokenOnce().catch(async (error: unknown) => {
@@ -71,12 +71,13 @@ export function runAuthBootProbe(): Promise<void> {
       authStorage.markAuthenticated();
       return;
     }
-    // 앱(웹뷰): resume 시 네이티브가 세션을 재주입하는 중이라 첫 refresh 가
-    // 일시 실패할 수 있다. 1회 실패로 guest 를 확정하면 로그인 세션인데도
-    // login 으로 튕긴다. 짧게 한 번 더 재시도(재주입 완료 대기)한 뒤에도
-    // 실패하면 그때 확정한다. 브라우저·비앱은 즉시 확정(기존 동작).
+    // 앱(웹뷰): resume 시 네이티브가 세션 쿠키를 재주입하는 중이라 첫 refresh 가
+    // 일시 실패할 수 있다. 1회 실패로 guest 를 확정하면 로그인 세션인데도 login
+    // 으로 튕긴다. 재주입 완료 신호(native:auth_ready, 이미 준비면 즉시)나 짧은
+    // 유예까지 기다린 뒤 다시 refresh, 그래도 실패하면 그때 확정한다. 브라우저·
+    // 비앱은 즉시 확정(기존 동작).
     if (isNativeBridgeAvailable()) {
-      await new Promise((resolve) => setTimeout(resolve, NATIVE_BOOT_RETRY_MS));
+      await waitForNativeAuthReady(NATIVE_AUTH_READY_TIMEOUT_MS);
       if (authStorage.getStatus() !== 'unknown') {
         return;
       }

--- a/src/app.module/hooks/useIsNativeApp.ts
+++ b/src/app.module/hooks/useIsNativeApp.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { NATIVE_APP_UA_PATTERN } from '@module/utils/nativeAppUserAgent';
 import { useSyncExternalStore } from 'react';
 
 // SSR UA 매칭이 실패하더라도 chrome 이 겹쳐 보이지 않도록 클라이언트에서
@@ -12,7 +13,7 @@ import { useSyncExternalStore } from 'react';
 // 3. navigator.userAgent — 토큰 `1D1S-App` 매칭. 채널/마커가 모두 없는
 //    임시 환경(예: 브라우저 devtools UA 스푸핑) 에 대한 보조.
 
-const NATIVE_APP_UA_PATTERN = /1D1S-App/i;
+// UA 마커는 미들웨어(서버)와 공유하는 단일 소스(nativeAppUserAgent)에서 가져온다.
 const NATIVE_READY_EVENT = 'native:ready';
 
 interface NativeWindow {

--- a/src/app.module/hooks/useNativeSubmitBar.ts
+++ b/src/app.module/hooks/useNativeSubmitBar.ts
@@ -15,6 +15,11 @@ interface NativeSubmitBarOptions {
   steps?: number;
   /** back 탭 콜백(이전 단계 등). 없으면 back 은 무시된다. */
   onBack?(): void;
+  /**
+   * 비활성 사유(첫 미충족 필수 항목 안내). disabled 일 때 앱이 노출한다.
+   * 활성이면 무시된다. 값이 바뀌면 재전송한다.
+   */
+  disabledHint?: string;
 }
 
 /**
@@ -41,6 +46,7 @@ export function useNativeSubmitBar(
   const step = options?.step;
   const steps = options?.steps;
   const onBack = options?.onBack;
+  const disabledHint = options?.disabledHint;
 
   // 핸들러는 매 렌더 바뀌지만(클로저) 구독은 한 번만 걸도록 ref 로 최신화한다.
   const primaryRef = useRef(onPrimary);
@@ -54,8 +60,8 @@ export function useNativeSubmitBar(
     if (!delegated) {
       return;
     }
-    sendNativeFormCta({ label, disabled, step, steps });
-  }, [delegated, label, disabled, step, steps]);
+    sendNativeFormCta({ label, disabled, disabledHint, step, steps });
+  }, [delegated, label, disabled, disabledHint, step, steps]);
 
   // 해제는 언마운트에서만 — 값이 바뀔 때마다 null→재전송하면 바가 깜빡인다.
   useEffect(

--- a/src/app.module/hooks/useTokenRefreshOnResume.ts
+++ b/src/app.module/hooks/useTokenRefreshOnResume.ts
@@ -4,6 +4,7 @@ import {
   refreshAccessTokenOnce,
   runAuthBootProbe,
 } from '@module/api/tokenRefresh';
+import { onNativeAuthReady } from '@module/utils/nativeAuthReady';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
@@ -81,9 +82,18 @@ export function useTokenRefreshOnResume(): void {
       void tryRefresh();
     };
 
+    // 앱이 resume 세션 재주입 완료를 알리면(native:auth_ready) 즉시 갱신한다.
+    // 부팅 probe 유예를 이미 넘겨 guest 로 굳은 탭도 이 신호로 복구된다. 방금
+    // 재주입된 세션을 확실히 태우도록 throttle 을 무시한다(lastRefreshAt 리셋).
+    const handleAuthReady = (): void => {
+      lastRefreshAtRef.current = 0;
+      void tryRefresh();
+    };
+
     document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('pageshow', handlePageShow);
     window.addEventListener('focus', handleFocus);
+    const offAuthReady = onNativeAuthReady(handleAuthReady);
 
     // 마운트 직후 권위 있는 부팅 세션 확인. tryRefresh 와 달리 결과를
     // authStorage 상태(authenticated/guest)로 확정해, JS 힌트가 소실된 Safari
@@ -96,6 +106,7 @@ export function useTokenRefreshOnResume(): void {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('pageshow', handlePageShow);
       window.removeEventListener('focus', handleFocus);
+      offAuthReady();
     };
   }, [queryClient]);
 }

--- a/src/app.module/middleware/auth.ts
+++ b/src/app.module/middleware/auth.ts
@@ -202,16 +202,13 @@ export async function authMiddleware(
     if (matched.type === 'list-redirect' && hasSessionHint(req)) {
       return {};
     }
-    // 앱(웹뷰)은 resume 시 네이티브가 세션 쿠키를 재주입하는데, 그 전에 웹뷰가
-    // 리로드되면 이 서버 refresh 가 일시적으로 실패한다. 그때 하드 /login 으로
-    // 튕기면 네이티브 세션이 살아있는데도 로그인 화면이 렌더된다. 앱 요청이면
-    // (UA 마커) 통과시키고 클라이언트가 해결하게 위임한다 — 스켈레톤 → 네이티브
-    // refresh 재시도(runAuthBootProbe grace) → 확정 guest 일 때만 리다이렉트.
-    // 브라우저·비앱은 기존대로 하드 게이트(민감 경로 보호).
-    if (
-      matched.type === 'login-redirect' &&
-      isNativeAppUserAgent(req.headers.get('user-agent'))
-    ) {
+    // 앱(웹뷰): resume·푸시 딥링크로 세션 재주입 전에 열려 이 서버 refresh 가
+    // 일시 실패해도, 하드 리다이렉트(login 또는 목록) 대신 통과시키고
+    // 클라이언트 grace 가 해결하게 위임한다 — 스켈레톤 → 네이티브 refresh 재시도
+    // (runAuthBootProbe: native:auth_ready/유예) → 확정 guest 일 때만 로그인.
+    // 딥링크 상세(list-redirect)·민감 경로(login-redirect) 모두 동일 규율.
+    // 브라우저·비앱은 기존 하드 게이트(민감 경로 보호).
+    if (isNativeAppUserAgent(req.headers.get('user-agent'))) {
       return passThrough;
     }
     return { block: buildUnauthorizedResponse(req, matched) };

--- a/src/app.module/middleware/auth.ts
+++ b/src/app.module/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { API_BASE_URL } from '../api/config';
+import { isNativeAppUserAgent } from '../utils/nativeAppUserAgent';
 import { buildLoginUrl, RETURN_TO_PARAM } from '../utils/returnTo';
 import {
   ACCESS_TOKEN_COOKIE_CANDIDATES,
@@ -200,6 +201,18 @@ export async function authMiddleware(
     // login-redirect(마이페이지/작성 등 민감 경로)는 기존대로 하드 게이트.
     if (matched.type === 'list-redirect' && hasSessionHint(req)) {
       return {};
+    }
+    // 앱(웹뷰)은 resume 시 네이티브가 세션 쿠키를 재주입하는데, 그 전에 웹뷰가
+    // 리로드되면 이 서버 refresh 가 일시적으로 실패한다. 그때 하드 /login 으로
+    // 튕기면 네이티브 세션이 살아있는데도 로그인 화면이 렌더된다. 앱 요청이면
+    // (UA 마커) 통과시키고 클라이언트가 해결하게 위임한다 — 스켈레톤 → 네이티브
+    // refresh 재시도(runAuthBootProbe grace) → 확정 guest 일 때만 리다이렉트.
+    // 브라우저·비앱은 기존대로 하드 게이트(민감 경로 보호).
+    if (
+      matched.type === 'login-redirect' &&
+      isNativeAppUserAgent(req.headers.get('user-agent'))
+    ) {
+      return passThrough;
     }
     return { block: buildUnauthorizedResponse(req, matched) };
   }

--- a/src/app.module/utils/nativeAppUserAgent.ts
+++ b/src/app.module/utils/nativeAppUserAgent.ts
@@ -3,11 +3,10 @@
 // 서버(미들웨어 엣지)와 클라(useIsNativeApp)가 같은 마커를 쓰도록 한 곳에 둔다.
 // 브라우저 API 를 쓰지 않으므로 엣지 런타임·클라이언트 양쪽에서 import 가능하다.
 //
-// ⚠️ 계약: 앱이 웹뷰 UA 에 이 마커를 포함시킨다(resume 세션 재주입과 함께 진행
-//    중). 앱 세션이 최종 마커 문자열을 확정하면 아래 정규식만 교체하면 된다.
-//    현재 값은 기존 클라 감지(useIsNativeApp)와 동일한 '1D1S-App' 로 둔다 —
-//    마커가 없으면 매칭이 안 돼 기존 하드 게이트로 폴백하므로 회귀 위험이 없다.
-export const NATIVE_APP_UA_PATTERN = /1D1S-App/i;
+// 계약(앱 빌드 134): 모든 웹뷰 UA 끝에 `1D1S-App/<버전>`(예: `1D1S-App/1.0.0`)
+// 를 붙인다. 버전이 올라도(1.1.0 등) 감지되도록 **접두사 `1D1S-App/`** 로
+// 매칭한다. 마커가 없으면 매칭 안 돼 기존 하드 게이트로 폴백(회귀 없음).
+export const NATIVE_APP_UA_PATTERN = /1D1S-App\//i;
 
 /** UA 문자열에 네이티브 앱 마커가 있는지. */
 export function isNativeAppUserAgent(

--- a/src/app.module/utils/nativeAppUserAgent.ts
+++ b/src/app.module/utils/nativeAppUserAgent.ts
@@ -1,0 +1,17 @@
+// 네이티브 앱 웹뷰를 User-Agent 로 식별하는 단일 소스.
+//
+// 서버(미들웨어 엣지)와 클라(useIsNativeApp)가 같은 마커를 쓰도록 한 곳에 둔다.
+// 브라우저 API 를 쓰지 않으므로 엣지 런타임·클라이언트 양쪽에서 import 가능하다.
+//
+// ⚠️ 계약: 앱이 웹뷰 UA 에 이 마커를 포함시킨다(resume 세션 재주입과 함께 진행
+//    중). 앱 세션이 최종 마커 문자열을 확정하면 아래 정규식만 교체하면 된다.
+//    현재 값은 기존 클라 감지(useIsNativeApp)와 동일한 '1D1S-App' 로 둔다 —
+//    마커가 없으면 매칭이 안 돼 기존 하드 게이트로 폴백하므로 회귀 위험이 없다.
+export const NATIVE_APP_UA_PATTERN = /1D1S-App/i;
+
+/** UA 문자열에 네이티브 앱 마커가 있는지. */
+export function isNativeAppUserAgent(
+  userAgent: string | null | undefined
+): boolean {
+  return NATIVE_APP_UA_PATTERN.test(userAgent ?? '');
+}

--- a/src/app.module/utils/nativeAuthReady.ts
+++ b/src/app.module/utils/nativeAuthReady.ts
@@ -1,0 +1,57 @@
+// 앱→웹 `native:auth_ready` 계약(앱 빌드 134).
+//
+// 앱은 resume 후 웹 세션 쿠키 재주입이 "완료된 직후" 살아있는 탭 웹뷰 전부에
+// `native:auth_ready`(payload 없음)를 디스패치하고, 늦게 붙은 리스너를 위해
+// 멱등 플래그 `window.__1D1S_AUTH_READY__ = true` 를 세운다.
+//
+// 웹은 인증 라우트에서 쿠키 부재를 보자마자 /login 으로 튕기지 않고, 이 신호
+// (또는 이미 세워진 플래그)나 짧은 유예까지 기다린 뒤 인증을 확정한다.
+
+const NATIVE_AUTH_READY_EVENT = 'native:auth_ready';
+
+interface AuthReadyWindow {
+  __1D1S_AUTH_READY__?: boolean;
+}
+
+/** 앱이 세션 재주입 완료를 이미 알렸는지(멱등 플래그). */
+export function isNativeAuthReady(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return (window as Window & AuthReadyWindow).__1D1S_AUTH_READY__ === true;
+}
+
+/** `native:auth_ready` 구독. 반환값은 해제 함수. */
+export function onNativeAuthReady(handler: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+  window.addEventListener(NATIVE_AUTH_READY_EVENT, handler);
+  return () => window.removeEventListener(NATIVE_AUTH_READY_EVENT, handler);
+}
+
+/**
+ * 세션 재주입 완료(`native:auth_ready` 또는 이미 세워진 플래그)를 최대
+ * `timeoutMs` 까지 기다린다. 이미 준비됐으면 즉시 resolve, 아니면 이벤트나
+ * 타임아웃 중 먼저 오는 것에서 resolve 한다(둘 다 성공적 진행).
+ */
+export function waitForNativeAuthReady(timeoutMs: number): Promise<void> {
+  if (typeof window === 'undefined' || isNativeAuthReady()) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    let done = false;
+    // 이벤트/타임아웃 중 먼저 온 것에서 1회만 진행한다. 늦게 온 쪽은 done
+    // 가드로 no-op — 타임아웃 핸들을 따로 clear 하지 않아도 안전하다.
+    const finish = (): void => {
+      if (done) {
+        return;
+      }
+      done = true;
+      window.removeEventListener(NATIVE_AUTH_READY_EVENT, finish);
+      resolve();
+    };
+    window.addEventListener(NATIVE_AUTH_READY_EVENT, finish);
+    setTimeout(finish, timeoutMs);
+  });
+}

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -571,10 +571,14 @@ function ensurePopupResultListener(): void {
       return;
     }
     pendingNativePopups.delete(detail.id);
-    // action 이 없으면 dismiss — 그냥 닫기로 읽는다.
+    // action 이 없으면 dismiss — 그냥 닫기로 읽는다. popupKey 는 'cta'(어느 장의
+    // 링크인지)에만 필요하고, 'dismissForever'/'close' 는 노출된 전체 key 를
+    // 대상으로 처리하므로 없어도 된다. 예전엔 popupKey 가 없으면 action 을
+    // 무조건 'close' 로 낮춰, 앱이 popupKey 없이 dismissForever 를 보내면 "다시
+    // 보지 않기" 쿠키가 저장되지 않아 재노출됐다(미persist 버그).
     resolver(
-      detail.action && detail.popupKey
-        ? { action: detail.action, popupKey: detail.popupKey }
+      detail.action
+        ? { action: detail.action, popupKey: detail.popupKey ?? '' }
         : { action: 'close', popupKey: '' }
     );
   });

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -252,6 +252,9 @@ export type NativeMessage =
       type: 'form_cta';
       label?: string;
       disabled?: boolean;
+      // 비활성 사유(첫 미충족 필수 항목 안내). 앱은 disabled 상태에서 이 문구를
+      // 노출하거나 버튼 탭 시 띄운다. 충족되면 미포함(힌트 제거).
+      disabledHint?: string;
       step?: number;
       steps?: number;
     }
@@ -740,6 +743,8 @@ export function isNativeChallengeCreatedModalAvailable(): boolean {
 export interface NativeFormCtaPayload {
   label: string;
   disabled?: boolean;
+  // 비활성 사유(첫 미충족 필수 항목 안내). disabled 일 때만 의미가 있다.
+  disabledHint?: string;
   // 단계 표시(선택). 회원가입처럼 다단계 폼에서만 쓴다.
   step?: number;
   steps?: number;
@@ -761,6 +766,7 @@ export function sendNativeFormCta(payload: NativeFormCtaPayload | null): void {
     type: 'form_cta',
     label: payload.label,
     disabled: payload.disabled,
+    disabledHint: payload.disabledHint,
     step: payload.step,
     steps: payload.steps,
   });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -87,9 +87,15 @@ export default function RootLayout({
   // `<Link>` prefetch 가 죽으므로(= "이동마다 로딩") 서버 UA 판정은 쓰지
   // 않는다. 스크립트는 정적 HTML 에 그대로 실려 나가므로 route 는 정적
   // prefetch 가능 상태를 유지하면서도 chrome 가시성은 페인트 시점에 이미
-  // 결정돼 있다. 하이드레이션 이후 토글되는 값이 아니라 시프트가 없다.
+  // 결정돼 있다.
+  //
+  // suppressHydrationWarning: 스크립트가 페인트 전에 data-native-app 을 'true'
+  // 로 바꿔 놓는데, 이게 없으면 하이드레이션에서 React 가 서버 렌더값('false')
+  // 으로 되돌려 sticky/native-hide chrome 이 한 프레임 보였다 사라진다(탐색
+  // 헤더 반짝임). 이 플래그로 스크립트가 세운 값을 하이드레이션이 건드리지
+  // 않게 해, 첫 페인트~하이드레이션 내내 숨김 상태가 유지된다(전 페이지 공통).
   return (
-    <html lang="ko" data-native-app="false">
+    <html lang="ko" data-native-app="false" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: NATIVE_APP_INIT_SCRIPT }} />
       </head>


### PR DESCRIPTION
## 상용 승격 (develop → main)

#250 이후 develop 누적 8건. main-only 는 이전 승격 머지커밋(#248/#249/#250)뿐 — 직접 핫픽스 없음, 충돌 없음.

### resume/딥링크 인증 방어층 (앱 세션 계약)
- resume 로그인 렌더 방지: 앱 login-redirect 미들웨어 소프트닝 + 부팅 grace
- UA 마커 프리픽스 1D1S-App/ + native:auth_ready grace (빌드 134)
- 푸시 딥링크 상세 로그인 팝업 겹침: 상세 auth grace + 로그인 모달 dedup

### 렌더/UX
- 탐색 등 웹 헤더 반짝임 제거: html suppressHydrationWarning (첫 페인트 숨김 유지) ← 상용 증상 핵심
- 로그인 팝업 재노출·미persist: 다시 보지 않기 쿠키 + 세션 차단 WebView 공유
- 홈 인사 닉네임 빈 값/안 보임: 닉네임 소스 직접 로딩 판정
- 일지 작성 포커스 흰 화면 (앱 시트 웹뷰)
- 챌린지 완료 버튼 막힘 사유 안내 (form_cta disabledHint)

gate: lint 0 err · tsc · vitest 192 · build 통과(develop).