### PR TITLE
release: 챌린지 완료·참여종료 딱지 크기 소폭 상향

### DIFF
--- a/src/app.feature/challenge/board/screen/MyChallengeListScreen.tsx
+++ b/src/app.feature/challenge/board/screen/MyChallengeListScreen.tsx
@@ -104,8 +104,10 @@ const MyChallengeCardItem = React.memo(
             {hasLeft ? (
               <span
                 className={cn(
-                  'rounded-full bg-gray-900/80 px-2 py-0.5',
-                  'text-[10px] font-extrabold text-white'
+                  // 완료 딱지와 같은 규격(11px/px-2.5/py-1)으로 맞춰야
+                  // 둘이 나란히 붙을 때 높이가 어긋나지 않는다.
+                  'rounded-full bg-gray-900/80 px-2.5 py-1',
+                  'text-[11px] font-extrabold whitespace-nowrap text-white'
                 )}
               >
                 참여종료

--- a/src/app.feature/challenge/shared/components/ChallengeCompletedBadge.tsx
+++ b/src/app.feature/challenge/shared/components/ChallengeCompletedBadge.tsx
@@ -23,12 +23,14 @@ export function ChallengeCompletedBadge({
     <span
       className={cn(
         'inline-flex shrink-0 items-center gap-1 rounded-full',
-        'bg-emerald-50 px-2 py-0.5 text-[10px] font-extrabold',
+        // 10px 는 작아서 읽기 불편하다는 피드백 → 카드 상태 배지와 같은
+        // 11px/px-2.5/py-1 규격으로 소폭 올린다(참여종료 딱지와 동일 규격).
+        'bg-emerald-50 px-2.5 py-1 text-[11px] font-extrabold',
         'whitespace-nowrap text-emerald-700',
         className
       )}
     >
-      <CircleCheck className="h-3 w-3 shrink-0" aria-hidden />
+      <CircleCheck className="h-3.5 w-3.5 shrink-0" aria-hidden />
       {label}
     </span>
   );


### PR DESCRIPTION
## 승격 범위 (#256 이후 1건)

| 커밋 | 내용 |
|---|---|
| `28cb83c` | 완료·참여종료 딱지 크기 10px → 11px |

2 files, +8 −4. 순수 UI 크기 조정으로 로직·데이터·노출 조건 변경 없음.

## 변경 값

| 항목 | before | after |
|---|---|---|
| 폰트 | `text-[10px]` | `text-[11px]` |
| 가로 패딩 | `px-2` | `px-2.5` |
| 세로 패딩 | `py-0.5` | `py-1` |
| 완료 아이콘 | `h-3 w-3` | `h-3.5 w-3.5` |

`ChallengeCard`가 이미 쓰는 상태 배지 규격(`text-[11px] px-2.5 py-1`)에 맞췄고, 두 딱지가 같은 규격이라 내 챌린지 카드에서 나란히 붙어도 높이가 어긋나지 않습니다.

## 회귀 위험

미들웨어 · API · 타입 · 라우팅 · robots/sitemap · layout 메타 전부 무변경.