### PR TITLE
feat(cache): 무한 스크롤 목록 영속화 — persister 쓰기 시 첫 페이지만 저장

### DIFF
--- a/src/app.feature/diary/board/hooks/useDiaryQueries.ts
+++ b/src/app.feature/diary/board/hooks/useDiaryQueries.ts
@@ -67,13 +67,17 @@ export function useDiaryList(
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) =>
       lastPage.pageInfo.hasNextPage ? lastPage.pageInfo.nextCursor : undefined,
-    // W12: 일지→챌린지→일지 뒤로가기 시 재요청/재로딩을 막는다. remount refetch
-    // 를 끄고 캐시를 그대로 보여준다. 새 일지/수정/삭제는 mutation 이
-    // DIARY_QUERY_KEYS.lists() 를 invalidate 하므로 목록 최신성은 유지된다.
+    // W12: 일지→챌린지→일지 뒤로가기 시 재요청/재로딩을 막는다. 그 왕복은
+    // staleTime(5분) 안에 끝나므로 `refetchOnMount: true` 로도 재요청이 없다
+    // — true 는 "stale 일 때만" 재요청이기 때문이다. false 는 아무리 오래된
+    // 캐시여도 절대 재검증하지 않아, localStorage 에서 복원한 최대 24시간
+    // 전 목록이 invalidate 전까지 그대로 남는 문제가 있었다.
+    // 새 일지/수정/삭제는 mutation 이 DIARY_QUERY_KEYS.lists() 를
+    // invalidate 하므로 목록 최신성은 유지된다.
     // 다른 창/탭에서 돌아오면(window focus) 새로고침한다.
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: 'always',
-    refetchOnMount: false,
+    refetchOnMount: true,
   });
 }
 

--- a/src/app.lib/queryPersist.test.ts
+++ b/src/app.lib/queryPersist.test.ts
@@ -1,0 +1,94 @@
+import type { PersistedClient } from '@tanstack/react-query-persist-client';
+import { describe, expect, it } from 'vitest';
+
+import { truncateInfinitePages } from './queryPersist';
+
+type DehydratedQuery = PersistedClient['clientState']['queries'][number];
+
+function makeQuery(hash: string, data: unknown): DehydratedQuery {
+  return {
+    queryHash: hash,
+    queryKey: [hash],
+    state: { data, dataUpdateCount: 1, dataUpdatedAt: 0 },
+  } as unknown as DehydratedQuery;
+}
+
+function makeClient(queries: DehydratedQuery[]): PersistedClient {
+  return {
+    timestamp: 0,
+    buster: 'test',
+    clientState: { mutations: [], queries },
+  };
+}
+
+function firstQueryData(client: PersistedClient): unknown {
+  return client.clientState.queries[0]?.state.data;
+}
+
+describe('truncateInfinitePages', () => {
+  it('무한 스크롤 쿼리를 첫 페이지만 남긴다', () => {
+    const client = makeClient([
+      makeQuery('diary-list', {
+        pages: [{ items: ['a'] }, { items: ['b'] }, { items: ['c'] }],
+        pageParams: [undefined, 'cursor-1', 'cursor-2'],
+      }),
+    ]);
+
+    const result = truncateInfinitePages(client);
+
+    expect(firstQueryData(result)).toEqual({
+      pages: [{ items: ['a'] }],
+      pageParams: [undefined],
+    });
+  });
+
+  it('pages 와 pageParams 를 같은 인덱스로 자른다', () => {
+    const client = makeClient([
+      makeQuery('challenge-list', {
+        pages: [{ id: 1 }, { id: 2 }],
+        pageParams: ['p1', 'p2'],
+      }),
+    ]);
+
+    const data = firstQueryData(truncateInfinitePages(client)) as {
+      pages: unknown[];
+      pageParams: unknown[];
+    };
+
+    expect(data.pages).toHaveLength(1);
+    expect(data.pageParams).toHaveLength(1);
+    expect(data.pageParams[0]).toBe('p1');
+  });
+
+  it('일반 useQuery 데이터는 건드리지 않는다', () => {
+    const listData = [{ id: 1 }, { id: 2 }];
+    const client = makeClient([makeQuery('home-random', listData)]);
+
+    expect(firstQueryData(truncateInfinitePages(client))).toBe(listData);
+  });
+
+  it('페이지가 하나뿐이면 원본 쿼리를 그대로 재사용한다', () => {
+    const query = makeQuery('single', {
+      pages: [{ items: [] }],
+      pageParams: [undefined],
+    });
+
+    const result = truncateInfinitePages(makeClient([query]));
+
+    expect(result.clientState.queries[0]).toBe(query);
+  });
+
+  it('원본 캐시 객체를 변형하지 않는다', () => {
+    const data = {
+      pages: [{ id: 1 }, { id: 2 }],
+      pageParams: [undefined, 'c1'],
+    };
+    const client = makeClient([makeQuery('mutation-check', data)]);
+
+    truncateInfinitePages(client);
+
+    // 여기서 잘리면 화면에 떠 있는 목록이 1페이지로 줄어든다.
+    expect(data.pages).toHaveLength(2);
+    expect(data.pageParams).toHaveLength(2);
+  });
+});

