### PR TITLE
feat(challenge): 챌린지 나가기에 확인 다이얼로그 추가

### DIFF
--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -8,6 +8,7 @@ import { ChallengeDetailSkeleton } from '@component/skeletons/ChallengeDetailSke
 import { getCategoryLabel } from '@constants/categories';
 import { formatChallengeTypeLabel } from '@feature/challenge/shared/utils/challengeDisplay';
 import { resolveSidebarMemberId } from '@feature/diary/detail/utils/diaryViewData';
+import { ConfirmDialog } from '@feature/member/settings/components/ConfirmDialog';
 import { getApiErrorCode, normalizeApiError } from '@module/api/error';
 import { notifyApiError } from '@module/api/errorNotify';
 import { useNativeCapability } from '@module/hooks/useNativeCapability';
@@ -200,6 +201,8 @@ export function ChallengeDetailScreen({
   const [passwordNeedsGoals, setPasswordNeedsGoals] = useState(false);
   // 비로그인 사용자가 로그인 필요 액션(참여·좋아요 등)을 누르면 로그인 유도.
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
+  // 챌린지 나가기는 되돌릴 수 없어(LEAVE 상태는 재참여 불가) 확인을 받는다.
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
 
   // 로그인 필요 액션 게이트. 비로그인이면 로그인 유도 다이얼로그를 띄우고
   // false 를 반환한다(호출부는 즉시 return).
@@ -359,12 +362,29 @@ export function ChallengeDetailScreen({
     );
   };
 
+  // 재참여 불가는 확정 사실이다 — 탈퇴하면 myStatus 가 LEAVE 가 되는데
+  // canJoinByStatus 는 NONE/REJECTED 만 허용한다(위 참여 게이트 참고).
+  const leaveConfirmDescription = isHost
+    ? [
+        '나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도',
+        '사라져요. 방장이 나가면 남은 챌린지원들의 운영에도 영향이 있어요.',
+        '한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.',
+      ].join(' ')
+    : [
+        '나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도',
+        '사라져요. 한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.',
+      ].join(' ');
+
+  // 확인 다이얼로그의 [나가기] 에서만 호출된다. 버튼 클릭은 다이얼로그를
+  // 열기만 한다 — 오탭으로 즉시 탈퇴되던 동작을 막는다.
   const handleLeaveChallenge = (): void => {
     leaveChallenge.mutate(challengeId, {
       onSuccess: () => {
+        setShowLeaveConfirm(false);
         toast.success('챌린지에서 나갔습니다.');
       },
       onError: (mutationError) => {
+        // 실패면 다이얼로그를 열어 둔 채로 알린다(재시도 가능).
         notifyApiError(mutationError);
       },
     });
@@ -583,6 +603,22 @@ export function ChallengeDetailScreen({
           onOpenChange={setShowCreateUnavailableDialog}
           title="새 일지를 작성할 수 없습니다."
           description="최근 3일 동안 작성 가능한 날짜를 모두 사용했습니다."
+        />
+        <ConfirmDialog
+          open={showLeaveConfirm}
+          onOpenChange={setShowLeaveConfirm}
+          tone="danger"
+          icon="Close"
+          title={
+            isHost ? '방장인 챌린지에서 나갈까요?' : '챌린지에서 나갈까요?'
+          }
+          description={leaveConfirmDescription}
+          confirmLabel="나가기"
+          pendingLabel="나가는 중..."
+          isPending={leaveChallenge.isPending}
+          isDisabled={leaveChallenge.isPending}
+          onCancel={() => setShowLeaveConfirm(false)}
+          onConfirm={handleLeaveChallenge}
         />
 
         {/* 히어로 + 모바일 floating 뒤로가기 — 탭 위에 항상 고정 노출 */}
@@ -907,7 +943,7 @@ export function ChallengeDetailScreen({
               {isParticipating ? (
                 <button
                   type="button"
-                  onClick={handleLeaveChallenge}
+                  onClick={() => setShowLeaveConfirm(true)}
                   disabled={leaveChallenge.isPending}
                   className={cn(
                     'mt-1 self-center text-[12px] text-gray-500',


### PR DESCRIPTION
## 문제

챌린지 상세의 "챌린지 나가기" 버튼이 확인 없이 곧바로
`DELETE /challenges/{id}/participants` 를 호출했다 —
`ChallengeDetailScreen.tsx:910` 의 `onClick={handleLeaveChallenge}`.
오탭 한 번으로 탈퇴가 끝난다.

**되돌릴 수 없다.** 탈퇴하면 `myStatus` 가 `LEAVE` 가 되는데, 참여 게이트
`canJoinByStatus` 는 `NONE`/`REJECTED` 만 허용한다
(`ChallengeDetailScreen.tsx:249`). 즉 **같은 챌린지에 다시 참여할 수 없다.**

## 변경

기존 `ConfirmDialog`(`@feature/member/settings/components/ConfirmDialog`)를
재사용한다 — 설정의 로그아웃·회원탈퇴, 사용자 차단이 쓰는 것과 동일.
새 컴포넌트를 만들지 않았다.

- 버튼 클릭은 다이얼로그를 **열기만** 하고, `[나가기]` 에서만 `mutate` 한다.
- `tone="danger"` → 확인 버튼이 위험색. 취소는 기본 라벨 `취소`.
- 성공 시 다이얼로그를 닫고, **실패 시 열어 둔 채** 토스트로 알려 재시도를
  허용한다.
- 요청 중에는 `ConfirmDialog` 가 닫기 요청을 무시한다(더블탭·바깥탭 방지).
- 네이티브 쉘에서는 이 컴포넌트가 OS 다이얼로그로 위임하므로 앱에서도
  일관된 모습이 된다(웹 다이얼로그가 앱 안에 혼자 뜨지 않음).

### 문구

비방장:
> **챌린지에서 나갈까요?**
> 나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도 사라져요.
> 한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.

방장(`myStatus === 'HOST'`):
> **방장인 챌린지에서 나갈까요?**
> 나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도 사라져요.
> 방장이 나가면 남은 챌린지원들의 운영에도 영향이 있어요.
> 한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.

## ⚠️ 방장 탈퇴 — 서버 동작 확인 필요

`PARTICIPATING_STATUS` 에 `HOST` 가 포함돼 있어
(`challengeLabels.ts:10-14`) **방장에게도 같은 버튼이 노출되고 같은
엔드포인트를 호출한다.** 서버가 이때 위임/삭제/거부 중 무엇을 하는지는 이
레포에서 확인할 수 없다(서버 코드 없음, docs·에러코드에도 언급 없음).

그래서 방장 문구는 **특정 동작을 단정하지 않는 선에서 경고만** 한다.
서버 동작이 확정되면 문구를 그에 맞게 고쳐야 한다. 상용 승격 전 확인 권장.

## 검증

- `pnpm exec tsc --noEmit` 통과
- `pnpm lint` 0 errors
- `pnpm vitest run` 25 파일 / 209 테스트 통과
- `pnpm build` 통과

브라우저 실제 동작은 확인하지 않았다(정적 검증까지만).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when leaving a challenge.
  * Displays an additional warning for challenge hosts.
  * Provides loading and disabled states while the leave request is processing.
  * Keeps the dialog open if leaving fails, allowing users to retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->