### PR TITLE
feat(notification): 상세 진입 시 엔티티 단위 읽음 처리

### DIFF
--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -9,6 +9,7 @@ import { getCategoryLabel } from '@constants/categories';
 import { formatChallengeTypeLabel } from '@feature/challenge/shared/utils/challengeDisplay';
 import { resolveSidebarMemberId } from '@feature/diary/detail/utils/diaryViewData';
 import { ConfirmDialog } from '@feature/member/settings/components/ConfirmDialog';
+import { useMarkDetailAsRead } from '@feature/notification/hooks/useMarkDetailAsRead';
 import { getApiErrorCode, normalizeApiError } from '@module/api/error';
 import { notifyApiError } from '@module/api/errorNotify';
 import { useNativeCapability } from '@module/hooks/useNativeCapability';
@@ -154,6 +155,9 @@ export function ChallengeDetailScreen({
   const { data, isLoading, isError, error } = useChallengeDetail(challengeId);
   const showSkeleton = useMinimumLoading(isLoading);
   useSignalPageReady('challenge_detail', !showSkeleton && Boolean(data));
+  // 상세 진입 = 이 챌린지 관련 알림 읽음. 목록·딥링크·푸시 어느 경로로
+  // 들어와도 걸리도록 로딩 여부와 무관하게 진입 시점에 건다.
+  useMarkDetailAsRead('CHALLENGE_DETAIL', challengeId);
   // 앱 native_skeleton 중엔 웹 스켈레톤을 그리지 않는다(이중 방지) — 네이티브가
   // 덮고, page_ready 로 콘텐츠 준비를 알려 걷게 한다.
   const nativeSkeleton = useNativeCapability(isNativeSkeletonAvailable);

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -3,6 +3,7 @@
 import { Button, MobileHeader, Text } from '@1d1s/design-system';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import { DiaryDetailSkeleton } from '@component/skeletons/DiaryDetailSkeleton';
+import { useMarkDetailAsRead } from '@feature/notification/hooks/useMarkDetailAsRead';
 import { normalizeApiError } from '@module/api/error';
 import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { useNativeCapability } from '@module/hooks/useNativeCapability';
@@ -412,6 +413,9 @@ export function DiaryDetailScreen({
   });
   const showSkeleton = useMinimumLoading(isLoading);
   useSignalPageReady('diary_detail', !showSkeleton && Boolean(data));
+  // 상세 진입 = 이 일지 관련 알림(댓글·좋아요 등) 읽음. 목록·딥링크·푸시
+  // 어느 경로로 들어와도 걸리도록 로딩 여부와 무관하게 진입 시점에 건다.
+  useMarkDetailAsRead('DIARY_DETAIL', safeDiaryId);
   // 앱이 native_skeleton 을 그리는 동안 웹 스켈레톤을 또 그리면 이중이 된다.
   // 이 경우 로딩 중엔 아무것도 렌더하지 않고(네이티브가 덮음) page_ready 로
   // 콘텐츠 준비를 알려 네이티브 스켈레톤을 걷게 한다.

--- a/src/app.feature/notification/api/notificationApi.ts
+++ b/src/app.feature/notification/api/notificationApi.ts
@@ -2,6 +2,7 @@ import { apiClient, silentAuthClient } from '@module/api/client';
 import { requestData } from '@module/api/request';
 
 import {
+  MarkTargetAsReadParams,
   NotificationEndpoint,
   NotificationListData,
   NotificationListParams,
@@ -72,6 +73,19 @@ export const notificationApi = {
   markAsRead: async (notificationId: number): Promise<void> => {
     await apiClient.patch(`/notifications/${notificationId}/read`);
   },
+
+  // 엔티티 단위 읽음 처리(상세 진입 트리거). 바디 없이 쿼리스트링만 보낸다.
+  // 멱등이라 진입마다 호출해도 되고, 0건이어도 200 이다. 응답 data 는 처리
+  // 후 남은 **전체** 미읽음 수라 헤더 뱃지에 그대로 넣을 수 있다.
+  markTargetAsRead: async ({
+    targetType,
+    targetId,
+  }: MarkTargetAsReadParams): Promise<UnreadCount> =>
+    requestData<UnreadCount>(apiClient, {
+      url: '/notifications/read',
+      method: 'PATCH',
+      params: { targetType, targetId },
+    }),
 
   markAllAsRead: async (): Promise<void> => {
     await apiClient.patch('/notifications/read-all');

--- a/src/app.feature/notification/hooks/useMarkDetailAsRead.test.tsx
+++ b/src/app.feature/notification/hooks/useMarkDetailAsRead.test.tsx
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useMarkDetailAsRead } from './useMarkDetailAsRead';
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  loggedIn: { value: true },
+}));
+
+vi.mock('./useNotificationMutations', () => ({
+  useMarkTargetAsRead: () => ({ mutate: mocks.mutate }),
+}));
+
+vi.mock('@feature/member/hooks/useIsLoggedIn', () => ({
+  useIsLoggedIn: (): boolean => mocks.loggedIn.value,
+}));
+
+function Probe({
+  targetId,
+  enabled = true,
+}: {
+  targetId: number;
+  enabled?: boolean;
+}): null {
+  useMarkDetailAsRead('CHALLENGE_DETAIL', targetId, enabled);
+  return null;
+}
+
+beforeEach(() => {
+  mocks.mutate.mockClear();
+  mocks.loggedIn.value = true;
+});
+
+describe('useMarkDetailAsRead', () => {
+  it('마운트 시 1회 호출한다', () => {
+    render(<Probe targetId={7} />);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      targetType: 'CHALLENGE_DETAIL',
+      targetId: 7,
+    });
+  });
+
+  it('리렌더로는 다시 호출하지 않는다', () => {
+    const { rerender } = render(<Probe targetId={7} />);
+    rerender(<Probe targetId={7} />);
+    rerender(<Probe targetId={7} />);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('targetId 가 바뀌면 새로 호출한다', () => {
+    const { rerender } = render(<Probe targetId={7} />);
+    rerender(<Probe targetId={8} />);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(2);
+    expect(mocks.mutate).toHaveBeenLastCalledWith({
+      targetType: 'CHALLENGE_DETAIL',
+      targetId: 8,
+    });
+  });
+
+  it('비로그인이면 호출하지 않는다', () => {
+    mocks.loggedIn.value = false;
+
+    render(<Probe targetId={7} />);
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it('로그인이 늦게 확정되면 그때 호출한다', () => {
+    // 부팅 프로브(authStatus unknown → authenticated) 경로.
+    mocks.loggedIn.value = false;
+    const { rerender } = render(<Probe targetId={7} />);
+    expect(mocks.mutate).not.toHaveBeenCalled();
+
+    mocks.loggedIn.value = true;
+    rerender(<Probe targetId={7} />);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('유효하지 않은 id 는 건너뛴다', () => {
+    render(<Probe targetId={0} />);
+    render(<Probe targetId={Number.NaN} />);
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it('enabled=false 면 호출하지 않는다', () => {
+    render(<Probe targetId={7} enabled={false} />);
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app.feature/notification/hooks/useMarkDetailAsRead.ts
+++ b/src/app.feature/notification/hooks/useMarkDetailAsRead.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { useEffect, useRef } from 'react';
+
+import type { NotificationReadTargetType } from '../type/notification';
+import { useMarkTargetAsRead } from './useNotificationMutations';
+
+/**
+ * 상세 화면 진입 시 그 엔티티에 걸린 알림을 읽음 처리한다.
+ *
+ * 리스트·딥링크·알림·푸시 등 **어떤 경로로 들어오든** 트리거되도록 상세
+ * 화면의 진입 지점(훅)에 둔다. 알림 목록에서 항목을 눌러 들어오는 경로만
+ * 처리하면 푸시·딥링크 진입에서 뱃지가 안 줄어든다.
+ *
+ * - 마운트 1회 + targetId 변경 시 1회. 리렌더로는 재호출하지 않는다.
+ * - 비로그인/확인 중(authStatus !== 'authenticated')이면 호출하지 않는다.
+ *   로그인이 부팅 프로브로 늦게 확정돼도 값이 바뀌면 그때 한 번 발화한다.
+ * - 실패는 무시한다(useMarkTargetAsRead 가 전역 토스트도 끈다).
+ *
+ * 데이터 페칭이 아니라 진입 시점의 side effect 라 useMutation + effect 조합을
+ * 쓴다(아키텍처 불변량의 "useEffect 로 페칭 금지" 는 useQuery 계열 이야기).
+ */
+export function useMarkDetailAsRead(
+  targetType: NotificationReadTargetType,
+  targetId: number,
+  enabled = true
+): void {
+  const isLoggedIn = useIsLoggedIn();
+  const { mutate } = useMarkTargetAsRead();
+  // 이미 처리한 대상. 같은 상세에서 리렌더가 나도 다시 쏘지 않는다.
+  const markedRef = useRef<string | null>(null);
+
+  const shouldMark =
+    enabled && isLoggedIn && Number.isFinite(targetId) && targetId > 0;
+  const target = `${targetType}:${targetId}`;
+
+  useEffect(() => {
+    if (!shouldMark || markedRef.current === target) {
+      return;
+    }
+    markedRef.current = target;
+    mutate({ targetType, targetId });
+  }, [shouldMark, target, targetType, targetId, mutate]);
+}

--- a/src/app.feature/notification/hooks/useNotificationMutations.ts
+++ b/src/app.feature/notification/hooks/useNotificationMutations.ts
@@ -9,6 +9,7 @@ import {
 import { notificationApi } from '../api/notificationApi';
 import { NOTIFICATION_QUERY_KEYS } from '../consts/queryKeys';
 import {
+  MarkTargetAsReadParams,
   NotificationEndpoint,
   NotificationListData,
   NotificationPreferences,
@@ -155,5 +156,42 @@ export function useRegisterEndpoint(): UseMutationResult<
   return useMutation({
     mutationFn: (data: WebPushEndpointRequest) =>
       notificationApi.registerEndpoint(data),
+  });
+}
+
+/**
+ * 엔티티 단위 읽음 처리(상세 진입). 응답이 처리 후 남은 **전체** 미읽음
+ * 수라, 헤더 뱃지 쿼리에 그대로 써넣고 목록은 무효화한다.
+ *
+ * 낙관적 갱신을 하지 않는다 — 이 상세에 걸린 알림이 몇 건인지 클라가 알 수
+ * 없어 미리 뺄 수가 없다. 서버가 정확한 수를 돌려주므로 응답으로 덮는다.
+ *
+ * 읽음 처리는 부가기능이라 실패해도 조용히 넘어간다(skipGlobalErrorToast).
+ * 상세 화면 표시를 막지 않는 게 우선이다.
+ */
+export function useMarkTargetAsRead(): UseMutationResult<
+  UnreadCount,
+  Error,
+  MarkTargetAsReadParams
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: MarkTargetAsReadParams) =>
+      notificationApi.markTargetAsRead(params),
+    meta: { skipGlobalErrorToast: true },
+    onSuccess: (data) => {
+      if (data) {
+        queryClient.setQueryData<UnreadCount>(
+          NOTIFICATION_QUERY_KEYS.unreadCount(),
+          data
+        );
+      }
+      // 목록을 열면 읽음이 반영돼 보이도록. 뱃지와 달리 목록은 서버가 준
+      // 카운트로 대체할 수 없어 무효화로 다시 받는다.
+      void queryClient.invalidateQueries({
+        queryKey: NOTIFICATION_QUERY_KEYS.lists(),
+      });
+    },
   });
 }

--- a/src/app.feature/notification/type/notification.ts
+++ b/src/app.feature/notification/type/notification.ts
@@ -73,3 +73,16 @@ export interface WebPushEndpointRequest {
 export interface UnreadCount {
   unreadCount: number;
 }
+
+/**
+ * 엔티티 단위 읽음 처리 대상.
+ *
+ * 웹은 상세 화면 두 곳만 보낸다. 서버가 형제 타입(CHALLENGE_LIST,
+ * DIARY_COMMENT 등)까지 알아서 확장 처리하므로 클라가 나열하지 않는다.
+ */
+export type NotificationReadTargetType = 'CHALLENGE_DETAIL' | 'DIARY_DETAIL';
+
+export interface MarkTargetAsReadParams {
+  targetType: NotificationReadTargetType;
+  targetId: number;
+}


### PR DESCRIPTION
## 계약

```
PATCH /notifications/read?targetType={enum}&targetId={long}   (바디 없음)
→ { message, data: { unreadCount } }   // 처리 후 남은 **전체** 미읽음 수
```

| 진입 | targetType | targetId |
|---|---|---|
| 챌린지 상세 | `CHALLENGE_DETAIL` | `challengeId` |
| 일지 상세 | `DIARY_DETAIL` | `diaryId` |

형제 타입(`CHALLENGE_LIST`/`DIARY_COMMENT`)은 서버가 확장 처리하므로 클라
enum 에 나열하지 않았다.

## 트리거 위치 — 클릭 핸들러가 아니라 상세 화면 진입 지점

| 파일 | 위치 |
|---|---|
| `ChallengeDetailScreen.tsx:158` | `useMarkDetailAsRead('CHALLENGE_DETAIL', challengeId)` |
| `DiaryDetailScreen.tsx:415` | `useMarkDetailAsRead('DIARY_DETAIL', safeDiaryId)` |

둘 다 `useSignalPageReady` 바로 아래, **조건부 early return 위**에 뒀다
(Rules of Hooks).

알림 목록의 클릭 핸들러에 붙이지 않은 이유: 목록·딥링크·**푸시**·외부 링크
어느 경로로 들어와도 걸려야 한다. 클릭 경로만 처리하면 푸시로 바로 들어온
사용자는 뱃지가 그대로 남는다.

로딩 여부와 무관하게 진입 시점에 건다 — 상세 응답이 늦어도 읽음은 처리된다.

## 중복 호출 방지

`useMarkDetailAsRead` 가 `markedRef` 로 `targetType:targetId` 를 기억한다.

- 마운트 1회 + `targetId` 변경 시 1회
- 리렌더로는 재호출 안 함
- 비로그인/확인 중(`useIsLoggedIn()` = `authStatus === 'authenticated'`)이면 스킵.
  부팅 프로브로 로그인이 **늦게 확정되면 그때 한 번** 발화한다(반응형 훅).
- `targetId` 가 0/NaN 이면 스킵

## 뱃지 갱신 방식

```ts
onSuccess: (data) => {
  queryClient.setQueryData(NOTIFICATION_QUERY_KEYS.unreadCount(), data);
  void queryClient.invalidateQueries({ queryKey: NOTIFICATION_QUERY_KEYS.lists() });
}
```

- **뱃지(unread-count)**: 응답으로 **덮어쓴다**. 이 상세에 걸린 알림이 몇
  건인지 클라가 알 수 없어 낙관적 감산이 불가능한데, 서버가 정확한 잔여
  수를 주므로 그대로 신뢰한다. 헤더 뱃지가 왕복 없이 즉시 반영된다.
- **알림 목록(lists)**: 카운트로 대체할 수 없어 `invalidate` 로 다시 받는다.
  목록을 열면 읽음 상태가 반영돼 보인다.

## 실패 처리

`meta: { skipGlobalErrorToast: true }` — 읽음 처리는 부가기능이라 실패해도
상세 화면 표시를 막지 않는다. `getQueryClient` 의 `mutationCache.onError` 가
이 meta 를 보고 토스트를 건너뛴다(로그아웃 mutation 과 동일한 패턴).

## 검증

신규 테스트 `useMarkDetailAsRead.test.tsx` 7케이스 — 마운트 1회 / 리렌더
재호출 안 함 / `targetId` 변경 시 재호출 / 비로그인 스킵 / **로그인 늦게
확정되면 그때 호출** / 잘못된 id 스킵 / `enabled=false` 스킵.

`pnpm vitest run` 27 파일 · 221 테스트 통과 · `lint` 0 errors ·
`tsc --noEmit` · `pnpm build` 통과.

실제 API 호출은 확인하지 않았다(정적 검증 + 단위 테스트까지만). dev 에서
푸시·딥링크 진입 시 뱃지가 줄어드는지 확인 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications related to a challenge or diary are automatically marked as read when its detail page is opened.
  * Unread notification counts and notification lists update automatically after marking items as read.
* **Bug Fixes**
  * Prevented duplicate notification read actions during page updates.
  * Added handling for authentication, invalid detail IDs, and configurable read behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->