--- a/src/app.lib/queryPersist.ts
+++ b/src/app.lib/queryPersist.ts
@@ -1,4 +1,8 @@
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
+import type {
+  PersistedClient,
+  Persister,
+} from '@tanstack/react-query-persist-client';
 
 // React Query 캐시를 localStorage 에 영속한다. 웹뷰가 리로드/재생성돼도(앱)
 // 재fetch 없이 이전 캐시로 즉시 렌더하기 위함(브라우저 세션이 유지하던 이점을
@@ -15,19 +19,79 @@ export const RQ_PERSIST_MAX_AGE = 24 * 60 * 60 * 1000;
 // 모두 새 커밋 → SHA 변경 → 자동 무효화.
 export const RQ_PERSIST_BUSTER = `v1-${process.env.NEXT_PUBLIC_BUILD_ID ?? 'dev'}`;
 
+interface InfinitePages {
+  pages: unknown[];
+  pageParams: unknown[];
+}
+
+function isInfiniteData(data: unknown): data is InfinitePages {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const candidate = data as Partial<InfinitePages>;
+  return Array.isArray(candidate.pages) && Array.isArray(candidate.pageParams);
+}
+
+/**
+ * 영속 대상에서 무한 스크롤 쿼리의 **첫 페이지만** 남긴다.
+ *
+ * 누적 페이지 전체(수백 KB)를 throttle 주기마다 JSON.stringify 로 동기
+ * 기록하면 저사양 기기에서 스크롤 중 프레임이 끊긴다. 그렇다고 통째로
+ * 제외하면(이전 동작) 리스트 탭은 복귀할 때마다 스켈레톤이다. 첫 페이지만
+ * 남기면 쓰기 비용은 일반 쿼리 수준으로 유지하면서 복귀 즉시 첫 화면이
+ * 채워진다 — 어차피 복원 직후 사용자가 보는 것은 첫 페이지뿐이다.
+ *
+ * pages/pageParams 를 **같은 인덱스로** 자르므로 복원 후 getNextPageParam
+ * 은 첫 페이지를 lastPage 로 받아 다음 커서를 정상 계산한다(hasNextPage 도
+ * 첫 페이지의 pageInfo 로 다시 도출된다).
+ *
+ * 살아있는 쿼리 캐시가 참조하는 객체를 그대로 받으므로 **변형하지 않고**
+ * 새 객체로 복사한다 — 여기서 mutate 하면 화면의 목록이 1페이지로 잘린다.
+ */
+export function truncateInfinitePages(
+  client: PersistedClient
+): PersistedClient {
+  return {
+    ...client,
+    clientState: {
+      ...client.clientState,
+      queries: client.clientState.queries.map((query) => {
+        const data = query.state.data;
+        if (!isInfiniteData(data) || data.pages.length <= 1) {
+          return query;
+        }
+        return {
+          ...query,
+          state: {
+            ...query.state,
+            data: {
+              ...data,
+              pages: data.pages.slice(0, 1),
+              pageParams: data.pageParams.slice(0, 1),
+            },
+          },
+        };
+      }),
+    },
+  };
+}
+
 /** 클라이언트에서만 localStorage persister 를 만든다. 서버(SSR)면 null. */
