### PR TITLE
release: 일지 댓글 버튼 무반응 수정 (댓글 섹션으로 스크롤)

### DIFF
--- a/src/app.feature/diary/detail/components/DiaryActionToolbar.tsx
+++ b/src/app.feature/diary/detail/components/DiaryActionToolbar.tsx
@@ -9,8 +9,9 @@ interface DiaryActionToolbarProps {
   diaryData: DiaryDetailViewData;
   totalCommentCount: number;
   isLikePending: boolean;
-  // 앱에서 댓글 시트를 열 수 있을 때만 넘어온다. 없으면 카운터는 그대로
-  // 표시 전용(span)이라 웹 동작이 바뀌지 않는다.
+  // 댓글 카운터를 눌렀을 때의 동작(일지 상세는 댓글 섹션으로 스크롤).
+  // 넘기지 않으면 카운터가 button 이 아닌 표시 전용 span 으로 렌더된다 —
+  // 눌러도 반응이 없으므로, 이동시킬 곳이 있으면 반드시 넘길 것.
   onCommentTap?(): void;
   onLikeToggle(): void;
   onShare(): void;

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -17,7 +17,7 @@ import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import { Flag } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useChallengeDetail } from '../../../challenge/board/hooks/useChallengeQueries';
 import { MemberBlockButton } from '../../../friend/components/MemberBlockButton';
@@ -81,6 +81,16 @@ function DiaryDetailView({
   const router = useRouter();
   // 알림 딥링크/콜드 스타트로 진입해 history 가 없을 때 일지 목록으로 보낸다.
   const handleBack = useSafeBack('/diary');
+  // 액션바의 댓글 수 pill → 댓글 섹션으로 스크롤. 그동안 onCommentTap 을
+  // 아무도 넘기지 않아 pill 이 button 이 아닌 span 으로 렌더됐고, 눌러도
+  // 아무 일도 일어나지 않았다.
+  const commentSectionRef = useRef<HTMLElement | null>(null);
+  const handleCommentTap = useCallback((): void => {
+    commentSectionRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  }, []);
   const { data: sidebarData } = useSidebar();
   const isLoggedIn = useIsLoggedIn();
   const currentMemberId = useMemo(
@@ -256,6 +266,7 @@ function DiaryDetailView({
                   diaryData={diaryData}
                   totalCommentCount={totalCommentCount}
                   isLikePending={isLikePending}
+                  onCommentTap={handleCommentTap}
                   onLikeToggle={onLikeToggle}
                   onShare={() => void handleShare()}
                 />
@@ -348,7 +359,15 @@ function DiaryDetailView({
             ) : null}
           </article>
 
-          <aside>
+          {/* scroll-mt: 스크롤 목적지가 sticky 헤더 뒤로 숨지 않게 —
+              모바일 MobileHeader(h-14 + safe-area), 데스크탑 AppTopNav(62px) */}
+          <aside
+            ref={commentSectionRef}
+            className={cn(
+              'scroll-mt-[calc(3.5rem+env(safe-area-inset-top)+0.5rem)]',
+              'lg:scroll-mt-20'
+            )}
+          >
             <DiaryCommentSection
               diaryId={diaryData.id}
               currentMemberId={currentMemberId}


### PR DESCRIPTION
## 승격 범위 (#258 이후 1건)

| 커밋 | 내용 |
|---|---|
| `d25c008` | 일지 상세 댓글 버튼 → 댓글 섹션으로 스크롤 |

2 files (`DiaryDetailScreen.tsx`, `DiaryActionToolbar.tsx`).

## 배경 — 사용자 제보

모바일에서 댓글 버튼을 눌러도 반응 없음.

원인: `DiaryActionToolbar`의 댓글 수 pill은 `onCommentTap`이 있을 때만 `<button>`, 없으면 표시 전용 `<span>`으로 렌더되는데(`DiaryActionToolbar.tsx:55-76`), **이 프롭을 넘기는 호출부가 한 곳도 없었습니다.** 네이티브 댓글 시트를 상정하고 만든 프롭이 끝내 배선되지 않아, 웹에서는 계속 클릭 불가 span이었습니다.

## 변경

- `DiaryDetailScreen`이 댓글 섹션(`<aside>`)에 ref를 잡고, `onCommentTap`으로 `scrollIntoView({ behavior: 'smooth', block: 'start' })` 전달
- 목적지가 sticky 헤더 뒤로 숨지 않게 `scroll-margin-top` 지정
  - 모바일: `calc(3.5rem + env(safe-area-inset-top) + 0.5rem)` — MobileHeader(h-14 + safe-area)
  - 데스크탑: `lg:scroll-mt-20` — AppTopNav(62px)
- 프롭 주석을 실제 용도로 갱신

데스크탑도 같은 핸들러를 쓰며, 기존 레이아웃/마크업은 그대로입니다.