### PR TITLE
release: 스토리 full-bleed 상용 승격 (필터 작업 제외)

### DIFF
--- a/src/app.feature/stories/components/Stories.tsx
+++ b/src/app.feature/stories/components/Stories.tsx
@@ -56,7 +56,7 @@ function StoryLoginPrompt({
   return (
     <div
       className={cn(
-        'scrollbar-hide flex w-full overflow-x-auto',
+        'scrollbar-hide flex overflow-x-auto',
         'gap-3 py-3.5',
         STORY_RAIL_BLEED
       )}

--- a/src/app.feature/stories/components/StoryRing.tsx
+++ b/src/app.feature/stories/components/StoryRing.tsx
@@ -62,7 +62,7 @@ function StoryRing({
   return (
     <div
       className={cn(
-        'scrollbar-hide flex w-full items-start gap-3',
+        'scrollbar-hide flex items-start gap-3',
         'overflow-x-auto py-3.5',
         // 가로 스크롤러는 화면 끝까지 흘러야 한다. 부모(px-5/lg:px-8) 안에
         // 갇히면 스크롤한 카드가 여백 경계에서 뚝 잘려 보인다 — 좌우 여백은

--- a/src/app.feature/stories/components/StoryRingSkeleton.tsx
+++ b/src/app.feature/stories/components/StoryRingSkeleton.tsx
@@ -19,7 +19,7 @@ export default function StoryRingSkeleton({
   return (
     <div
       className={cn(
-        'scrollbar-hide flex w-full items-start gap-3',
+        'scrollbar-hide flex items-start gap-3',
         'overflow-x-auto py-3.5',
         STORY_RAIL_BLEED
       )}

--- a/src/app.feature/stories/consts/layout.ts
+++ b/src/app.feature/stories/consts/layout.ts
@@ -7,5 +7,11 @@
  * (패딩을 부모에만 두면 카드가 여백 선에서 잘려 보였다 — 실제 QA 증상)
  *
  * HomeScreen 의 패딩을 바꾸면 이 값도 같이 바꿔야 한다.
+ *
+ * ⚠️ 이 클래스를 쓰는 스크롤 컨테이너에 `w-full` 을 붙이지 말 것.
+ * box-sizing:border-box 에서 width:100% 는 border-box 를 부모 content 폭(= 화면폭
+ * − 2×패딩)으로 고정한다. 음수 마진은 왼쪽만 당길 뿐 폭을 넓히지 못해 오른쪽이
+ * 2×패딩만큼 짧아져 마지막 카드가 잘렸다(실제 QA 증상). width 를 auto 로 두면
+ * 음수 마진에 맞춰 border-box 가 화면폭까지 확장돼 edge-to-edge full-bleed 가 된다.
  */
 export const STORY_RAIL_BLEED = '-mx-5 px-5 lg:-mx-8 lg:px-8';


### PR DESCRIPTION
## 상용 승격 (준비된 것만)

#252 이후 develop 에서 **스토리 full-bleed 수정 1건만** 승격. 상세필터 토글
(e0aa26d)은 필터 배치가 진행 중이라 이번 승격에서 제외(develop 에 보류).
필터 네이티브 동기화·내챌린지 위임은 코드 미커밋(진단만) → 자연 제외.

### 포함
- fix(stories): 홈 스토리 가로 스크롤 오른쪽 잘림 — full-bleed 컨테이너
  w-full 제거 (box-sizing:border-box 에서 width:100% 가 우변을 2×패딩만큼
  잘라 마지막 카드가 잘리던 것 → auto 폭으로 edge-to-edge)

### 제외 (다음 배치)
- 상세필터 토글 디자인(e0aa26d), 네이티브 필터 동기화, 내챌린지 필터 위임

gate: lint 0 · tsc · vitest 192 · knip · build 통과(d0a7b3d, develop CI green).