### PR TITLE
release: develop → main 상용 승격 (#253 이후 2건)

### DIFF
--- a/src/app.component/cards/DiaryCard.tsx
+++ b/src/app.component/cards/DiaryCard.tsx
@@ -5,6 +5,7 @@ import { ChallengeChip } from '@component/cards/ChallengeChip';
 import FadeInImage from '@component/FadeInImage';
 import LikeBurst from '@component/LikeBurst';
 import { Skeleton } from '@component/Skeleton';
+import { EMOTION_TONE } from '@feature/diary/shared/utils/feeling';
 import { cn } from '@module/utils/cn';
 import { createActivationKeydownHandler } from '@module/utils/event';
 import Image from 'next/image';
@@ -19,14 +20,8 @@ const EMOTION_IMAGE: Record<DiaryEmotion, { src: string; alt: string }> = {
   sad: { src: '/images/mood-sad.svg', alt: '슬픈 얼굴' },
 };
 
-// 감정별 무드 컬러 — 포인트 텍스트(달성률) / 체크 원 배경(달성 목표).
-// 무드 SVG 얼굴색 팔레트(happy=main/피치, soso=mint, sad=blue)를 따르되,
-// 흰 체크·텍스트 대비를 위해 한 단계 진한 톤을 쓴다.
-const EMOTION_TONE: Record<DiaryEmotion, { fg: string; check: string }> = {
-  happy: { fg: 'text-main-700', check: 'bg-main-700' },
-  soso: { fg: 'text-mint-900', check: 'bg-mint-800' },
-  sad: { fg: 'text-blue-600', check: 'bg-blue-500' },
-};
+// 감정별 무드 컬러(달성률 텍스트·체크 원)는 카드·상세 공유 단일 소스
+// (@feature/diary/shared/utils/feeling)에서 가져온다.
 
 // next/image는 절대 URL이거나 / 시작 상대 경로만 허용한다. 백엔드가 raw key를
 // 줄 때 next/image의 URL 파서가 throw 하므로 안전한 형태만 통과시킨다.

--- a/src/app.feature/challenge/board/components/FilterDisclosure.tsx
+++ b/src/app.feature/challenge/board/components/FilterDisclosure.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { cn } from '@module/utils/cn';
-import { SlidersHorizontal } from 'lucide-react';
+import { ChevronDown, SlidersHorizontal } from 'lucide-react';
 import React, { useState } from 'react';
 
 interface FilterDisclosureProps {
@@ -13,6 +13,10 @@ interface FilterDisclosureProps {
 /**
  * 카테고리 외 세부 필터(종류·상태 등)를 접기/펴기 한다. 기본 접힘.
  * 챌린지 보드·내 챌린지 목록의 상단 필터 영역 높이를 줄이기 위한 공용 래퍼.
+ *
+ * 토글은 히트영역을 넉넉히(px-3.5 py-2, 아이콘~셰브론 전체가 탭 타깃) 잡고,
+ * 접힘/펼침은 오른쪽 셰브론 회전 + 펼침 시 강조 톤으로 표시한다(예전 12px
+ * "접기/펴기" 텍스트 대비 명확·큰 타깃). 앱 네이티브 필터도 이 디자인에 맞춘다.
  */
 export function FilterDisclosure({
   children,
@@ -28,15 +32,29 @@ export function FilterDisclosure({
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
         className={cn(
-          'flex items-center gap-1.5 text-[12px] font-bold text-gray-500',
-          'transition-colors hover:text-gray-700'
+          'inline-flex items-center gap-2 rounded-full border px-3.5 py-2',
+          'text-[13px] font-bold transition-colors',
+          open
+            ? 'border-main-200 bg-main-50 text-main-800'
+            : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
         )}
       >
-        <SlidersHorizontal className="h-3.5 w-3.5" />
+        <SlidersHorizontal
+          className={cn('h-4 w-4', open ? 'text-main-700' : 'text-gray-500')}
+          aria-hidden
+        />
         {label}
-        <span className="text-gray-400">{open ? '접기' : '펴기'}</span>
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 transition-transform duration-200',
+            open ? 'rotate-180 text-main-700' : 'text-gray-400'
+          )}
+          aria-hidden
+        />
       </button>
-      {open ? <div className="mt-2 flex flex-col gap-2.5">{children}</div> : null}
+      {open ? (
+        <div className="mt-2.5 flex flex-col gap-2.5">{children}</div>
+      ) : null}
     </div>
   );
 }

--- a/src/app.feature/diary/detail/components/DiaryGoalsCard.tsx
+++ b/src/app.feature/diary/detail/components/DiaryGoalsCard.tsx
@@ -10,11 +10,14 @@ const NOOP_VALUE_CHANGE = (): void => {};
 interface DiaryGoalsCardProps {
   checklistItems: ChecklistItem[];
   checkedChecklistIds: string[];
+  /** 체크 원 색 — 카드와 동일하게 무드 톤을 받는다(CSS color). */
+  checkColor?: string;
 }
 
 export function DiaryGoalsCard({
   checklistItems,
   checkedChecklistIds,
+  checkColor,
 }: DiaryGoalsCardProps): React.ReactElement {
   const checklistOptions = useMemo(
     () =>
@@ -45,6 +48,7 @@ export function DiaryGoalsCard({
           options={checklistOptions}
           value={checkedChecklistIds}
           onValueChange={NOOP_VALUE_CHANGE}
+          checkColor={checkColor}
           readOnly
         />
       ) : (

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -24,6 +24,7 @@ import { useIsLoggedIn } from '../../../member/hooks/useIsLoggedIn';
 import { useSidebar } from '../../../member/hooks/useMemberQueries';
 import { useDiaryDetail } from '../../board/hooks/useDiaryQueries';
 import { DiaryContentRenderer } from '../../shared/components/DiaryContentRenderer';
+import { toneFromFeeling } from '../../shared/utils/feeling';
 import { DiaryActionToolbar } from '../components/DiaryActionToolbar';
 import { DiaryAuthorRow } from '../components/DiaryAuthorRow';
 import {
@@ -58,19 +59,6 @@ import {
   mapDiaryToViewData,
   resolveSidebarMemberId,
 } from '../utils/diaryViewData';
-
-function getFeelingTextClass(feeling: DiaryDetailViewData['feeling']): string {
-  if (feeling === 'HAPPY') {
-    return 'text-main-800';
-  }
-  if (feeling === 'NORMAL') {
-    return 'text-green-800';
-  }
-  if (feeling === 'SAD') {
-    return 'text-blue-600';
-  }
-  return 'text-gray-500';
-}
 
 function DiaryDetailView({
   diaryData,
@@ -149,7 +137,8 @@ function DiaryDetailView({
     await navigator.clipboard.writeText(shareUrl);
   };
 
-  const isHundredPercent = diaryData.achievementPercent === 100;
+  // 기분·달성률·목표 체크 색을 카드와 동일한 무드 톤으로 통일(공유 소스).
+  const feelingTone = toneFromFeeling(diaryData.feeling);
 
   return (
     <div
@@ -259,12 +248,11 @@ function DiaryDetailView({
               </div>
             </section>
 
-            {/* Card 3 — 오늘의 기분 + 달성률 (독립 섹션, 프레스 모션) */}
+            {/* Card 3 — 오늘의 기분 + 달성률 (표시 전용, 클릭/프레스 없음) */}
             <section
               className={cn(
                 'flex items-center gap-2.5 rounded-[10px]',
-                'border border-gray-200 bg-white px-3.5 py-3',
-                'transition duration-200 ease-out active:scale-[0.97]'
+                'border border-gray-200 bg-white px-3.5 py-3'
               )}
             >
               {diaryData.feelingMoodImage ? (
@@ -281,17 +269,14 @@ function DiaryDetailView({
               <Text
                 size="caption1"
                 weight="semibold"
-                className={getFeelingTextClass(diaryData.feeling)}
+                className={feelingTone.fg}
               >
                 오늘의 기분 · {diaryData.feelingLabel}
               </Text>
               <Text
                 size="caption1"
                 weight="extrabold"
-                className={cn(
-                  'ml-auto shrink-0',
-                  isHundredPercent ? 'text-green-600' : 'text-main-800'
-                )}
+                className={cn('ml-auto shrink-0', feelingTone.fg)}
               >
                 달성 {diaryData.achievementPercent}%
               </Text>
@@ -300,6 +285,7 @@ function DiaryDetailView({
             <DiaryGoalsCard
               checklistItems={diaryData.checklistItems}
               checkedChecklistIds={diaryData.checkedChecklistIds}
+              checkColor={feelingTone.checkColor}
             />
 
             {/* Card 4 — 오늘의 기록: 본문 + 이미지 (모바일·태블릿은 플랫).

--- a/src/app.feature/diary/shared/utils/feeling.ts
+++ b/src/app.feature/diary/shared/utils/feeling.ts
@@ -11,3 +11,39 @@ export function mapFeelingToEmotion(feeling: Feeling): DiaryEmotion {
   }
   return 'soso';
 }
+
+export interface EmotionTone {
+  /** 텍스트 색(달성률·기분 텍스트) — Tailwind class. */
+  fg: string;
+  /** 체크 원 배경(카드가 직접 렌더) — Tailwind class. */
+  check: string;
+  /** DS CheckList 의 checkColor(상세 목표 리스트) — CSS color. */
+  checkColor: string;
+}
+
+// 감정별 무드 컬러 — 카드·상세가 공유하는 단일 소스. 무드 SVG 얼굴색 팔레트
+// (happy=main/피치·soso=mint·sad=blue)를 따르되 흰 체크·텍스트 대비를 위해 한
+// 단계 진한 톤을 쓴다. Tailwind class 는 카드가 직접 렌더하는 요소용, checkColor
+// 는 DS CheckList(상세)용 — JIT 가 동적 클래스를 못 만들어 두 형태를 함께 둔다.
+export const EMOTION_TONE: Record<DiaryEmotion, EmotionTone> = {
+  happy: {
+    fg: 'text-main-700',
+    check: 'bg-main-700',
+    checkColor: 'var(--color-main-700)',
+  },
+  soso: {
+    fg: 'text-mint-900',
+    check: 'bg-mint-800',
+    checkColor: 'var(--color-mint-800)',
+  },
+  sad: {
+    fg: 'text-blue-600',
+    check: 'bg-blue-500',
+    checkColor: 'var(--color-blue-500)',
+  },
+};
+
+/** 상세의 Feeling 값에서 바로 무드 톤을 얻는다(카드와 동일 매핑·색). */
+export function toneFromFeeling(feeling: Feeling): EmotionTone {
+  return EMOTION_TONE[mapFeelingToEmotion(feeling)];
+}


### PR DESCRIPTION
## 상용 승격 (준비된 것만)

#253 이후 develop 누적 2건. 필터 네이티브 동기화(filter_spec)·내챌린지 위임은
코드 미커밋(계약/진단 단계) → 자연 제외. main-only 핫픽스 없음, develop CI green.

### 포함
- fix(diary): 일지 상세 기분/퍼센트 섹션 클릭 비활성(프레스 모션 제거) +
  카드와 색상 동기화(공유 EMOTION_TONE — 기분·달성률·목표 체크색 무드 톤 통일)
- fix(challenge): 상세 필터 토글 디자인·히트영역 개선 (pill+셰브론, 탭영역 확대)

### 제외 (다음 배치 — 계약 확정 후)
- 필터 filter_spec 브릿지(웹→앱 필터 정의), 내챌린지 native 필터 위임

gate: lint 0 · tsc · vitest 192 · knip · build 통과(develop @9c4c650).