### PR TITLE
release: RQ persist · 챌린지 나가기 확인 · page_ready 방어 · 상세 진입 읽음 처리

### DIFF
--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -8,6 +8,7 @@ import { ChallengeDetailSkeleton } from '@component/skeletons/ChallengeDetailSke
 import { getCategoryLabel } from '@constants/categories';
 import { formatChallengeTypeLabel } from '@feature/challenge/shared/utils/challengeDisplay';
 import { resolveSidebarMemberId } from '@feature/diary/detail/utils/diaryViewData';
+import { ConfirmDialog } from '@feature/member/settings/components/ConfirmDialog';
 import { getApiErrorCode, normalizeApiError } from '@module/api/error';
 import { notifyApiError } from '@module/api/errorNotify';
 import { useNativeCapability } from '@module/hooks/useNativeCapability';
@@ -200,6 +201,8 @@ export function ChallengeDetailScreen({
   const [passwordNeedsGoals, setPasswordNeedsGoals] = useState(false);
   // 비로그인 사용자가 로그인 필요 액션(참여·좋아요 등)을 누르면 로그인 유도.
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
+  // 챌린지 나가기는 되돌릴 수 없어(LEAVE 상태는 재참여 불가) 확인을 받는다.
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
 
   // 로그인 필요 액션 게이트. 비로그인이면 로그인 유도 다이얼로그를 띄우고
   // false 를 반환한다(호출부는 즉시 return).
@@ -359,12 +362,29 @@ export function ChallengeDetailScreen({
     );
   };
 
+  // 재참여 불가는 확정 사실이다 — 탈퇴하면 myStatus 가 LEAVE 가 되는데
+  // canJoinByStatus 는 NONE/REJECTED 만 허용한다(위 참여 게이트 참고).
+  const leaveConfirmDescription = isHost
+    ? [
+        '나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도',
+        '사라져요. 방장이 나가면 남은 챌린지원들의 운영에도 영향이 있어요.',
+        '한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.',
+      ].join(' ')
+    : [
+        '나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도',
+        '사라져요. 한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.',
+      ].join(' ');
+
+  // 확인 다이얼로그의 [나가기] 에서만 호출된다. 버튼 클릭은 다이얼로그를
+  // 열기만 한다 — 오탭으로 즉시 탈퇴되던 동작을 막는다.
   const handleLeaveChallenge = (): void => {
     leaveChallenge.mutate(challengeId, {
       onSuccess: () => {
+        setShowLeaveConfirm(false);
         toast.success('챌린지에서 나갔습니다.');
       },
       onError: (mutationError) => {
+        // 실패면 다이얼로그를 열어 둔 채로 알린다(재시도 가능).
         notifyApiError(mutationError);
       },
     });
@@ -583,6 +603,22 @@ export function ChallengeDetailScreen({
           onOpenChange={setShowCreateUnavailableDialog}
           title="새 일지를 작성할 수 없습니다."
           description="최근 3일 동안 작성 가능한 날짜를 모두 사용했습니다."
+        />
+        <ConfirmDialog
+          open={showLeaveConfirm}
+          onOpenChange={setShowLeaveConfirm}
+          tone="danger"
+          icon="Close"
+          title={
+            isHost ? '방장인 챌린지에서 나갈까요?' : '챌린지에서 나갈까요?'
+          }
+          description={leaveConfirmDescription}
+          confirmLabel="나가기"
+          pendingLabel="나가는 중..."
+          isPending={leaveChallenge.isPending}
+          isDisabled={leaveChallenge.isPending}
+          onCancel={() => setShowLeaveConfirm(false)}
+          onConfirm={handleLeaveChallenge}
         />
 
         {/* 히어로 + 모바일 floating 뒤로가기 — 탭 위에 항상 고정 노출 */}
@@ -907,7 +943,7 @@ export function ChallengeDetailScreen({
               {isParticipating ? (
                 <button
                   type="button"
-                  onClick={handleLeaveChallenge}
+                  onClick={() => setShowLeaveConfirm(true)}
                   disabled={leaveChallenge.isPending}
                   className={cn(
                     'mt-1 self-center text-[12px] text-gray-500',

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -9,6 +9,7 @@ import { getCategoryLabel } from '@constants/categories';
 import { formatChallengeTypeLabel } from '@feature/challenge/shared/utils/challengeDisplay';
 import { resolveSidebarMemberId } from '@feature/diary/detail/utils/diaryViewData';
 import { ConfirmDialog } from '@feature/member/settings/components/ConfirmDialog';
+import { useMarkDetailAsRead } from '@feature/notification/hooks/useMarkDetailAsRead';
 import { getApiErrorCode, normalizeApiError } from '@module/api/error';
 import { notifyApiError } from '@module/api/errorNotify';
 import { useNativeCapability } from '@module/hooks/useNativeCapability';
@@ -154,6 +155,9 @@ export function ChallengeDetailScreen({
   const { data, isLoading, isError, error } = useChallengeDetail(challengeId);
   const showSkeleton = useMinimumLoading(isLoading);
   useSignalPageReady('challenge_detail', !showSkeleton && Boolean(data));
+  // 상세 진입 = 이 챌린지 관련 알림 읽음. 목록·딥링크·푸시 어느 경로로
+  // 들어와도 걸리도록 로딩 여부와 무관하게 진입 시점에 건다.
+  useMarkDetailAsRead('CHALLENGE_DETAIL', challengeId);
   // 앱 native_skeleton 중엔 웹 스켈레톤을 그리지 않는다(이중 방지) — 네이티브가
   // 덮고, page_ready 로 콘텐츠 준비를 알려 걷게 한다.
   const nativeSkeleton = useNativeCapability(isNativeSkeletonAvailable);

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -364,10 +364,20 @@ export function ChallengeDetailScreen({
 
   // 재참여 불가는 확정 사실이다 — 탈퇴하면 myStatus 가 LEAVE 가 되는데
   // canJoinByStatus 는 NONE/REJECTED 만 허용한다(위 참여 게이트 참고).
+  //
+  // 방장 문구는 위임/삭제를 **분기하지 않고 통합 경고**로 간다. 서버
+  // (ChallengeService)는 방장 탈퇴 시 남은 후보가 있으면 transferHost,
+  // 없으면 챌린지 softDelete 인데, 그 갈림길을 클라가 신뢰성 있게 판정할 수
+  // 없다: summary.participantCnt 를 주는 useChallengeDetail 은 전역 기본값
+  // (staleTime 5분, refetchOnMount false)이라 재검증 없이 렌더되고, RQ
+  // persist 대상이라 최대 24시간 전 스냅샷이 복원될 수 있다. 그 값으로
+  // 분기하면 실제로는 삭제되는데 "권한이 넘어가요" 라고 안내하게 된다.
+  // 서버의 "후보" 기준(PENDING/LEAVE 포함 여부)도 클라 계약에 없다.
   const leaveConfirmDescription = isHost
     ? [
         '나가면 참여자 목록에서 빠지고 이 챌린지의 진행률·순위 기록도',
-        '사라져요. 방장이 나가면 남은 챌린지원들의 운영에도 영향이 있어요.',
+        '사라져요. 방장이 나가면 방장 권한이 다음 참여자에게 넘어가고,',
+        '남은 참여자가 없으면 챌린지가 삭제돼요.',
         '한 번 나가면 같은 챌린지에 다시 참여할 수 없어요.',
       ].join(' ')
     : [
@@ -604,14 +614,14 @@ export function ChallengeDetailScreen({
           title="새 일지를 작성할 수 없습니다."
           description="최근 3일 동안 작성 가능한 날짜를 모두 사용했습니다."
         />
+        {/* 제목은 방장/참여자 공통 — 방장 분기는 본문이 담당한다. 제목에
+            위임·삭제를 넣으면 둘 중 하나를 단정하게 된다. */}
         <ConfirmDialog
           open={showLeaveConfirm}
           onOpenChange={setShowLeaveConfirm}
           tone="danger"
           icon="Close"
-          title={
-            isHost ? '방장인 챌린지에서 나갈까요?' : '챌린지에서 나갈까요?'
-          }
+          title="정말 나가시겠어요?"
           description={leaveConfirmDescription}
           confirmLabel="나가기"
           pendingLabel="나가는 중..."

--- a/src/app.feature/diary/board/hooks/useDiaryQueries.ts
+++ b/src/app.feature/diary/board/hooks/useDiaryQueries.ts
@@ -67,13 +67,17 @@ export function useDiaryList(
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) =>
       lastPage.pageInfo.hasNextPage ? lastPage.pageInfo.nextCursor : undefined,
-    // W12: 일지→챌린지→일지 뒤로가기 시 재요청/재로딩을 막는다. remount refetch
-    // 를 끄고 캐시를 그대로 보여준다. 새 일지/수정/삭제는 mutation 이
-    // DIARY_QUERY_KEYS.lists() 를 invalidate 하므로 목록 최신성은 유지된다.
+    // W12: 일지→챌린지→일지 뒤로가기 시 재요청/재로딩을 막는다. 그 왕복은
+    // staleTime(5분) 안에 끝나므로 `refetchOnMount: true` 로도 재요청이 없다
+    // — true 는 "stale 일 때만" 재요청이기 때문이다. false 는 아무리 오래된
+    // 캐시여도 절대 재검증하지 않아, localStorage 에서 복원한 최대 24시간
+    // 전 목록이 invalidate 전까지 그대로 남는 문제가 있었다.
+    // 새 일지/수정/삭제는 mutation 이 DIARY_QUERY_KEYS.lists() 를
+    // invalidate 하므로 목록 최신성은 유지된다.
     // 다른 창/탭에서 돌아오면(window focus) 새로고침한다.
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: 'always',
-    refetchOnMount: false,
+    refetchOnMount: true,
   });
 }
 

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -3,6 +3,7 @@
 import { Button, MobileHeader, Text } from '@1d1s/design-system';
 import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import { DiaryDetailSkeleton } from '@component/skeletons/DiaryDetailSkeleton';
+import { useMarkDetailAsRead } from '@feature/notification/hooks/useMarkDetailAsRead';
 import { normalizeApiError } from '@module/api/error';
 import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { useNativeCapability } from '@module/hooks/useNativeCapability';
@@ -412,6 +413,9 @@ export function DiaryDetailScreen({
   });
   const showSkeleton = useMinimumLoading(isLoading);
   useSignalPageReady('diary_detail', !showSkeleton && Boolean(data));
+  // 상세 진입 = 이 일지 관련 알림(댓글·좋아요 등) 읽음. 목록·딥링크·푸시
+  // 어느 경로로 들어와도 걸리도록 로딩 여부와 무관하게 진입 시점에 건다.
+  useMarkDetailAsRead('DIARY_DETAIL', safeDiaryId);
   // 앱이 native_skeleton 을 그리는 동안 웹 스켈레톤을 또 그리면 이중이 된다.
   // 이 경우 로딩 중엔 아무것도 렌더하지 않고(네이티브가 덮음) page_ready 로
   // 콘텐츠 준비를 알려 네이티브 스켈레톤을 걷게 한다.

--- a/src/app.feature/notification/api/notificationApi.ts
+++ b/src/app.feature/notification/api/notificationApi.ts
@@ -2,6 +2,7 @@ import { apiClient, silentAuthClient } from '@module/api/client';
 import { requestData } from '@module/api/request';
 
 import {
+  MarkTargetAsReadParams,
   NotificationEndpoint,
   NotificationListData,
   NotificationListParams,
@@ -72,6 +73,19 @@ export const notificationApi = {
   markAsRead: async (notificationId: number): Promise<void> => {
     await apiClient.patch(`/notifications/${notificationId}/read`);
   },
+
+  // 엔티티 단위 읽음 처리(상세 진입 트리거). 바디 없이 쿼리스트링만 보낸다.
+  // 멱등이라 진입마다 호출해도 되고, 0건이어도 200 이다. 응답 data 는 처리
+  // 후 남은 **전체** 미읽음 수라 헤더 뱃지에 그대로 넣을 수 있다.
+  markTargetAsRead: async ({
+    targetType,
+    targetId,
+  }: MarkTargetAsReadParams): Promise<UnreadCount> =>
+    requestData<UnreadCount>(apiClient, {
+      url: '/notifications/read',
+      method: 'PATCH',
+      params: { targetType, targetId },
+    }),
 
   markAllAsRead: async (): Promise<void> => {
     await apiClient.patch('/notifications/read-all');

--- a/src/app.feature/notification/hooks/useMarkDetailAsRead.test.tsx
+++ b/src/app.feature/notification/hooks/useMarkDetailAsRead.test.tsx
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useMarkDetailAsRead } from './useMarkDetailAsRead';
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  loggedIn: { value: true },
+}));
+
+vi.mock('./useNotificationMutations', () => ({
+  useMarkTargetAsRead: () => ({ mutate: mocks.mutate }),
+}));
+
+vi.mock('@feature/member/hooks/useIsLoggedIn', () => ({
+  useIsLoggedIn: (): boolean => mocks.loggedIn.value,
+}));
+
+function Probe({
+  targetId,
+  enabled = true,
+}: {
+  targetId: number;
+  enabled?: boolean;
+}): null {
+  useMarkDetailAsRead('CHALLENGE_DETAIL', targetId, enabled);
+  return null;
+}
+
+beforeEach(() => {
+  mocks.mutate.mockClear();
+  mocks.loggedIn.value = true;
+});
+
+describe('useMarkDetailAsRead', () => {
+  it('마운트 시 1회 호출한다', () => {
+    render(<Probe targetId={7} />);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      targetType: 'CHALLENGE_DETAIL',
+      targetId: 7,
+    });
+  });
+
+  it('리렌더로는 다시 호출하지 않는다', () => {
+    const { rerender } = render(<Probe targetId={7} />);
+    rerender(<Probe targetId={7} />);
+    rerender(<Probe targetId={7} />);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('targetId 가 바뀌면 새로 호출한다', () => {
+    const { rerender } = render(<Probe targetId={7} />);
+    rerender(<Probe targetId={8} />);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(2);
+    expect(mocks.mutate).toHaveBeenLastCalledWith({
+      targetType: 'CHALLENGE_DETAIL',
+      targetId: 8,
+    });
+  });
+
+  it('비로그인이면 호출하지 않는다', () => {
+    mocks.loggedIn.value = false;
+
+    render(<Probe targetId={7} />);
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it('로그인이 늦게 확정되면 그때 호출한다', () => {
+    // 부팅 프로브(authStatus unknown → authenticated) 경로.
+    mocks.loggedIn.value = false;
+    const { rerender } = render(<Probe targetId={7} />);
+    expect(mocks.mutate).not.toHaveBeenCalled();
+
+    mocks.loggedIn.value = true;
+    rerender(<Probe targetId={7} />);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('유효하지 않은 id 는 건너뛴다', () => {
+    render(<Probe targetId={0} />);
+    render(<Probe targetId={Number.NaN} />);
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it('enabled=false 면 호출하지 않는다', () => {
+    render(<Probe targetId={7} enabled={false} />);
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app.feature/notification/hooks/useMarkDetailAsRead.ts
+++ b/src/app.feature/notification/hooks/useMarkDetailAsRead.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { useEffect, useRef } from 'react';
+
+import type { NotificationReadTargetType } from '../type/notification';
+import { useMarkTargetAsRead } from './useNotificationMutations';
+
+/**
+ * 상세 화면 진입 시 그 엔티티에 걸린 알림을 읽음 처리한다.
+ *
+ * 리스트·딥링크·알림·푸시 등 **어떤 경로로 들어오든** 트리거되도록 상세
+ * 화면의 진입 지점(훅)에 둔다. 알림 목록에서 항목을 눌러 들어오는 경로만
+ * 처리하면 푸시·딥링크 진입에서 뱃지가 안 줄어든다.
+ *
+ * - 마운트 1회 + targetId 변경 시 1회. 리렌더로는 재호출하지 않는다.
+ * - 비로그인/확인 중(authStatus !== 'authenticated')이면 호출하지 않는다.
+ *   로그인이 부팅 프로브로 늦게 확정돼도 값이 바뀌면 그때 한 번 발화한다.
+ * - 실패는 무시한다(useMarkTargetAsRead 가 전역 토스트도 끈다).
+ *
+ * 데이터 페칭이 아니라 진입 시점의 side effect 라 useMutation + effect 조합을
+ * 쓴다(아키텍처 불변량의 "useEffect 로 페칭 금지" 는 useQuery 계열 이야기).
+ */
+export function useMarkDetailAsRead(
+  targetType: NotificationReadTargetType,
+  targetId: number,
+  enabled = true
+): void {
+  const isLoggedIn = useIsLoggedIn();
+  const { mutate } = useMarkTargetAsRead();
+  // 이미 처리한 대상. 같은 상세에서 리렌더가 나도 다시 쏘지 않는다.
+  const markedRef = useRef<string | null>(null);
+
+  const shouldMark =
+    enabled && isLoggedIn && Number.isFinite(targetId) && targetId > 0;
+  const target = `${targetType}:${targetId}`;
+
+  useEffect(() => {
+    if (!shouldMark || markedRef.current === target) {
+      return;
+    }
+    markedRef.current = target;
+    mutate({ targetType, targetId });
+  }, [shouldMark, target, targetType, targetId, mutate]);
+}

--- a/src/app.feature/notification/hooks/useNotificationMutations.ts
+++ b/src/app.feature/notification/hooks/useNotificationMutations.ts
@@ -9,6 +9,7 @@ import {
 import { notificationApi } from '../api/notificationApi';
 import { NOTIFICATION_QUERY_KEYS } from '../consts/queryKeys';
 import {
+  MarkTargetAsReadParams,
   NotificationEndpoint,
   NotificationListData,
   NotificationPreferences,
@@ -155,5 +156,42 @@ export function useRegisterEndpoint(): UseMutationResult<
   return useMutation({
     mutationFn: (data: WebPushEndpointRequest) =>
       notificationApi.registerEndpoint(data),
+  });
+}
+
+/**
+ * 엔티티 단위 읽음 처리(상세 진입). 응답이 처리 후 남은 **전체** 미읽음
+ * 수라, 헤더 뱃지 쿼리에 그대로 써넣고 목록은 무효화한다.
+ *
+ * 낙관적 갱신을 하지 않는다 — 이 상세에 걸린 알림이 몇 건인지 클라가 알 수
+ * 없어 미리 뺄 수가 없다. 서버가 정확한 수를 돌려주므로 응답으로 덮는다.
+ *
+ * 읽음 처리는 부가기능이라 실패해도 조용히 넘어간다(skipGlobalErrorToast).
+ * 상세 화면 표시를 막지 않는 게 우선이다.
+ */
+export function useMarkTargetAsRead(): UseMutationResult<
+  UnreadCount,
+  Error,
+  MarkTargetAsReadParams
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: MarkTargetAsReadParams) =>
+      notificationApi.markTargetAsRead(params),
+    meta: { skipGlobalErrorToast: true },
+    onSuccess: (data) => {
+      if (data) {
+        queryClient.setQueryData<UnreadCount>(
+          NOTIFICATION_QUERY_KEYS.unreadCount(),
+          data
+        );
+      }
+      // 목록을 열면 읽음이 반영돼 보이도록. 뱃지와 달리 목록은 서버가 준
+      // 카운트로 대체할 수 없어 무효화로 다시 받는다.
+      void queryClient.invalidateQueries({
+        queryKey: NOTIFICATION_QUERY_KEYS.lists(),
+      });
+    },
   });
 }

--- a/src/app.feature/notification/type/notification.ts
+++ b/src/app.feature/notification/type/notification.ts
@@ -73,3 +73,16 @@ export interface WebPushEndpointRequest {
 export interface UnreadCount {
   unreadCount: number;
 }
+
+/**
+ * 엔티티 단위 읽음 처리 대상.
+ *
+ * 웹은 상세 화면 두 곳만 보낸다. 서버가 형제 타입(CHALLENGE_LIST,
+ * DIARY_COMMENT 등)까지 알아서 확장 처리하므로 클라가 나열하지 않는다.
+ */
+export type NotificationReadTargetType = 'CHALLENGE_DETAIL' | 'DIARY_DETAIL';
+
+export interface MarkTargetAsReadParams {
+  targetType: NotificationReadTargetType;
+  targetId: number;
+}

--- a/src/app.lib/queryPersist.test.ts
+++ b/src/app.lib/queryPersist.test.ts
@@ -1,0 +1,94 @@
+import type { PersistedClient } from '@tanstack/react-query-persist-client';
+import { describe, expect, it } from 'vitest';
+
+import { truncateInfinitePages } from './queryPersist';
+
+type DehydratedQuery = PersistedClient['clientState']['queries'][number];
+
+function makeQuery(hash: string, data: unknown): DehydratedQuery {
+  return {
+    queryHash: hash,
+    queryKey: [hash],
+    state: { data, dataUpdateCount: 1, dataUpdatedAt: 0 },
+  } as unknown as DehydratedQuery;
+}
+
+function makeClient(queries: DehydratedQuery[]): PersistedClient {
+  return {
+    timestamp: 0,
+    buster: 'test',
+    clientState: { mutations: [], queries },
+  };
+}
+
+function firstQueryData(client: PersistedClient): unknown {
+  return client.clientState.queries[0]?.state.data;
+}
+
+describe('truncateInfinitePages', () => {
+  it('무한 스크롤 쿼리를 첫 페이지만 남긴다', () => {
+    const client = makeClient([
+      makeQuery('diary-list', {
+        pages: [{ items: ['a'] }, { items: ['b'] }, { items: ['c'] }],
+        pageParams: [undefined, 'cursor-1', 'cursor-2'],
+      }),
+    ]);
+
+    const result = truncateInfinitePages(client);
+
+    expect(firstQueryData(result)).toEqual({
+      pages: [{ items: ['a'] }],
+      pageParams: [undefined],
+    });
+  });
+
+  it('pages 와 pageParams 를 같은 인덱스로 자른다', () => {
+    const client = makeClient([
+      makeQuery('challenge-list', {
+        pages: [{ id: 1 }, { id: 2 }],
+        pageParams: ['p1', 'p2'],
+      }),
+    ]);
+
+    const data = firstQueryData(truncateInfinitePages(client)) as {
+      pages: unknown[];
+      pageParams: unknown[];
+    };
+
+    expect(data.pages).toHaveLength(1);
+    expect(data.pageParams).toHaveLength(1);
+    expect(data.pageParams[0]).toBe('p1');
+  });
+
+  it('일반 useQuery 데이터는 건드리지 않는다', () => {
+    const listData = [{ id: 1 }, { id: 2 }];
+    const client = makeClient([makeQuery('home-random', listData)]);
+
+    expect(firstQueryData(truncateInfinitePages(client))).toBe(listData);
+  });
+
+  it('페이지가 하나뿐이면 원본 쿼리를 그대로 재사용한다', () => {
+    const query = makeQuery('single', {
+      pages: [{ items: [] }],
+      pageParams: [undefined],
+    });
+
+    const result = truncateInfinitePages(makeClient([query]));
+
+    expect(result.clientState.queries[0]).toBe(query);
+  });
+
+  it('원본 캐시 객체를 변형하지 않는다', () => {
+    const data = {
+      pages: [{ id: 1 }, { id: 2 }],
+      pageParams: [undefined, 'c1'],
+    };
+    const client = makeClient([makeQuery('mutation-check', data)]);
+
+    truncateInfinitePages(client);
+
+    // 여기서 잘리면 화면에 떠 있는 목록이 1페이지로 줄어든다.
+    expect(data.pages).toHaveLength(2);
+    expect(data.pageParams).toHaveLength(2);
+  });
+});

--- a/src/app.lib/queryPersist.ts
+++ b/src/app.lib/queryPersist.ts
@@ -1,4 +1,8 @@
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
+import type {
+  PersistedClient,
+  Persister,
+} from '@tanstack/react-query-persist-client';
 
 // React Query 캐시를 localStorage 에 영속한다. 웹뷰가 리로드/재생성돼도(앱)
 // 재fetch 없이 이전 캐시로 즉시 렌더하기 위함(브라우저 세션이 유지하던 이점을
@@ -15,19 +19,79 @@ export const RQ_PERSIST_MAX_AGE = 24 * 60 * 60 * 1000;
 // 모두 새 커밋 → SHA 변경 → 자동 무효화.
 export const RQ_PERSIST_BUSTER = `v1-${process.env.NEXT_PUBLIC_BUILD_ID ?? 'dev'}`;
 
+interface InfinitePages {
+  pages: unknown[];
+  pageParams: unknown[];
+}
+
+function isInfiniteData(data: unknown): data is InfinitePages {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const candidate = data as Partial<InfinitePages>;
+  return Array.isArray(candidate.pages) && Array.isArray(candidate.pageParams);
+}
+
+/**
+ * 영속 대상에서 무한 스크롤 쿼리의 **첫 페이지만** 남긴다.
+ *
+ * 누적 페이지 전체(수백 KB)를 throttle 주기마다 JSON.stringify 로 동기
+ * 기록하면 저사양 기기에서 스크롤 중 프레임이 끊긴다. 그렇다고 통째로
+ * 제외하면(이전 동작) 리스트 탭은 복귀할 때마다 스켈레톤이다. 첫 페이지만
+ * 남기면 쓰기 비용은 일반 쿼리 수준으로 유지하면서 복귀 즉시 첫 화면이
+ * 채워진다 — 어차피 복원 직후 사용자가 보는 것은 첫 페이지뿐이다.
+ *
+ * pages/pageParams 를 **같은 인덱스로** 자르므로 복원 후 getNextPageParam
+ * 은 첫 페이지를 lastPage 로 받아 다음 커서를 정상 계산한다(hasNextPage 도
+ * 첫 페이지의 pageInfo 로 다시 도출된다).
+ *
+ * 살아있는 쿼리 캐시가 참조하는 객체를 그대로 받으므로 **변형하지 않고**
+ * 새 객체로 복사한다 — 여기서 mutate 하면 화면의 목록이 1페이지로 잘린다.
+ */
+export function truncateInfinitePages(
+  client: PersistedClient
+): PersistedClient {
+  return {
+    ...client,
+    clientState: {
+      ...client.clientState,
+      queries: client.clientState.queries.map((query) => {
+        const data = query.state.data;
+        if (!isInfiniteData(data) || data.pages.length <= 1) {
+          return query;
+        }
+        return {
+          ...query,
+          state: {
+            ...query.state,
+            data: {
+              ...data,
+              pages: data.pages.slice(0, 1),
+              pageParams: data.pageParams.slice(0, 1),
+            },
+          },
+        };
+      }),
+    },
+  };
+}
+
 /** 클라이언트에서만 localStorage persister 를 만든다. 서버(SSR)면 null. */
-export function createRqPersister():
-  | ReturnType<typeof createSyncStoragePersister>
-  | null {
+export function createRqPersister(): Persister | null {
   if (typeof window === 'undefined') {
     return null;
   }
-  return createSyncStoragePersister({
+  const persister = createSyncStoragePersister({
     storage: window.localStorage,
     key: RQ_PERSIST_KEY,
     // 캐시 갱신이 몰릴 때 쓰기를 1s 로 합쳐 메인스레드를 보호한다.
     throttleTime: 1000,
   });
+  return {
+    ...persister,
+    persistClient: (client) =>
+      persister.persistClient(truncateInfinitePages(client)),
+  };
 }
 
 /**

--- a/src/app.module/hooks/useSignalPageReady.test.tsx
+++ b/src/app.module/hooks/useSignalPageReady.test.tsx
@@ -1,0 +1,92 @@
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSignalPageReady } from './useSignalPageReady';
+
+// 핸드셰이크(`__1D1S_FEATURES__`) 주입 시점을 테스트가 직접 통제한다.
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  skeletonAvailable: { value: false },
+}));
+
+vi.mock('@module/utils/nativeBridge', () => ({
+  isNativeSkeletonAvailable: (): boolean => mocks.skeletonAvailable.value,
+  sendNativePageReady: mocks.send,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: (): string => '/challenge',
+}));
+
+function Probe({ ready }: { ready: boolean }): null {
+  useSignalPageReady('challenge_board', ready);
+  return null;
+}
+
+/** 앱이 핸드셰이크를 주입하는 순간(플래그 세팅 + native:ready 발화). */
+function injectHandshake(): void {
+  act(() => {
+    mocks.skeletonAvailable.value = true;
+    window.dispatchEvent(new Event('native:ready'));
+  });
+}
+
+beforeEach(() => {
+  mocks.send.mockClear();
+  mocks.skeletonAvailable.value = false;
+  // double rAF 를 동기 실행해 emit 을 즉시 관측한다.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+    cb(0);
+    return 0;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useSignalPageReady', () => {
+  it('핸드셰이크가 이미 끝났으면 즉시 emit 한다', () => {
+    mocks.skeletonAvailable.value = true;
+
+    render(<Probe ready />);
+
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    expect(mocks.send).toHaveBeenCalledWith('challenge_board', '/challenge');
+  });
+
+  it('핸드셰이크 전에는 emit 하지 않는다', () => {
+    render(<Probe ready />);
+
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+
+  it('ready 가 첫 렌더부터 true 여도 늦게 온 핸드셰이크에 재시도한다', () => {
+    // 회귀 방지 본체: 예전 구현은 effect 가 플래그 주입 전에 한 번 돌고
+    // 끝나 page_ready 가 영구 유실됐다(앱 스켈레톤 12초 유지).
+    render(<Probe ready />);
+    expect(mocks.send).not.toHaveBeenCalled();
+
+    injectHandshake();
+
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+    expect(mocks.send).toHaveBeenCalledWith('challenge_board', '/challenge');
+  });
+
+  it('핸드셰이크가 여러 번 와도 route 당 1회만 emit 한다', () => {
+    render(<Probe ready />);
+    injectHandshake();
+    injectHandshake();
+
+    expect(mocks.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('ready 가 false 면 핸드셰이크가 와도 emit 하지 않는다', () => {
+    render(<Probe ready={false} />);
+    injectHandshake();
+
+    expect(mocks.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/app.module/hooks/useSignalPageReady.ts
+++ b/src/app.module/hooks/useSignalPageReady.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useNativeCapability } from '@module/hooks/useNativeCapability';
 import {
   isNativeSkeletonAvailable,
   sendNativePageReady,
@@ -19,18 +20,31 @@ import { useEffect, useRef } from 'react';
  * - native_skeleton 피처를 announce 한 앱에서만 emit(브라우저·구버전은 no-op).
  *   Rules of Hooks — 조건부 early return 위에서 호출할 것.
  *
+ * 피처 게이트는 반드시 **반응형**이어야 한다(useNativeCapability). 예전엔
+ * effect 안에서 isNativeSkeletonAvailable() 를 직접 호출했는데, 앱은
+ * 핸드셰이크를 onPageFinished 에서 주입하므로 `__1D1S_FEATURES__` 가
+ * 하이드레이션보다 늦게 채워질 수 있다. ready 가 첫 렌더부터 true 인 화면
+ * (RQ persist 캐시가 즉시 히트하는 challenge_board 등)은 effect 가 플래그
+ * 주입 **전에** 한 번 돌고 게이트에 걸려 끝났고, deps 가 그대로라 재시도도
+ * 없어 page_ready 가 영구 유실됐다 — 앱 스켈레톤이 12초 상한까지 안 걷혔다.
+ * useNativeCapability 는 `native:ready` 를 구독하므로 플래그가 늦게 와도
+ * false→true 로 리렌더가 걸리고, deps 에 들어간 이 값이 바뀌면서 effect 가
+ * 다시 돌아 emit 한다(주입 순서와 무관).
+ *
  * @param screenId 계약상 화면 식별자(예: 'diary_detail').
  * @param ready 화면 핵심 콘텐츠가 렌더됐는지(스켈레톤 종료 플래그).
  */
 export function useSignalPageReady(screenId: string, ready: boolean): void {
   const pathname = usePathname();
   const signaledRouteRef = useRef<string | null>(null);
+  const nativeSkeleton = useNativeCapability(isNativeSkeletonAvailable);
 
   useEffect(() => {
     if (!ready || signaledRouteRef.current === pathname) {
       return;
     }
-    if (!isNativeSkeletonAvailable()) {
+    if (!nativeSkeleton) {
+      // 아직 핸드셰이크 전. 플래그가 도착하면 이 effect 가 다시 돈다.
       return;
     }
     signaledRouteRef.current = pathname;
@@ -48,5 +62,5 @@ export function useSignalPageReady(screenId: string, ready: boolean): void {
       cancelAnimationFrame(outer);
       cancelAnimationFrame(inner);
     };
-  }, [ready, pathname, screenId]);
+  }, [ready, nativeSkeleton, pathname, screenId]);
 }

--- a/src/app.module/providers/QueryClientProvider.tsx
+++ b/src/app.module/providers/QueryClientProvider.tsx
@@ -47,17 +47,14 @@ export function TanStackQueryProvider({
         buster: RQ_PERSIST_BUSTER,
         dehydrateOptions: {
           // 성공 쿼리만 저장(pending/error 제외) + meta.noPersist 옵트아웃.
-          // 무한 스크롤 쿼리도 제외한다 — 누적 페이지 전체가 1초마다
-          // JSON.stringify 로 localStorage 에 동기 기록되면(수백 KB) 저사양
-          // 기기에서는 스크롤 중 수 프레임짜리 멈춤이 된다. 복원해 봤자
-          // 첫 페이지만 보여주면 되는 데이터라 저장 가치도 낮다.
+          // 무한 스크롤 쿼리도 포함한다 — 예전엔 누적 페이지 전체를 1초마다
+          // JSON.stringify 하는 비용(수백 KB) 때문에 통째로 제외했지만,
+          // 그러면 탐색·일지·챌린지 리스트가 복귀할 때마다 스켈레톤이었다.
+          // 지금은 persister 가 쓰기 직전에 첫 페이지만 남기므로
+          // (truncateInfinitePages) 쓰기 비용은 일반 쿼리 수준이다.
           shouldDehydrateQuery: (query) =>
             defaultShouldDehydrateQuery(query) &&
-            query.meta?.noPersist !== true &&
-            !Array.isArray(
-              (query.state.data as { pageParams?: unknown[] } | undefined)
-                ?.pageParams
-            ),
+            query.meta?.noPersist !== true,
         },
       }}
     >


### PR DESCRIPTION
develop 에 쌓인 4개 작업을 상용으로 승격한다.

## 포함 내용

| # | 내용 | 핵심 |
|---|---|---|
| #263 | RQ persist — 무한 스크롤 목록 첫 페이지 영속화 | 탐색·일지·챌린지 리스트가 복귀 시 스켈레톤 없이 뜬다 |
| #264 + #266 | 챌린지 나가기 확인 다이얼로그 | 오탭 즉시 탈퇴 방지 + 방장 위임/삭제 통합 경고 |
| #265 | `page_ready` 유실 수정 | 앱 복귀 시 네이티브 스켈레톤이 12초까지 안 걷히던 레이스 |
| #267 | 상세 진입 시 엔티티 단위 읽음 처리 | `PATCH /notifications/read` 트리거 + 뱃지 갱신 |

> #266 은 #264 의 후속(문구 확정)이라 같은 기능이다. 그 외 무관한 변경은 없다 —
> 변경 파일 13개 전부 위 4건에 속한다.

## ⚠️ 머지 순서 — 서버 선행 필요

#267 은 서버 상용의 `PATCH /notifications/read` 에 의존한다. **서버 상용 배포
완료를 확인한 뒤 머지**할 것(main push = Vercel PROD 자동배포).

실패해도 치명적이진 않다 — `useMarkTargetAsRead` 가
`meta.skipGlobalErrorToast` 로 조용히 무시하고 상세 표시를 막지 않는다.
다만 순서를 지키면 뱃지가 안 줄어드는 과도기 자체가 없다.

## 변경 요약

**#263** `queryPersist.ts` — persister 쓰기 직전 `pages`/`pageParams` 를 같은
인덱스로 1개만 남긴다(`truncateInfinitePages`). 누적 stringify 비용은 그대로
작게 두면서 복귀 첫 화면이 채워진다. `QueryClientProvider` 의 infinite 제외
조건 삭제. `useDiaryList` `refetchOnMount` false→true(stale 일 때만 재검증).

**#264/#266** `ChallengeDetailScreen` — 나가기 버튼이 다이얼로그를 열기만 하고
`[나가기]` 에서만 mutate. 기존 `ConfirmDialog` 재사용(네이티브에선 OS
다이얼로그로 위임). 방장은 위임/삭제를 단정하지 않는 통합 경고.

**#265** `useSignalPageReady` — 피처 게이트를 `useNativeCapability` 로 전환해
`native:ready` 가 늦게 와도 재시도 emit. 이 훅을 쓰는 18개 화면 공통 적용.

**#267** 상세 진입 지점(`ChallengeDetailScreen` / `DiaryDetailScreen`)에서
`useMarkDetailAsRead` 로 1회 호출. 응답의 전체 미읽음 수로 뱃지 쿼리를
덮고 알림 목록은 invalidate.

## 검증

- `pnpm vitest run` 27 파일 · 221 테스트 (신규 회귀 테스트 3종 포함:
  `queryPersist` 5, `useSignalPageReady` 5, `useMarkDetailAsRead` 7)
- `pnpm lint` 0 errors · `tsc --noEmit` · `pnpm build` 통과
- 4건 모두 dev 배포 후 번들 문자열 확인 완료

브라우저·앱 실제 동작은 확인하지 않았다(정적 검증 + 단위 테스트 + dev 번들
확인까지).