-export function createRqPersister():
-  | ReturnType<typeof createSyncStoragePersister>
-  | null {
+export function createRqPersister(): Persister | null {
   if (typeof window === 'undefined') {
     return null;
   }
-  return createSyncStoragePersister({
+  const persister = createSyncStoragePersister({
     storage: window.localStorage,
     key: RQ_PERSIST_KEY,
     // 캐시 갱신이 몰릴 때 쓰기를 1s 로 합쳐 메인스레드를 보호한다.
     throttleTime: 1000,
   });
+  return {
+    ...persister,
+    persistClient: (client) =>
+      persister.persistClient(truncateInfinitePages(client)),
+  };
 }
 
 /**

--- a/src/app.module/providers/QueryClientProvider.tsx
+++ b/src/app.module/providers/QueryClientProvider.tsx
@@ -47,17 +47,14 @@ export function TanStackQueryProvider({
         buster: RQ_PERSIST_BUSTER,
         dehydrateOptions: {
           // 성공 쿼리만 저장(pending/error 제외) + meta.noPersist 옵트아웃.
-          // 무한 스크롤 쿼리도 제외한다 — 누적 페이지 전체가 1초마다
-          // JSON.stringify 로 localStorage 에 동기 기록되면(수백 KB) 저사양
-          // 기기에서는 스크롤 중 수 프레임짜리 멈춤이 된다. 복원해 봤자
-          // 첫 페이지만 보여주면 되는 데이터라 저장 가치도 낮다.
+          // 무한 스크롤 쿼리도 포함한다 — 예전엔 누적 페이지 전체를 1초마다
+          // JSON.stringify 하는 비용(수백 KB) 때문에 통째로 제외했지만,
+          // 그러면 탐색·일지·챌린지 리스트가 복귀할 때마다 스켈레톤이었다.
+          // 지금은 persister 가 쓰기 직전에 첫 페이지만 남기므로
+          // (truncateInfinitePages) 쓰기 비용은 일반 쿼리 수준이다.
           shouldDehydrateQuery: (query) =>
             defaultShouldDehydrateQuery(query) &&
-            query.meta?.noPersist !== true &&
-            !Array.isArray(
-              (query.state.data as { pageParams?: unknown[] } | undefined)
-                ?.pageParams
-            ),
+            query.meta?.noPersist !== true,
         },
       }}
     >


### PR DESCRIPTION
## 목표

재진입·복귀 시 스켈레톤 없이 마지막 데이터 즉시 표시 + 백그라운드 재검증.
앱 WebView 가 리로드돼도 localStorage 는 살아남으므로 앱 복귀 스켈레톤도 줄어든다.

## 배경 — persistQueryClient 는 이미 있었고, 갭이 2개였다

`PersistQueryClientProvider` · localStorage persister · maxAge 24h ·
buster(커밋 SHA) · 로그아웃 purge 는 모두 이미 배선돼 있었다. 그런데
정작 요청 범위인 리스트 탭들이 동작하지 않았다.

### 갭 1 — 무한 스크롤 쿼리가 영속화에서 통째로 제외

`shouldDehydrateQuery` 가 `pageParams` 를 가진 쿼리를 전부 제외하고 있었다.
그 결과 `useDiaryList` · `useChallengeList`(탐색의 `useExploreOfficialChallenges`
도 내부적으로 이걸 쓴다)가 저장되지 않아, 4탭 중 홈만 영속화됐다.

제외 이유는 정당했다 — 누적 페이지 전체를 throttle 주기마다
`JSON.stringify` 로 동기 기록하면 저사양 기기에서 스크롤 중 프레임이 끊긴다.

**그래서 제외를 푸는 대신 쓰기 직전에 첫 페이지만 남긴다**
(`truncateInfinitePages`). 쓰기 비용은 일반 쿼리 수준으로 유지되고,
복원 직후 사용자가 실제로 보는 첫 화면은 채워진다.

- `pages` / `pageParams` 를 **같은 인덱스로** 자른다 → 복원 후
  `getNextPageParam` 이 첫 페이지를 `lastPage` 로 받아 다음 커서를 정상
  계산하고, `hasNextPage` 도 첫 페이지 `pageInfo` 로 재도출된다.
- 살아있는 쿼리 캐시가 참조하는 객체를 **변형하지 않고** 새 객체로 복사한다
  — mutate 하면 화면에 떠 있는 목록이 1페이지로 잘린다. 회귀 테스트 포함.
- 일반 `useQuery` 데이터는 손대지 않는다(`pages`+`pageParams` 둘 다 배열일
  때만 동작).

### 갭 2 — 복원돼도 재검증이 안 붙는 쿼리

`useDiaryList` 만 `refetchOnMount: false` 였다. v5 에서 `false` 는
**stale 이어도 재요청하지 않음**이라, localStorage 에서 복원한 최대 24시간
전 목록이 invalidate 전까지 그대로 남는다.

`true` 로 바꿨다 — `true` 는 "stale 일 때만" 재요청이므로 원래 의도였던
W12(일지→챌린지→일지 뒤로가기)는 `staleTime` 5분 안에 끝나 그대로 재요청이
없다. 홈·탐색·챌린지 리스트는 이미 `FRESH_ON_RETURN`(`refetchOnMount: true`)
을 쓰고 있어 변경 불필요.

> 전역 기본값(`getQueryClient` 의 `refetchOnMount: false`)은 **건드리지 않았다.**
> 상세·폼·작성 화면까지 재요청이 늘어나고, `refetchPolicy.ts` 가 문서화한
> 설계("다른 쿼리는 전역 기본값을 그대로 따른다")와 어긋난다.

## 변경 범위

| 파일 | 변경 |
|---|---|
| `src/app.lib/queryPersist.ts` | `truncateInfinitePages` 추가, persister 를 감싸 쓰기 시 적용 |
| `src/app.module/providers/QueryClientProvider.tsx` | `shouldDehydrateQuery` 의 infinite 제외 조건 삭제 |
| `src/app.feature/diary/board/hooks/useDiaryQueries.ts` | `useDiaryList` `refetchOnMount` false → true |
| `src/app.lib/queryPersist.test.ts` | 신규 — truncate 5케이스 |

스토리지(localStorage) · maxAge(24h) · buster · 로그아웃 purge 는 현행 유지.

## 검증

- `pnpm vitest run` — 25 파일 / 209 테스트 통과 (신규 5 포함)
- `pnpm lint` — 0 errors (변경 파일 지적 없음)
- `pnpm exec tsc --noEmit` — 통과
- `pnpm build` — 통과

브라우저 실제 동작은 확인하지 않았다(정적 검증까지만). dev 배포 후 확인 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Diary lists now refresh more reliably when returning to a screen or focusing the app, while still using fresh cached data when available.
  - Restored infinite-scroll lists now retain their initial page and continue loading additional content as needed.
  - Query persistence is handled more safely, preserving regular cached data and avoiding unnecessary storage growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->