### PR TITLE
fix(challenge): 나가기 다이얼로그 문구 확정 — 방장 위임/삭제 통합 경고

### DIFF
--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -364,10 +364,20 @@ export function ChallengeDetailScreen({
 
   // 재참여 불가는 확정 사실이다 — 탈퇴하면 myStatus 가 LEAVE 가 되는데
   // canJoinByStatus 는 NONE/REJECTED 만 허용한다(위 참여 게이트 참고).
+  //
+  // 방장 문구는 위임/삭제를 **분기하지 않고 통합 경고**로 간다. 서버
+  // (ChallengeService)는 방장 탈퇴 시 남은 후보가 있으면 transferHost,
+  // 없으면 챌린지 softDelete 인데, 그 갈림길을 클라가 신뢰성 있게 판정할 수
+  // 없다: summary.participantCnt 를 주는 useChallengeDetail 은 전역 기본값
+  // (staleTime 5분, refetchOnMount false)이라 재검증 없이 렌더되고, RQ
+  // persist 대상이라 최대 24시간 전 스냅샷이 복원될 수 있다. 그 값으로
+  // 분기하면 실제로는 삭제되는데 "권한이 넘어가요" 라고 안내하게 된다.
+  // 서버의 "후보" 기준(PENDING/LEAVE 포함 여부)도 클라 계약에 없다.
   const leaveConfirmDescription = isHost
     ? [
         '나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도',
-        '사라져요. 방장이 나가면 남은 챌린지원들의 운영에도 영향이 있어요.',
+        '사라져요. 방장이 나가면 방장 권한이 다음 참여자에게 넘어가고,',
+        '남은 참여자가 없으면 챌린지가 삭제돼요.',
         '한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.',
       ].join(' ')
     : [
@@ -604,14 +614,14 @@ export function ChallengeDetailScreen({
           title="새 일지를 작성할 수 없습니다."
           description="최근 3일 동안 작성 가능한 날짜를 모두 사용했습니다."
         />
+        {/* 제목은 방장/참여자 공통 — 방장 분기는 본문이 담당한다. 제목에
+            위임·삭제를 넣으면 둘 중 하나를 단정하게 된다. */}
         <ConfirmDialog
           open={showLeaveConfirm}
           onOpenChange={setShowLeaveConfirm}
           tone="danger"
           icon="Close"
-          title={
-            isHost ? '방장인 챌린지에서 나갈까요?' : '챌린지에서 나갈까요?'
-          }
+          title="정말 나가시겠어요?"
           description={leaveConfirmDescription}
           confirmLabel="나가기"
           pendingLabel="나가는 중..."


### PR DESCRIPTION
## 서버 동작 (확인됨)

`ChallengeService` 기준:

| 상황 | 서버 처리 |
|---|---|
| 방장 탈퇴 + 남은 후보 있음 | 다음 참여자에게 `transferHost` |
| 방장 탈퇴 + 후보 없음(마지막 1명) | 챌린지 `softDelete` |
| 일반 참여자 탈퇴 | 그냥 나가기 |

## 결정: 케이스별 분기 대신 **통합 경고**

위임/삭제 갈림길을 클라가 신뢰성 있게 판정할 수 없다.

`summary.participantCnt` 를 주는 `useChallengeDetail`
(`useChallengeQueries.ts:50-58`)은 `FRESH_ON_RETURN` 없이 **전역 기본값**을
쓴다 — `staleTime` 5분, **`refetchOnMount: false`**,
`refetchOnWindowFocus: false`. 마운트 시 재검증이 아예 없다.

게다가 `meta.noPersist` 가 없어 **RQ persist 대상**이다. #263 이후
localStorage 에 최대 24시간 영속되므로, **24시간 전 스냅샷이 복원된 채
재검증 없이** 렌더될 수 있다.

이 값으로 분기하면 → 실제로는 챌린지가 삭제되는데 화면에는 "방장 권한이 다음
참여자에게 넘어가요" 라고 뜬다. 되돌릴 수 없는 액션에서 가장 나쁜 오안내다.
서버의 "후보" 판정 기준(PENDING/LEAVE 포함 여부)도 클라 계약에 없다.

통합 경고는 두 결과를 **모두** 알려주므로 어느 쪽으로 가든 틀리지 않는다.

## 확정 문구

**일반 참여자**
> **정말 나가시겠어요?**
> 나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도 사라져요.
> 한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.

**방장** (`myStatus === 'HOST'`)
> **정말 나가시겠어요?**
> 나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도 사라져요.
> **방장이 나가면 방장 권한이 다음 참여자에게 넘어가고, 남은 참여자가 없으면
> 챌린지가 삭제돼요.**
> 한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.

버튼: `[취소]` / `[나가기]`(위험색) — 양쪽 공통.

### 제목·버튼을 공통으로 둔 이유

- **제목**: 방장/참여자 모두 "정말 나가시겠어요?". 제목에 "위임" 이나 "삭제"
  를 넣으면 둘 중 하나를 단정하게 된다. 분기는 본문이 담당한다.
- **확인 버튼**: "나가기" 유지. "삭제" 로 바꾸면 위임 케이스에서 틀린다.

## 후속 제안 (이 PR 범위 밖)

케이스별 문구를 정말 원하면 서버가 상세 응답에 `willDeleteOnHostLeave`
같은 **판정 결과 자체**를 내려주는 게 맞다. 클라가 참여자 수로 역산하는 방식은
캐시 신선도와 후보 기준 정의에 계속 의존해 깨지기 쉽다.

## 검증

- `pnpm exec tsc --noEmit` 통과
- `pnpm lint` 0 errors
- `pnpm vitest run` 26 파일 / 214 테스트 통과
- `pnpm build` 통과

브라우저 실제 동작은 확인하지 않았다(정적 검증까지만).