### PR TITLE
fix(native): page_ready 유실 수정 — 피처 게이트를 반응형으로 전환

### DIFF
--- a/src/app.module/hooks/useSignalPageReady.test.tsx
+++ b/src/app.module/hooks/useSignalPageReady.test.tsx
@@ -1,0 +1,92 @@
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSignalPageReady } from './useSignalPageReady';
+
+// 핸드셰이크(`__1D1S_FEATURES__`) 주입 시점을 테스트가 직접 통제한다.
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  skeletonAvailable: { value: false },
+}));
+
+vi.mock('@module/utils/nativeBridge', () => ({
+  isNativeSkeletonAvailable: (): boolean => mocks.skeletonAvailable.value,
+  sendNativePageReady: mocks.send,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: (): string => '/challenge',
+}));
+
+function Probe({ ready }: { ready: boolean }): null {
+  useSignalPageReady('challenge_board', ready);
+  return null;
+}
+
+/** 앱이 핸드셰이크를 주입하는 순간(플래그 세팅 + native:ready 발화). */
+function injectHandshake(): void {
+  act(() => {
+    mocks.skeletonAvailable.value = true;
+    window.dispatchEvent(new Event('native:ready'));
+  });
+}
+
+beforeEach(() => {
+  mocks.send.mockClear();
+  mocks.skeletonAvailable.value = false;
+  // double rAF 를 동기 실행해 emit 을 즉시 관측한다.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+    cb(0);
+    return 0;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useSignalPageReady', () => {
+  it('핸드셰이크가 이미 끝났으면 즉시 emit 한다', () => {
+    mocks.skeletonAvailable.value = true;
+
+    render(<Probe ready />);
+
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    expect(mocks.send).toHaveBeenCalledWith('challenge_board', '/challenge');
+  });
+
+  it('핸드셰이크 전에는 emit 하지 않는다', () => {
+    render(<Probe ready />);
+
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+
+  it('ready 가 첫 렌더부터 true 여도 늦게 온 핸드셰이크에 재시도한다', () => {
+    // 회귀 방지 본체: 예전 구현은 effect 가 플래그 주입 전에 한 번 돌고
+    // 끝나 page_ready 가 영구 유실됐다(앱 스켈레톤 12초 유지).
+    render(<Probe ready />);
+    expect(mocks.send).not.toHaveBeenCalled();
+
+    injectHandshake();
+
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    expect(mocks.send).toHaveBeenCalledWith('challenge_board', '/challenge');
+  });
+
+  it('핸드셰이크가 여러 번 와도 route 당 1회만 emit 한다', () => {
+    render(<Probe ready />);
+    injectHandshake();
+    injectHandshake();
+
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('ready 가 false 면 핸드셰이크가 와도 emit 하지 않는다', () => {
+    render(<Probe ready={false} />);
+    injectHandshake();
+
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/app.module/hooks/useSignalPageReady.ts
+++ b/src/app.module/hooks/useSignalPageReady.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useNativeCapability } from '@module/hooks/useNativeCapability';
 import {
   isNativeSkeletonAvailable,
   sendNativePageReady,
@@ -19,18 +20,31 @@ import { useEffect, useRef } from 'react';
  * - native_skeleton 피처를 announce 한 앱에서만 emit(브라우저·구버전은 no-op).
  *   Rules of Hooks — 조건부 early return 위에서 호출할 것.
  *
+ * 피처 게이트는 반드시 **반응형**이어야 한다(useNativeCapability). 예전엔
+ * effect 안에서 isNativeSkeletonAvailable() 를 직접 호출했는데, 앱은
+ * 핸드셰이크를 onPageFinished 에서 주입하므로 `__1D1S_FEATURES__` 가
+ * 하이드레이션보다 늦게 채워질 수 있다. ready 가 첫 렌더부터 true 인 화면
+ * (RQ persist 캐시가 즉시 히트하는 challenge_board 등)은 effect 가 플래그
+ * 주입 **전에** 한 번 돌고 게이트에 걸려 끝났고, deps 가 그대로라 재시도도
+ * 없어 page_ready 가 영구 유실됐다 — 앱 스켈레톤이 12초 상한까지 안 걷혔다.
+ * useNativeCapability 는 `native:ready` 를 구독하므로 플래그가 늦게 와도
+ * false→true 로 리렌더가 걸리고, deps 에 들어간 이 값이 바뀌면서 effect 가
+ * 다시 돌아 emit 한다(주입 순서와 무관).
+ *
  * @param screenId 계약상 화면 식별자(예: 'diary_detail').
  * @param ready 화면 핵심 콘텐츠가 렌더됐는지(스켈레톤 종료 플래그).
  */
 export function useSignalPageReady(screenId: string, ready: boolean): void {
   const pathname = usePathname();
   const signaledRouteRef = useRef<string | null>(null);
+  const nativeSkeleton = useNativeCapability(isNativeSkeletonAvailable);
 
   useEffect(() => {
     if (!ready || signaledRouteRef.current === pathname) {
       return;
     }
-    if (!isNativeSkeletonAvailable()) {
+    if (!nativeSkeleton) {
+      // 아직 핸드셰이크 전. 플래그가 도착하면 이 effect 가 다시 돈다.
       return;
     }
     signaledRouteRef.current = pathname;
@@ -48,5 +62,5 @@ export function useSignalPageReady(screenId: string, ready: boolean): void {
       cancelAnimationFrame(outer);
       cancelAnimationFrame(inner);
     };
-  }, [ready, pathname, screenId]);
+  }, [ready, nativeSkeleton, pathname, screenId]);
 }


### PR DESCRIPTION
## 문제

앱 백그라운드 장기 복귀 시 challenge 탭의 네이티브 스켈레톤이 12초 상한까지
걷히지 않는다. `page_ready` 가 **아예 나가지 않기** 때문이다.

## 레이스

앱은 핸드셰이크를 `onPageFinished` 에서 주입하므로
`__1D1S_FEATURES__.native_skeleton` 이 하이드레이션보다 늦게 채워질 수 있다.

`useSignalPageReady` 는 effect 안에서 `isNativeSkeletonAvailable()` 를
**명령형**으로 호출했다 (`useSignalPageReady.ts:33`). 그런데 `ready` 가 첫
렌더부터 true 인 화면 — RQ persist 캐시가 즉시 히트하는 `challenge_board`
(`ready = !isLoading`, `ChallengeBoardScreen.tsx:227`) — 은 effect 가 플래그
주입 **전에** 한 번 돌고 게이트에 걸려 끝난다.

deps 가 `[ready, pathname, screenId]` 뿐이라 플래그가 나중에 도착해도 이
effect 는 다시 돌지 않는다 → **영구 침묵**.

## 수정

게이트를 `useNativeCapability(isNativeSkeletonAvailable)` 로 바꾼다.

```diff
+ const nativeSkeleton = useNativeCapability(isNativeSkeletonAvailable);

  useEffect(() => {
    if (!ready || signaledRouteRef.current === pathname) return;
-   if (!isNativeSkeletonAvailable()) return;
+   if (!nativeSkeleton) return;
    ...
- }, [ready, pathname, screenId]);
+ }, [ready, nativeSkeleton, pathname, screenId]);
```

`useNativeCapability` 는 `useSyncExternalStore` 로 **`native:ready` 이벤트를
구독**한다. 플래그가 늦게 와도 스냅샷이 false→true 로 바뀌어 리렌더되고,
deps 에 들어간 이 값이 바뀌면서 effect 가 다시 돌아 emit 한다.
**주입 순서와 무관**해진다.

### 이벤트 방식 확인 결과 — 폴링 불필요

브릿지에 이미 `native:ready` 계약이 있다. 앱(Flutter)이 핸드셰이크 주입 시
`window` 로 발화하고, 웹은 구독만 한다. 이미 `useIsNativeApp` ·
`useNativeCapability` · `useNativeSubmitBar`(form_cta) ·
`useNativeVoteFab`(vote_fab) · `VoteFloatingScreen`(vote_native) 이 전부 이
패턴을 쓴다. **새 폴링·새 구독 코드를 만들지 않았다.**

`isNativeSkeletonAvailable` 을 명령형으로 쓰던 곳은 이 훅 하나뿐이었다 —
`DiaryDetailScreen:418` · `ChallengeDetailScreen:159` 는 이미
`useNativeCapability` 를 쓰고 있었다.

## 적용 범위

이 훅을 쓰는 **18개 화면 전부**에 공통 적용된다 (challenge_board,
diary_board, mypage, notification, statistics, friend_*, member_*,
*_detail, signup, explore …). 중복 emit 은 기존 `signaledRouteRef`(route 당
1회)가 그대로 막는다.

## 검증

신규 회귀 테스트 `useSignalPageReady.test.tsx` 5케이스. **구현을 되돌리면 2건이
실제로 실패**하는 것까지 확인했다(테스트가 이 레이스를 정확히 재현):

- `ready` 가 첫 렌더부터 true 여도 늦게 온 핸드셰이크에 재시도한다 ← 본체
- 핸드셰이크가 여러 번 와도 route 당 1회만 emit 한다
- 핸드셰이크가 이미 끝났으면 즉시 emit / 전에는 emit 안 함 / `ready=false` 면 emit 안 함

`pnpm vitest run` 26 파일 · 214 테스트 통과 · `lint` 0 errors ·
`tsc --noEmit` · `pnpm build` 통과.

브라우저·앱 실제 동작은 확인하지 않았다(정적 검증 + 단위 테스트까지만).