### PR TITLE
release: 투표 위젯 확장 — 기간 표시·상시 노출·내 선택 강조·재투표·네이티브 FAB 브릿지

### DIFF
--- a/src/app.feature/vote/components/VoteFloatingWidget.tsx
+++ b/src/app.feature/vote/components/VoteFloatingWidget.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { Button } from '@1d1s/design-system';
+import { useNativeVoteFab } from '@module/hooks/useNativeVoteFab';
 import { cn } from '@module/utils/cn';
+import { formatMonthDayKR } from '@module/utils/date';
 import {
   Check,
   ChevronLeft,
@@ -41,6 +43,17 @@ interface VotePanelProps {
   onClose(): void;
   /** 투표가 2건 이상일 때만 — 목록으로 돌아가는 핸들러 */
   onBack?(): void;
+}
+
+// 투표 기간 라벨. formatMonthDayKR 은 Date 파싱을 거치지 않아 타임존으로
+// 하루가 밀리지 않는다. 형식이 아니면 빈 문자열 → 라벨 자체를 숨긴다.
+function formatVotePeriod(startDate: string, endDate: string): string {
+  const start = formatMonthDayKR(startDate);
+  const end = formatMonthDayKR(endDate);
+  if (!start || !end) {
+    return '';
+  }
+  return start === end ? start : `${start} ~ ${end}`;
 }
 
 // 플로팅 카드 공통 골격. 목록/상세 두 단계가 같은 크기·모서리·스크롤 규칙을
@@ -162,6 +175,7 @@ function VotePanel({
     vote?.selectionType === 'MULTIPLE'
       ? '원하는 항목을 모두 선택해 주세요.'
       : '하나의 항목을 선택해 주세요.';
+  const votePeriod = vote ? formatVotePeriod(vote.startDate, vote.endDate) : '';
 
   return (
     <section aria-label="오늘의 투표" className={PANEL_CLASS}>
@@ -194,6 +208,9 @@ function VotePanel({
           <h2 className="text-lg leading-snug font-extrabold text-gray-900">
             {isLoading ? '투표를 불러오고 있어요' : vote?.title}
           </h2>
+          {votePeriod ? (
+            <p className="mt-1 text-xs text-gray-400">{votePeriod}</p>
+          ) : null}
         </div>
         <PanelCloseButton onClick={onClose} />
       </div>
@@ -308,39 +325,47 @@ function VoteListPanel({
       </div>
 
       <ul className="mt-4 flex flex-col gap-2.5">
-        {votes.map((vote) => (
-          <li key={vote.id}>
-            <button
-              type="button"
-              onClick={() => onSelect(vote.id)}
-              className={cn(
-                'flex min-h-12 w-full items-center gap-3 text-left',
-                'rounded-3 border border-gray-200 bg-white px-3.5 py-3',
-                'hover:border-main-500 transition'
-              )}
-            >
-              <span className="min-w-0 flex-1 text-sm font-semibold">
-                {vote.title}
-              </span>
-              {vote.voted ? (
-                <span
-                  className={cn(
-                    'inline-flex shrink-0 items-center gap-1 rounded-full',
-                    'bg-gray-100 px-2 py-0.5 text-[11px] font-bold',
-                    'text-gray-600'
-                  )}
-                >
-                  <Check className="h-3 w-3" strokeWidth={3} aria-hidden />
-                  참여 완료
+        {votes.map((vote) => {
+          const period = formatVotePeriod(vote.startDate, vote.endDate);
+          return (
+            <li key={vote.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(vote.id)}
+                className={cn(
+                  'flex min-h-12 w-full items-center gap-3 text-left',
+                  'rounded-3 border border-gray-200 bg-white px-3.5 py-3',
+                  'hover:border-main-500 transition'
+                )}
+              >
+                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="truncate text-sm font-semibold">
+                    {vote.title}
+                  </span>
+                  {period ? (
+                    <span className="text-[11px] text-gray-400">{period}</span>
+                  ) : null}
                 </span>
-              ) : null}
-              <ChevronRight
-                className="h-4 w-4 shrink-0 text-gray-400"
-                aria-hidden
-              />
-            </button>
-          </li>
-        ))}
+                {vote.voted ? (
+                  <span
+                    className={cn(
+                      'inline-flex shrink-0 items-center gap-1 rounded-full',
+                      'bg-gray-100 px-2 py-0.5 text-[11px] font-bold',
+                      'text-gray-600'
+                    )}
+                  >
+                    <Check className="h-3 w-3" strokeWidth={3} aria-hidden />
+                    참여 완료
+                  </span>
+                ) : null}
+                <ChevronRight
+                  className="h-4 w-4 shrink-0 text-gray-400"
+                  aria-hidden
+                />
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );
@@ -366,18 +391,22 @@ function VoteFab({
       )}
     >
       <Vote className="h-6 w-6" aria-hidden />
-      <span
-        aria-hidden
-        className={cn(
-          'absolute -top-0.5 -right-0.5 flex items-center justify-center',
-          'rounded-full border-2 border-white bg-red-500',
-          remaining > 1
-            ? 'h-5 min-w-5 px-1 text-[11px] leading-none font-bold'
-            : 'h-3 w-3'
-        )}
-      >
-        {remaining > 1 ? remaining : null}
-      </span>
+      {/* 배지는 미참여가 남아 있을 때만. 다 응답해도 버튼은 유지되는데
+          빨간 점까지 남으면 "안 본 게 있다"는 오신호가 된다. */}
+      {remaining > 0 ? (
+        <span
+          aria-hidden
+          className={cn(
+            'absolute -top-0.5 -right-0.5 flex items-center justify-center',
+            'rounded-full border-2 border-white bg-red-500',
+            remaining > 1
+              ? 'h-5 min-w-5 px-1 text-[11px] leading-none font-bold'
+              : 'h-3 w-3'
+          )}
+        >
+          {remaining > 1 ? remaining : null}
+        </span>
+      ) : null}
     </button>
   );
 }
@@ -480,10 +509,20 @@ export default function VoteFloatingWidget({
     resetPanelState();
   }, [resetPanelState]);
 
-  const remaining = votes.filter((vote) => !vote.voted).length;
-  // 참여할 투표가 남아 있을 때만 띄운다. 방금 제출한 결과를 보고 있는
-  // 동안(submittedVote)은 마지막 1건을 끝냈어도 카드를 닫지 않는다.
-  if (!enabled || (remaining === 0 && submittedVote === null)) {
+  const remaining = votes.filter((item) => !item.voted).length;
+
+  // 네이티브 쉘이 vote_fab 을 announce 했으면 앱이 고정 버튼을 그리고 웹
+  // FAB 는 숨긴다(패널은 그대로 웹이 소유). 구버전 쉘·브라우저는 false 라
+  // 기존 웹 FAB 가 유지된다. 훅이므로 early return 위에서 호출한다.
+  const isNativeFab = useNativeVoteFab({
+    visible: enabled && votes.length > 0,
+    count: remaining,
+    onTap: () => setIsMobileOpen(true),
+  });
+
+  // 진행 중인 투표가 하나라도 있으면 계속 노출한다. 예전엔 미참여가 0 이면
+  // 버튼째 사라져서, 참여 기간인데도 결과를 다시 볼 방법이 없었다.
+  if (!enabled || votes.length === 0) {
     return null;
   }
 
@@ -530,7 +569,7 @@ export default function VoteFloatingWidget({
       >
         {isDesktopOpen ? (
           renderPanel(handleDesktopClose)
-        ) : (
+        ) : isNativeFab ? null : (
           <VoteFab
             remaining={remaining}
             onClick={() => setIsDesktopOpen(true)}
@@ -547,7 +586,7 @@ export default function VoteFloatingWidget({
       >
         {isMobileOpen ? (
           renderPanel(handleMobileClose)
-        ) : (
+        ) : isNativeFab ? null : (
           <VoteFab
             remaining={remaining}
             onClick={() => setIsMobileOpen(true)}

--- a/src/app.feature/vote/components/VoteFloatingWidget.tsx
+++ b/src/app.feature/vote/components/VoteFloatingWidget.tsx
@@ -43,6 +43,11 @@ interface VotePanelProps {
   onClose(): void;
   /** 투표가 2건 이상일 때만 — 목록으로 돌아가는 핸들러 */
   onBack?(): void;
+  /** 재투표(수정) 모드 진행 중인지. */
+  isEditing: boolean;
+  /** 완료 상태에서 "수정" — 이전 선택을 프리체크하고 잠금을 푼다. */
+  onEdit(): void;
+  onCancelEdit(): void;
 }
 
 // 투표 기간 라벨. formatMonthDayKR 은 Date 파싱을 거치지 않아 타임존으로
@@ -169,6 +174,9 @@ function VotePanel({
   onRetry,
   onClose,
   onBack,
+  isEditing,
+  onEdit,
+  onCancelEdit,
 }: VotePanelProps): React.ReactElement {
   const hasSelection = selectedOptionIds.length > 0;
   const selectionGuide =
@@ -245,7 +253,7 @@ function VotePanel({
       {vote && !isError ? (
         <>
           <p className="mt-2 text-xs text-gray-500">
-            {isSubmitted
+            {isSubmitted && !isEditing
               ? '소중한 의견을 남겨주셔서 감사해요.'
               : selectionGuide}
           </p>
@@ -260,21 +268,62 @@ function VotePanel({
                 option={option}
                 selectionType={vote.selectionType}
                 isSelected={selectedOptionIds.includes(option.optionId)}
-                isSubmitted={isSubmitted}
+                isSubmitted={isSubmitted && !isEditing}
                 onClick={() => onOptionClick(option.optionId)}
               />
             ))}
           </div>
-          <Button
-            type="button"
-            size="lg"
-            fullWidth
-            disabled={!isSubmitted && (!hasSelection || isSubmitting)}
-            onClick={isSubmitted ? onClose : onSubmit}
-            className="mt-5"
-          >
-            {isSubmitted ? '확인' : isSubmitting ? '투표 중...' : '투표하기'}
-          </Button>
+          {isEditing ? (
+            <div className="mt-5 flex gap-2">
+              <Button
+                type="button"
+                size="lg"
+                variant="secondary"
+                fullWidth
+                disabled={isSubmitting}
+                onClick={onCancelEdit}
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                size="lg"
+                fullWidth
+                disabled={!hasSelection || isSubmitting}
+                onClick={onSubmit}
+              >
+                {isSubmitting ? '수정 중...' : '수정 완료'}
+              </Button>
+            </div>
+          ) : isSubmitted ? (
+            // 기간 안이면 몇 번이든 바꿀 수 있다(서버 upsert). 마감·비대상은
+            // 서버가 VOTE-004/VOTE-011 로 막고 전역 토스트가 사유를 띄운다.
+            <div className="mt-5 flex gap-2">
+              <Button
+                type="button"
+                size="lg"
+                variant="secondary"
+                fullWidth
+                onClick={onEdit}
+              >
+                수정
+              </Button>
+              <Button type="button" size="lg" fullWidth onClick={onClose}>
+                확인
+              </Button>
+            </div>
+          ) : (
+            <Button
+              type="button"
+              size="lg"
+              fullWidth
+              disabled={!hasSelection || isSubmitting}
+              onClick={onSubmit}
+              className="mt-5"
+            >
+              {isSubmitting ? '투표 중...' : '투표하기'}
+            </Button>
+          )}
         </>
       ) : null}
     </section>
@@ -423,6 +472,8 @@ export default function VoteFloatingWidget({
   const [renderedVoteId, setRenderedVoteId] = useState<number | null>(null);
   // 2건 이상일 때 목록에서 고른 투표. null 이면 목록 단계.
   const [selectedVoteId, setSelectedVoteId] = useState<number | null>(null);
+  // 재투표(수정) 모드. 완료 상태의 잠금을 로컬로만 푼다.
+  const [isEditing, setIsEditing] = useState(false);
 
   // 서버가 노출 대상(audience) 필터를 로그인 회원 기준으로 이미 적용해
   // 내려주므로, 받은 배열을 그대로 전부 노출한다. 예전엔 여기서
@@ -447,6 +498,15 @@ export default function VoteFloatingWidget({
   // voted:false 로 남아 있을 때 선택지가 계속 클릭 가능해 보인다.
   // 상세 응답의 voted 플래그를 함께 보고 확정 상태를 판정한다.
   const isAnswered = submittedVote !== null || vote?.voted === true;
+  const myOptionIds = vote?.myOptionIds;
+
+  // 강조할 선택지.
+  // - 완료 & 비수정: 서버의 myOptionIds — 어제·다른 기기에서 응답한 것도
+  //   세션 상태 없이 그대로 강조된다.
+  // - 수정 중/미응답: 이번 세션의 클릭(selectedOptionIds). 수정 중에 서버값을
+  //   OR 로 섞으면 이전 선택을 해제할 수 없어 복수 선택 변경이 막힌다.
+  const displayedOptionIds =
+    isAnswered && !isEditing ? (myOptionIds ?? []) : selectedOptionIds;
 
   // 표시 중인 투표가 바뀌면 이전 투표의 선택을 반드시 버린다 — 안 그러면
   // 오늘 투표가 2건 이상일 때 앞 투표의 optionId 가 다음 투표로 넘어간다.
@@ -457,11 +517,12 @@ export default function VoteFloatingWidget({
     // 제출 결과도 함께 버린다 — 안 그러면 A 를 제출하고 목록으로 돌아가
     // B 를 열었을 때 A 의 결과(선택지·비율)가 B 자리에 그대로 남는다.
     setSubmittedVote(null);
+    setIsEditing(false);
   }
 
   const handleOptionClick = useCallback(
     (optionId: number): void => {
-      if (!vote || isAnswered) {
+      if (!vote || (isAnswered && !isEditing)) {
         return;
       }
       setSelectedOptionIds((current) => {
@@ -473,11 +534,11 @@ export default function VoteFloatingWidget({
           : [...current, optionId];
       });
     },
-    [isAnswered, vote]
+    [isAnswered, isEditing, vote]
   );
 
   const handleSubmit = useCallback((): void => {
-    if (!vote || isAnswered || selectedOptionIds.length === 0) {
+    if (!vote || (isAnswered && !isEditing) || selectedOptionIds.length === 0) {
       return;
     }
     submitVote.mutate(
@@ -486,10 +547,28 @@ export default function VoteFloatingWidget({
         data: { optionIds: selectedOptionIds },
       },
       {
-        onSuccess: (detail) => setSubmittedVote(detail),
+        // 응답에 갱신된 myOptionIds·비율이 실려 온다. 캐시(detail/today)는
+        // useSubmitVote 가 함께 패치한다.
+        onSuccess: (detail) => {
+          setSubmittedVote(detail);
+          setIsEditing(false);
+          setSelectedOptionIds([]);
+        },
       }
     );
-  }, [isAnswered, selectedOptionIds, submitVote, vote]);
+  }, [isAnswered, isEditing, selectedOptionIds, submitVote, vote]);
+
+  // 수정 진입 시 이전 선택을 프리체크한다 — 복수 선택에서 처음부터 다시
+  // 고르게 하지 않기 위해 서버의 myOptionIds 를 그대로 시드로 쓴다.
+  const handleEdit = useCallback((): void => {
+    setSelectedOptionIds(myOptionIds ?? []);
+    setIsEditing(true);
+  }, [myOptionIds]);
+
+  const handleCancelEdit = useCallback((): void => {
+    setIsEditing(false);
+    setSelectedOptionIds([]);
+  }, []);
 
   // 카드를 접을 때는 진행 상태를 초기화해, 다시 열었을 때 목록(2건 이상)
   // 또는 깨끗한 상세(1건)에서 시작하게 한다.
@@ -497,6 +576,7 @@ export default function VoteFloatingWidget({
     setSelectedVoteId(null);
     setSubmittedVote(null);
     setSelectedOptionIds([]);
+    setIsEditing(false);
   }, []);
 
   const handleDesktopClose = useCallback((): void => {
@@ -535,7 +615,10 @@ export default function VoteFloatingWidget({
     isError: isDetailError,
     isSubmitting: submitVote.isPending,
     isSubmitted: isAnswered,
-    selectedOptionIds,
+    selectedOptionIds: displayedOptionIds,
+    isEditing,
+    onEdit: handleEdit,
+    onCancelEdit: handleCancelEdit,
     onOptionClick: handleOptionClick,
     onSubmit: handleSubmit,
     onRetry: () => {

--- a/src/app.feature/vote/type/vote.ts
+++ b/src/app.feature/vote/type/vote.ts
@@ -24,6 +24,9 @@ export interface VoteOption {
 
 export interface VoteDetail extends VoteSummary {
   options: VoteOption[];
+  // 내가 고른 optionId 들. 미응답·비로그인이면 []. 목록(VoteSummary)에는
+  // 없고 상세·제출/재투표 응답에만 실린다. 구버전 서버 대비 옵셔널.
+  myOptionIds?: number[];
 }
 
 export interface VoteSubmitRequest {

--- a/src/app.module/hooks/useNativeVoteFab.ts
+++ b/src/app.module/hooks/useNativeVoteFab.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useNativeCapability } from '@module/hooks/useNativeCapability';
+import {
+  isNativeVoteFabAvailable,
+  onNativeVoteFabTap,
+  sendNativeVoteFab,
+} from '@module/utils/nativeBridge';
+import { useEffect, useRef } from 'react';
+
+interface NativeVoteFabOptions {
+  /** 진행 중인 투표가 있어 버튼을 띄워야 하는지. false 면 앱 버튼을 내린다. */
+  visible: boolean;
+  /** 미참여 투표 수(배지용). 0 이면 앱은 배지 없이 버튼만 그린다. */
+  count: number;
+  /** 버튼 라벨. */
+  label?: string;
+  /** 네이티브 버튼 탭 콜백. 시트/패널을 여는 것은 웹 책임. */
+  onTap(): void;
+}
+
+/**
+ * 오늘의 투표 FAB 를 네이티브 고정 버튼으로 위임한다.
+ *
+ * 반환값이 true 면 앱이 버튼을 그리고 있으므로 호출부는 자기 웹 FAB 를
+ * 숨긴다. 브라우저·구버전 쉘(vote_fab 피처 없음)에선 false 라 웹 FAB 가
+ * 그대로 보인다 — 하위호환.
+ *
+ * visible/count/label 이 바뀔 때마다 재전송하고, 언마운트(라우트 이탈 포함)
+ * 에서 visible:false 로 해제한다. form_cta 와 같은 수명 규칙이다.
+ */
+export function useNativeVoteFab({
+  visible,
+  count,
+  label = '투표',
+  onTap,
+}: NativeVoteFabOptions): boolean {
+  // native:ready 로 vote_fab 피처가 늦게 주입돼도 재평가되도록 반응형으로 읽는다.
+  const delegated = useNativeCapability(isNativeVoteFabAvailable);
+
+  // 핸들러는 매 렌더 바뀌지만(클로저) 구독은 한 번만 걸도록 ref 로 최신화한다.
+  const tapRef = useRef(onTap);
+  useEffect(() => {
+    tapRef.current = onTap;
+  });
+
+  useEffect(() => {
+    if (!delegated) {
+      return;
+    }
+    sendNativeVoteFab({ visible, count, label });
+  }, [delegated, visible, count, label]);
+
+  // 해제는 언마운트에서만 — 값이 바뀔 때마다 내렸다 올리면 버튼이 깜빡인다.
+  // 위젯이 홈·탐색 밖에서 언마운트되므로 이게 곧 라우트 이탈 해제다.
+  useEffect(
+    () => () => {
+      sendNativeVoteFab({ visible: false });
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!delegated) {
+      return;
+    }
+    return onNativeVoteFabTap(() => tapRef.current());
+  }, [delegated]);
+
+  return delegated;
+}

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -261,6 +261,8 @@ export type NativeMessage =
       step?: number;
       steps?: number;
     }
+  // 오늘의 투표 FAB 를 네이티브 고정 버튼으로 위임. visible:false 로 해제.
+  | { type: 'vote_fab'; payload: NativeVoteFabPayload }
   // 화면 콘텐츠가 실제로 렌더된 시점. 앱이 해당 screen 의 네이티브 스켈레톤을
   // 걷고 워치독을 해제한다(흰 화면 방지). route 는 경로 검증·중복 방지용.
   | { type: 'page_ready'; screen: string; route: string };
@@ -287,6 +289,14 @@ function getNativeWindow(): NativeWindow | null {
 // 컨트롤이 된다. 응답이 필요한 새 위임은 이 플래그를 먼저 확인한다.
 function hasNativeFeature(name: string): boolean {
   return getNativeWindow()?.__1D1S_FEATURES__?.[name] === true;
+}
+
+export interface NativeVoteFabPayload {
+  // false 면 앱이 버튼을 내린다(라우트 이탈·진행 중 투표 0건).
+  visible: boolean;
+  // 미참여 투표 수. 0 이면 앱은 배지 없이 버튼만 그린다(웹 FAB 규칙과 동일).
+  count?: number;
+  label?: string;
 }
 
 export interface NativeToastPayload {
@@ -802,6 +812,37 @@ export function onNativeFormCtaAction(
   };
   win.addEventListener('native:form_cta_action', listener);
   return () => win.removeEventListener('native:form_cta_action', listener);
+}
+
+// ── 오늘의 투표 FAB 위임 (vote_fab) ──────────────────────────────────────
+// 웹 FAB 는 WebView 안에 갇혀 네이티브 하단 바 위로 올라가지 못한다. 앱이
+// 대신 고정 버튼을 그리고, 노출 여부·개수·라벨은 웹이 계속 갱신한다
+// (노출 판정의 권위는 웹). 앱→웹은 native:vote_fab_tap 이벤트로 돌아온다.
+// form_cta 와 같은 수명 규칙: 상태가 바뀌면 재전송, 떠날 때 해제.
+
+const VOTE_FAB_TAP_EVENT = 'native:vote_fab_tap';
+
+/** 투표 FAB 상태 전송. visible:false 가 해제 신호다. */
+export function sendNativeVoteFab(payload: NativeVoteFabPayload): void {
+  postNativeMessage({ type: 'vote_fab', payload });
+}
+
+/** 네이티브 투표 FAB 지원 여부(채널 + vote_fab 피처). 아니면 웹 FAB 유지. */
+export function isNativeVoteFabAvailable(): boolean {
+  return (
+    getNativeWindow()?.[CHANNEL_NAME] != null && hasNativeFeature('vote_fab')
+  );
+}
+
+/** 네이티브 투표 FAB 탭 구독. cleanup 반환. */
+export function onNativeVoteFabTap(handler: () => void): () => void {
+  const win = getNativeWindow();
+  if (!win) {
+    return () => {};
+  }
+  const listener = (): void => handler();
+  win.addEventListener(VOTE_FAB_TAP_EVENT, listener);
+  return () => win.removeEventListener(VOTE_FAB_TAP_EVENT, listener);
 }
 
 // ── 화면 준비 신호 (page_ready) ──────────────────────────────────────────


### PR DESCRIPTION
## 승격 범위 (#259 이후 2건)

| 커밋 | 내용 |
|---|---|
| `bd844a5` | 1단계 — 투표 기간 표시 + 상시 노출 + 네이티브 FAB 브릿지(웹측) |
| `5a07a0f` | 2단계 — 내 선택 강조(`myOptionIds`) + 재투표(수정) 모드 |

4 files, +305 −68.

## 서버 전제

서버 prod 승격 완료 — `myOptionIds`, 재투표 upsert(POST/PUT), `VOTE-011` 상용 반영됨.

## 변경 요약

**① 기간 표시** — 상세 패널 헤더·목록 행에 `8월 1일 ~ 8월 7일`. `formatMonthDayKR` 재사용(타임존 하루 밀림 없음).

**② 상시 노출** — 노출 조건을 `remaining === 0` → `votes.length === 0`으로. 진행 중 투표가 있으면 다 응답해도 버튼 유지(결과 재확인 가능). FAB 배지는 `remaining > 0`일 때만.

**③ 내 선택 강조** — `VoteDetail.myOptionIds`(옵셔널)로 완료 투표의 내 선택을 세션 상태 없이 강조.

**④ 재투표** — 완료 패널에 `수정`/`확인`, 수정 중 `취소`/`수정 완료`. 진입 시 `myOptionIds`로 프리체크. 기존 `useSubmitVote`(POST) 재사용(서버 upsert).

**⑤ 네이티브 FAB 브릿지(웹측)** — `vote_fab` 메시지/피처 플래그/탭 이벤트. 플래그 없으면 웹 FAB 유지(하위호환). `nativeBridge.ts`는 **삭제 라인 0의 순수 추가**.

## 회귀 위험

미들웨어 · axios client/interceptors/tokenRefresh · providers · next.config · package.json · robots/sitemap · layout 메타 **모두 무변경**. `AppLayoutShell.tsx`(#258 투표 라우트 화이트리스트)와 `DiaryDetailScreen.tsx`(#259 댓글 스크롤)도 이 범위에 없어 그대로 유지됩니다.

## 미확정 사항 (배포와 무관, 앱 세션 대조 필요)

`vote_fab` 계약 2건 — `count` 의미(웹은 미참여 수 전송), payload 중첩 여부(웹은 `payload`로 감쌈). 앱이 플래그를 announce하기 전까지 웹 동작은 기존과 동일합니다.