### PR TITLE
feat(chat): 웹 채팅 — 앱 parity 구현 + 아카이빙 + 앱 유도/딥링크 준비

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-toggle": "^1.1.3",
     "@radix-ui/react-toggle-group": "^1.1.3",
+    "@stomp/stompjs": "^7.3.0",
     "@tanstack/query-sync-storage-persister": "^5.101.4",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-persist-client": "^5.101.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@radix-ui/react-toggle-group':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@stomp/stompjs':
+        specifier: ^7.3.0
+        version: 7.3.0
       '@tanstack/query-sync-storage-persister':
         specifier: ^5.101.4
         version: 5.101.4
@@ -1972,6 +1975,9 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stomp/stompjs@7.3.0':
+    resolution: {integrity: sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -6735,6 +6741,8 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@stomp/stompjs@7.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:

--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -39,6 +39,8 @@ const RIGHT_RAIL_HIDDEN_ROUTES = [
   '/mypage',
   '/challenge/create',
   '/notification',
+  // 채팅은 화면 높이를 꽉 쓰는 단일 패널이라 레일과 나란히 두면 좁아진다.
+  '/chat',
   '/terms',
   '/privacy',
   '/install',

--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@1d1s/design-system';
+import { AppInstallPrompt } from '@feature/install/components/AppInstallPrompt';
 import { usePhoneNumberMissing } from '@feature/member/hooks/usePhoneNumberMissing';
 import { BrowserPermissionPrompt } from '@feature/notification/components/BrowserPermissionPrompt';
 import VoteFloatingScreen from '@feature/vote/screen/VoteFloatingScreen';
@@ -298,6 +299,10 @@ export default function AppLayoutShell({
       ) : null}
 
       {!isLoginPage && !isNativeApp ? <BrowserPermissionPrompt /> : null}
+      {/* 모바일 웹으로 들어온 사용자에게만 앱을 권한다. 스스로 데스크톱·
+          네이티브 웹뷰·홈 화면 PWA 를 걸러내므로 여기서는 조건을 겹치지
+          않는다(가시성 규칙이 두 곳에 흩어지면 한쪽만 바뀐다). */}
+      <AppInstallPrompt isNativeApp={isNativeAppFromServer} />
       <VoteFloatingScreen
         enabled={isLoggedIn && !isLoginPage && isVoteWidgetRoute}
         hasBottomNav={showBottomNav && !isNativeApp}

--- a/src/app.component/layout/AppTopNav.tsx
+++ b/src/app.component/layout/AppTopNav.tsx
@@ -5,6 +5,7 @@ import { ChallengeTrophyIcon } from '@component/ChallengeTrophyIcon';
 import FadeInImage from '@component/FadeInImage';
 import { ProfileAlertBadge } from '@component/ProfileAlertBadge';
 import { Skeleton } from '@component/Skeleton';
+import { ChatEntryButton } from '@feature/chat/components/ChatEntryButton';
 import { cn } from '@module/utils/cn';
 import {
   buildLoginUrl,
@@ -120,6 +121,8 @@ export default function AppTopNav({
       </nav>
 
       <div className="ml-auto flex items-center gap-2">
+        <ChatEntryButton />
+
         <Link
           href="/notification"
           aria-label="알림"

--- a/src/app.constants/appLinks.test.ts
+++ b/src/app.constants/appLinks.test.ts
@@ -54,12 +54,29 @@ describe('buildAssetLinks', () => {
     );
   });
 
-  it('지금은 업로드 키 지문 하나뿐 — Play 앱 서명 키가 오면 둘이 된다', () => {
+  it('업로드 키와 Play 앱 서명 키 지문을 모두 싣는다', () => {
     const fingerprints = (buildAssetLinks(PROD) as AssetLink[])[0].target
       .sha256_cert_fingerprints;
-    expect(fingerprints).toHaveLength(1);
-    expect(fingerprints[0]).toMatch(/^E3:32:B9:86/);
-    // 빈 슬롯이 그대로 새어 나가지 않는지(null 이 배열에 섞이면 검증 실패).
-    expect(fingerprints.every((value) => typeof value === 'string')).toBe(true);
+    // 하나만 있으면 한쪽 설치 경로가 검증에 실패한다 — 업로드 키만이면
+    // 스토어 설치본이, 앱 서명 키만이면 로컬 APK 가 막힌다.
+    expect(fingerprints).toEqual([
+      'E3:32:B9:86:FD:C8:0E:A0:67:B9:71:A7:E7:A5:3A:FE:8B:BB:92:21:47:6C:70:36:7A:96:D5:C5:54:7C:00:14',
+      '75:DA:D6:EC:C2:12:33:B8:C9:E3:DE:22:46:CE:A3:7F:41:BC:FB:66:99:7D:2A:7B:23:0F:98:9E:F1:78:32:8F',
+    ]);
+  });
+
+  it('지문 형식이 Google 이 받는 대문자 콜론 구분 SHA-256 이다', () => {
+    const fingerprints = (buildAssetLinks(PROD) as AssetLink[])[0].target
+      .sha256_cert_fingerprints;
+    fingerprints.forEach((value) => {
+      // 32바이트 = 콜론으로 이어진 2자리 16진수 32개.
+      expect(value).toMatch(/^([0-9A-F]{2}:){31}[0-9A-F]{2}$/);
+    });
+  });
+
+  it('relation 은 handle_all_urls 한 가지다', () => {
+    expect((buildAssetLinks(PROD) as AssetLink[])[0].relation).toEqual([
+      'delegate_permission/common.handle_all_urls',
+    ]);
   });
 });

--- a/src/app.constants/appLinks.test.ts
+++ b/src/app.constants/appLinks.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAppleAppSiteAssociation, buildAssetLinks } from './appLinks';
+
+interface Aasa {
+  applinks: { details: Array<{ appIDs: string[]; components: unknown[] }> };
+}
+
+interface AssetLink {
+  relation: string[];
+  target: { package_name: string; sha256_cert_fingerprints: string[] };
+}
+
+const PROD = '1day1streak.com';
+const DEV = 'dev.1day1streak.com';
+
+describe('buildAppleAppSiteAssociation', () => {
+  it('운영 호스트는 운영 appID 를 준다', () => {
+    const aasa = buildAppleAppSiteAssociation(PROD) as Aasa;
+    expect(aasa.applinks.details[0].appIDs).toEqual([
+      'VF3TAS8J2N.com.onedayonestreak.app',
+    ]);
+  });
+
+  it('dev 호스트와 로컬 별칭은 dev appID 를 준다', () => {
+    const dev = buildAppleAppSiteAssociation(DEV) as Aasa;
+    const local = buildAppleAppSiteAssociation(
+      'local.dev.1day1streak.com:3000'
+    ) as Aasa;
+    expect(dev.applinks.details[0].appIDs).toEqual([
+      'VF3TAS8J2N.com.onedayonestreak.app.dev',
+    ]);
+    expect(local.applinks.details[0].appIDs).toEqual(
+      dev.applinks.details[0].appIDs
+    );
+  });
+
+  it('앱 intent-filter 와 같은 두 갈래만 가로챈다', () => {
+    const aasa = buildAppleAppSiteAssociation(PROD) as Aasa;
+    expect(aasa.applinks.details[0].components).toEqual([
+      { '/': '/challenge/*' },
+      { '/': '/diary/*' },
+    ]);
+  });
+});
+
+describe('buildAssetLinks', () => {
+  it('호스트에 맞는 패키지를 준다', () => {
+    expect((buildAssetLinks(PROD) as AssetLink[])[0].target.package_name).toBe(
+      'com.onedayonestreak.app'
+    );
+    expect((buildAssetLinks(DEV) as AssetLink[])[0].target.package_name).toBe(
+      'com.onedayonestreak.app.dev'
+    );
+  });
+
+  it('지금은 업로드 키 지문 하나뿐 — Play 앱 서명 키가 오면 둘이 된다', () => {
+    const fingerprints = (buildAssetLinks(PROD) as AssetLink[])[0].target
+      .sha256_cert_fingerprints;
+    expect(fingerprints).toHaveLength(1);
+    expect(fingerprints[0]).toMatch(/^E3:32:B9:86/);
+    // 빈 슬롯이 그대로 새어 나가지 않는지(null 이 배열에 섞이면 검증 실패).
+    expect(fingerprints.every((value) => typeof value === 'string')).toBe(true);
+  });
+});

--- a/src/app.constants/appLinks.ts
+++ b/src/app.constants/appLinks.ts
@@ -1,0 +1,97 @@
+// 딥링크 도메인 검증 파일(.well-known)에 실리는 값.
+//
+// 앱은 flavor 마다 **다른 패키지·다른 호스트**를 쓴다(앱 저장소
+// android/app/build.gradle 의 productFlavors, iOS AuthConfig.xcconfig):
+//
+//   prod  1day1streak.com      com.onedayonestreak.app
+//   dev   dev.1day1streak.com  com.onedayonestreak.app.dev
+//
+// 그래서 파일 내용이 **요청 호스트에 따라 갈린다**. 배포를 두 벌로 나누는
+// 대신 호스트로 고르면, 어느 환경에 올라가도 그 도메인에 맞는 답이 나간다.
+
+/** Apple Developer Team ID. 앱 세션이 확인해 준 값. */
+const APPLE_TEAM_ID = 'VF3TAS8J2N';
+
+const PROD_PACKAGE = 'com.onedayonestreak.app';
+const DEV_PACKAGE = `${PROD_PACKAGE}.dev`;
+
+/**
+ * 업로드 키 SHA-256.
+ *
+ * 로컬·직접 설치(APK) 빌드는 이 키로 서명된다. Play 로 올린 빌드는 Play 가
+ * 다시 서명하므로 이 지문만으로는 **스토어 설치본에서 App Links 검증이
+ * 안 된다** — 아래 PLAY_SIGNING_SHA256 이 반드시 함께 들어가야 한다.
+ */
+const UPLOAD_KEY_SHA256 =
+  'E3:32:B9:86:FD:C8:0E:A0:67:B9:71:A7:E7:A5:3A:FE:8B:BB:92:21:47:6C:70:36:7A:96:D5:C5:54:7C:00:14';
+
+/**
+ * Play 앱 서명 키 SHA-256 — **아직 없다**.
+ *
+ * Play Console > 설정 > 앱 서명 > "앱 서명 키 인증서" 의 SHA-256 지문이다
+ * (업로드 키 인증서가 아니다 — 둘은 다른 값이고, 스토어 설치본을 검증하는
+ * 것은 앱 서명 키 쪽이다). 값이 오면 이 상수만 채우면 되고, 아래 목록이
+ * 자동으로 두 개가 된다.
+ */
+const PLAY_SIGNING_SHA256: string | null = null;
+
+const ANDROID_FINGERPRINTS = [UPLOAD_KEY_SHA256, PLAY_SIGNING_SHA256].filter(
+  (value): value is string => Boolean(value)
+);
+
+/**
+ * 이 호스트가 dev 환경인가.
+ *
+ * `dev.1day1streak.com` 과 로컬 별칭(`local.dev.…`)이 dev 앱을 가리킨다.
+ * 그 외(운영 도메인, 프리뷰 도메인)는 prod 로 본다 — 모르는 호스트에
+ * dev 앱 ID 를 내주는 것보다 운영 값을 내주는 편이 안전하다.
+ */
+function isDevHost(host: string): boolean {
+  const hostname = host.split(':')[0].toLowerCase();
+  return hostname === 'dev.1day1streak.com' || hostname.endsWith('.dev.1day1streak.com');
+}
+
+/** iOS Universal Links 용 appID (`TeamID.BundleID`). */
+export function resolveAppleAppId(host: string): string {
+  return `${APPLE_TEAM_ID}.${isDevHost(host) ? DEV_PACKAGE : PROD_PACKAGE}`;
+}
+
+/** Android App Links 용 패키지명. */
+export function resolveAndroidPackage(host: string): string {
+  return isDevHost(host) ? DEV_PACKAGE : PROD_PACKAGE;
+}
+
+/**
+ * 앱이 가로채는 경로. 앱의 intent-filter(`pathPrefix=/challenge`, `/diary`)와
+ * 같은 범위여야 한다 — 여기만 넓히면 앱에 없는 화면 링크가 앱으로 끌려간다.
+ */
+export const APP_LINK_COMPONENTS = [
+  { '/': '/challenge/*' },
+  { '/': '/diary/*' },
+];
+
+export function buildAppleAppSiteAssociation(host: string): unknown {
+  return {
+    applinks: {
+      details: [
+        {
+          appIDs: [resolveAppleAppId(host)],
+          components: APP_LINK_COMPONENTS,
+        },
+      ],
+    },
+  };
+}
+
+export function buildAssetLinks(host: string): unknown {
+  return [
+    {
+      relation: ['delegate_permission/common.handle_all_urls'],
+      target: {
+        namespace: 'android_app',
+        package_name: resolveAndroidPackage(host),
+        sha256_cert_fingerprints: ANDROID_FINGERPRINTS,
+      },
+    },
+  ];
+}

--- a/src/app.constants/appLinks.ts
+++ b/src/app.constants/appLinks.ts
@@ -19,25 +19,27 @@ const DEV_PACKAGE = `${PROD_PACKAGE}.dev`;
  * 업로드 키 SHA-256.
  *
  * 로컬·직접 설치(APK) 빌드는 이 키로 서명된다. Play 로 올린 빌드는 Play 가
- * 다시 서명하므로 이 지문만으로는 **스토어 설치본에서 App Links 검증이
- * 안 된다** — 아래 PLAY_SIGNING_SHA256 이 반드시 함께 들어가야 한다.
+ * 다시 서명하므로 이 지문만으로는 스토어 설치본이 검증되지 않는다 —
+ * 그쪽은 아래 PLAY_SIGNING_SHA256 이 맡는다.
  */
 const UPLOAD_KEY_SHA256 =
   'E3:32:B9:86:FD:C8:0E:A0:67:B9:71:A7:E7:A5:3A:FE:8B:BB:92:21:47:6C:70:36:7A:96:D5:C5:54:7C:00:14';
 
 /**
- * Play 앱 서명 키 SHA-256 — **아직 없다**.
+ * Play 앱 서명 키 SHA-256.
  *
- * Play Console > 설정 > 앱 서명 > "앱 서명 키 인증서" 의 SHA-256 지문이다
- * (업로드 키 인증서가 아니다 — 둘은 다른 값이고, 스토어 설치본을 검증하는
- * 것은 앱 서명 키 쪽이다). 값이 오면 이 상수만 채우면 되고, 아래 목록이
- * 자동으로 두 개가 된다.
+ * Play Console > 설정 > 앱 서명 > "앱 서명 키 인증서" 의 지문이다(업로드 키
+ * 인증서와 **다른 값**이다). Play 는 업로드된 AAB 를 이 키로 다시 서명하므로,
+ * 스토어에서 받은 설치본의 App Links 검증은 이 지문으로 통과한다.
+ *
+ * 둘 다 필요하다 — 업로드 키만 있으면 스토어 설치본이, 앱 서명 키만 있으면
+ * 로컬·사내 배포 APK 가 검증에 실패한다. 지문은 하나만 맞아도 통과하므로
+ * 나란히 두는 것이 정답이다.
  */
-const PLAY_SIGNING_SHA256: string | null = null;
+const PLAY_SIGNING_SHA256 =
+  '75:DA:D6:EC:C2:12:33:B8:C9:E3:DE:22:46:CE:A3:7F:41:BC:FB:66:99:7D:2A:7B:23:0F:98:9E:F1:78:32:8F';
 
-const ANDROID_FINGERPRINTS = [UPLOAD_KEY_SHA256, PLAY_SIGNING_SHA256].filter(
-  (value): value is string => Boolean(value)
-);
+const ANDROID_FINGERPRINTS = [UPLOAD_KEY_SHA256, PLAY_SIGNING_SHA256];
 
 /**
  * 이 호스트가 dev 환경인가.

--- a/src/app.constants/appStore.test.ts
+++ b/src/app.constants/appStore.test.ts
@@ -38,5 +38,6 @@ describe('스토어 좌표', () => {
   it('iTunes Lookup 으로 확인한 실제 앱을 가리킨다', () => {
     expect(APP_STORE_URL).toContain('id6793538373');
     expect(PLAY_STORE_URL).toContain('id=com.onedayonestreak.app');
+    expect(PLAY_STORE_URL).toContain('hl=ko');
   });
 });

--- a/src/app.constants/appStore.test.ts
+++ b/src/app.constants/appStore.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  APP_STORE_URL,
+  buildAndroidIntentUrl,
+  isDeepLinkablePath,
+  PLAY_STORE_URL,
+} from './appStore';
+
+describe('isDeepLinkablePath', () => {
+  it('앱이 intent-filter 로 선언한 두 갈래만 받는다', () => {
+    expect(isDeepLinkablePath('/challenge/12')).toBe(true);
+    expect(isDeepLinkablePath('/diary/3')).toBe(true);
+    // 앱에 없는 경로를 넘기면 앱만 열리고 그 화면으로는 못 간다.
+    expect(isDeepLinkablePath('/challenge')).toBe(false);
+    expect(isDeepLinkablePath('/challenge/create')).toBe(false);
+    expect(isDeepLinkablePath('/mypage')).toBe(false);
+    expect(isDeepLinkablePath('/')).toBe(false);
+  });
+});
+
+describe('buildAndroidIntentUrl', () => {
+  it('패키지와 스토어 폴백을 함께 실어 보낸다', () => {
+    const url = buildAndroidIntentUrl(
+      new URL('https://1day1streak.com/challenge/12?tab=diary')
+    );
+    expect(url).toContain('intent://1day1streak.com/challenge/12?tab=diary');
+    expect(url).toContain('scheme=https');
+    expect(url).toContain('package=com.onedayonestreak.app');
+    expect(url).toContain(
+      `S.browser_fallback_url=${encodeURIComponent(PLAY_STORE_URL)}`
+    );
+    expect(url.endsWith(';end')).toBe(true);
+  });
+});
+
+describe('스토어 좌표', () => {
+  it('iTunes Lookup 으로 확인한 실제 앱을 가리킨다', () => {
+    expect(APP_STORE_URL).toContain('id6793538373');
+    expect(PLAY_STORE_URL).toContain('id=com.onedayonestreak.app');
+  });
+});

--- a/src/app.constants/appStore.ts
+++ b/src/app.constants/appStore.ts
@@ -9,8 +9,10 @@ export const APP_PACKAGE_NAME = 'com.onedayonestreak.app';
 /** App Store trackId. */
 export const APP_STORE_ID = '6793538373';
 
+// hl=ko 로 한국어 스토어 페이지를 고정한다. 기기 언어가 무엇이든 국내
+// 사용자가 보는 문구를 맞추기 위한 것이고, 링크 동작에는 영향이 없다.
 export const PLAY_STORE_URL =
-  `https://play.google.com/store/apps/details?id=${APP_PACKAGE_NAME}`;
+  `https://play.google.com/store/apps/details?id=${APP_PACKAGE_NAME}&hl=ko`;
 
 export const APP_STORE_URL =
   `https://apps.apple.com/kr/app/1d1s/id${APP_STORE_ID}`;

--- a/src/app.constants/appStore.ts
+++ b/src/app.constants/appStore.ts
@@ -1,0 +1,53 @@
+// 네이티브 앱 배포 좌표. 스토어 링크·패키지·딥링크 규칙을 한 곳에 둔다.
+//
+// App Store 값은 iTunes Lookup API 로 확인한 실제 값이다
+// (trackId 6793538373 / bundleId com.onedayonestreak.app / 판매자 Noh Hyunkeun).
+
+/** Android 패키지명 = iOS 번들 ID (양쪽이 같다). */
+export const APP_PACKAGE_NAME = 'com.onedayonestreak.app';
+
+/** App Store trackId. */
+export const APP_STORE_ID = '6793538373';
+
+export const PLAY_STORE_URL =
+  `https://play.google.com/store/apps/details?id=${APP_PACKAGE_NAME}`;
+
+export const APP_STORE_URL =
+  `https://apps.apple.com/kr/app/1d1s/id${APP_STORE_ID}`;
+
+/**
+ * 앱이 딥링크로 받는 경로. 앱의 App Links intent-filter 가 이 두 갈래만
+ * 선언한다(`pathPrefix=/challenge`, `/diary`) — 앱에 없는 웹 경로까지
+ * 넘기면 앱이 열리기만 하고 그 화면으로는 못 간다.
+ */
+const DEEP_LINK_PREFIXES = ['/challenge/', '/diary/'];
+
+/** 이 경로를 앱에서 열 수 있는가. 아니면 앱 홈으로 보낸다. */
+export function isDeepLinkablePath(pathname: string): boolean {
+  return DEEP_LINK_PREFIXES.some(
+    (prefix) => pathname.startsWith(prefix) && /\d/.test(pathname.slice(prefix.length))
+  );
+}
+
+/**
+ * Android 전용 앱 열기 URL.
+ *
+ * `intent://` 는 **설치 여부를 브라우저가 판단해 준다** — 설치돼 있으면
+ * 패키지로 바로 열고, 없으면 `browser_fallback_url`(스토어) 로 간다.
+ * JS 로 설치 여부를 알아내려는 타이머 트릭이 필요 없다.
+ *
+ * 앱 링크 검증(assetlinks.json)이 아직 안 올라갔어도 동작한다 — 검증은
+ * "브라우저를 거치지 않고 바로 앱으로" 를 위한 것이고, 여기서는 패키지를
+ * 명시하기 때문이다.
+ */
+export function buildAndroidIntentUrl(url: URL): string {
+  const path = `${url.pathname.replace(/^\//, '')}${url.search}`;
+  const fallback = encodeURIComponent(PLAY_STORE_URL);
+  return [
+    `intent://${url.host}/${path}#Intent`,
+    'scheme=https',
+    `package=${APP_PACKAGE_NAME}`,
+    `S.browser_fallback_url=${fallback}`,
+    'end',
+  ].join(';');
+}

--- a/src/app.feature/auth/hooks/useAuthMutations.ts
+++ b/src/app.feature/auth/hooks/useAuthMutations.ts
@@ -1,3 +1,4 @@
+import { closeChatSocket } from '@feature/chat/socket/chatSocket';
 import { MEMBER_QUERY_KEYS } from '@feature/member/consts/queryKeys';
 import { clearCachedSidebar } from '@feature/member/hooks/useMemberQueries';
 import { beginLogoutSuppression } from '@module/api/errorNotify';
@@ -119,6 +120,10 @@ export function useLogout(): UseMutationResult<LogoutResponse, Error, void> {
       queryClient.removeQueries();
       // 영속된 RQ 캐시(localStorage)도 비운다 — 개인 데이터 잔존 방지.
       purgePersistedQueries();
+      // 채팅 소켓은 쿠키로 인증된 연결이라 로그아웃과 함께 끊는다. 안 끊으면
+      // 탭을 닫을 때까지 살아 있고, 서버의 동시 접속 한도(CHAT-015) 자리도
+      // 계속 차지한다.
+      closeChatSocket();
     },
     mutationFn: () => authApi.logout(),
     // 로그아웃 POST 는 best-effort 다. 실패해도(앱 네트워크/네이티브 경로에서

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -7,6 +7,7 @@ import { LoginRequiredDialog } from '@component/LoginRequiredDialog';
 import { ChallengeDetailSkeleton } from '@component/skeletons/ChallengeDetailSkeleton';
 import { getCategoryLabel } from '@constants/categories';
 import { formatChallengeTypeLabel } from '@feature/challenge/shared/utils/challengeDisplay';
+import { ChallengeChatEntry } from '@feature/chat/components/ChallengeChatEntry';
 import { resolveSidebarMemberId } from '@feature/diary/detail/utils/diaryViewData';
 import { ConfirmDialog } from '@feature/member/settings/components/ConfirmDialog';
 import { useMarkDetailAsRead } from '@feature/notification/hooks/useMarkDetailAsRead';
@@ -953,6 +954,11 @@ export function ChallengeDetailScreen({
                   isLikePending={isActionLoading}
                 />
               </div>
+
+              <ChallengeChatEntry
+                challengeId={challengeId}
+                enabled={isParticipating && isGroupChallenge}
+              />
 
               {isParticipating ? (
                 <button

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -486,9 +486,20 @@ export function ChallengeDetailScreen({
     );
   };
 
-  // 비공개 챌린지(403)는 비밀번호 검증 모달로 유도한다.
+  // 비공개 챌린지는 비밀번호 검증 모달로 유도한다.
+  //
+  // 서버 403 이 정본이지만, 그것만 믿으면 서버가 200 + 상세를 주는 순간
+  // (SEC-1) 웹이 그대로 본문을 그린다. 응답 안에 이미 판단 재료가 있으므로
+  // 같은 판정을 한 번 더 한다 — 서버가 고쳐진 뒤에는 403 이 먼저 오므로
+  // 이 조건은 조용히 잠들어 있다가 회귀 때만 깨어난다.
+  //
+  // 조건을 `myStatus === 'NONE'`(아예 남이다) 으로 좁힌 것은 의도적이다.
+  // PENDING·ACCEPTED 처럼 애매한 상태까지 클라가 막으면, 서버는 허용하는데
+  // 화면만 잠기는 반대쪽 사고가 난다. 신고된 누출 경로(링크로 직접 진입한
+  // 외부인)는 언제나 NONE 이다.
   const isPrivateChallengeLocked =
-    isError && normalizeApiError(error).status === 403;
+    (isError && normalizeApiError(error).status === 403) ||
+    (summary?.challengeType === 'PRIVATE' && myStatus === 'NONE');
 
   if (showSkeleton) {
     return nativeSkeleton ? null : <ChallengeDetailSkeleton />;

--- a/src/app.feature/chat/api/chatApi.ts
+++ b/src/app.feature/chat/api/chatApi.ts
@@ -1,0 +1,179 @@
+import { apiClient } from '@module/api/client';
+import { UPLOAD_TIMEOUT_MS } from '@module/api/config';
+import { requestData } from '@module/api/request';
+
+import {
+  ChatImagePresign,
+  ChatMessage,
+  ChatMessagePage,
+  ChatRoomList,
+  ChatSendRequest,
+  ChatShareResolution,
+} from '../type/chat';
+
+/** 서버 ChatImageService.MAX_IMAGE_SIZE 와 같은 값. */
+export const CHAT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * 서버가 받는 확장자 ↔ contentType 매핑. 둘이 어긋나면 400 이다.
+ * 업로드가 끝난 뒤에도 서버가 HEAD 로 크기·타입을 다시 확인한다.
+ */
+export function chatImageContentType(fileName: string): string | null {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) {
+    return 'image/jpeg';
+  }
+  if (lower.endsWith('.png')) {
+    return 'image/png';
+  }
+  if (lower.endsWith('.heic')) {
+    return 'image/heic';
+  }
+  return null;
+}
+
+/**
+ * 채팅 presign 은 서명에 **contentType 과 contentLength 만** 넣는다.
+ * 공용 putToStorage 는 Cache-Control 을 붙이므로 여기서는 쓸 수 없다 —
+ * 서명에 없는 헤더를 덧붙이면 S3 가 403(SignatureDoesNotMatch)을 준다.
+ */
+async function putChatImage(
+  uploadUrl: string,
+  file: File,
+  contentType: string
+): Promise<void> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+  try {
+    const response = await fetch(uploadUrl, {
+      method: 'PUT',
+      body: file,
+      headers: { 'Content-Type': contentType },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`이미지 업로드 실패 (${response.status})`);
+    }
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * 방 목록 응답은 배열(구) / 객체(신) 두 형태가 있다. 배포 시점이 어긋날 수
+ * 있어 둘 다 읽는다 — 구 형식이면 hiddenMemberIds 는 비어 있다.
+ */
+function parseRoomList(data: unknown): ChatRoomList {
+  const payload = data as Partial<ChatRoomList> | ChatRoomList['rooms'];
+  if (Array.isArray(payload)) {
+    return { rooms: payload, hiddenMemberIds: [] };
+  }
+  return {
+    rooms: payload?.rooms ?? [],
+    hiddenMemberIds: payload?.hiddenMemberIds ?? [],
+  };
+}
+
+export const chatApi = {
+  getRooms: async (): Promise<ChatRoomList> =>
+    parseRoomList(
+      await requestData<unknown>(apiClient, {
+        url: '/chat/rooms',
+        method: 'GET',
+      })
+    ),
+
+  /** 최신순 한 페이지. 첫 페이지는 cursor 를 생략한다. */
+  getMessages: async (
+    roomId: number,
+    params?: { cursor?: string; size?: number }
+  ): Promise<ChatMessagePage> =>
+    requestData<ChatMessagePage>(apiClient, {
+      url: `/chat/rooms/${roomId}/messages`,
+      method: 'GET',
+      params,
+    }),
+
+  /**
+   * REST 전송. 소켓이 아직 안 붙었어도 나가고, 응답과 브로드캐스트가 두 번
+   * 도착해도 clientMessageId 로 하나로 합쳐진다(서버 멱등).
+   */
+  sendMessage: async (
+    roomId: number,
+    data: ChatSendRequest
+  ): Promise<ChatMessage> =>
+    requestData<ChatMessage, ChatSendRequest>(apiClient, {
+      url: `/chat/rooms/${roomId}/messages`,
+      method: 'POST',
+      data,
+    }),
+
+  markRead: async (roomId: number, lastReadMessageId: number): Promise<void> =>
+    requestData<void, { lastReadMessageId: number }>(apiClient, {
+      url: `/chat/rooms/${roomId}/read`,
+      method: 'PUT',
+      data: { lastReadMessageId },
+    }),
+
+  setNotifications: async (roomId: number, enabled: boolean): Promise<void> =>
+    requestData<void, { enabled: boolean }>(apiClient, {
+      url: `/chat/rooms/${roomId}/notifications`,
+      method: 'PUT',
+      data: { enabled },
+    }),
+
+  setNotice: async (roomId: number, messageId: number): Promise<void> =>
+    requestData<void, { messageId: number }>(apiClient, {
+      url: `/chat/rooms/${roomId}/notice`,
+      method: 'PUT',
+      data: { messageId },
+    }),
+
+  clearNotice: async (roomId: number): Promise<void> =>
+    requestData<void>(apiClient, {
+      url: `/chat/rooms/${roomId}/notice`,
+      method: 'DELETE',
+    }),
+
+  /**
+   * 붙여넣은 링크가 공유 카드가 될 수 있는지 서버에 묻는다. 판정에 실패하면
+   * 그냥 글로 보낸다 — 링크 하나 때문에 전송을 막지 않는다.
+   */
+  resolveShare: async (url: string): Promise<ChatShareResolution> => {
+    try {
+      return await requestData<ChatShareResolution, { url: string }>(
+        apiClient,
+        { url: '/chat/shares/resolve', method: 'POST', data: { url } }
+      );
+    } catch {
+      return { shareable: false, type: null, targetId: null, share: null };
+    }
+  },
+
+  /** presign → S3 PUT → imageUploadId. 전송은 호출부가 이어서 한다. */
+  uploadImage: async (roomId: number, file: File): Promise<string> => {
+    const contentType = chatImageContentType(file.name);
+    if (!contentType) {
+      throw new Error('jpg · png · heic 만 보낼 수 있습니다.');
+    }
+    if (file.size > CHAT_IMAGE_MAX_BYTES) {
+      throw new Error('이미지는 10MB 이하만 보낼 수 있습니다.');
+    }
+    // ponytail: 압축하지 않는다. 서버가 확장자와 contentType 일치를 요구해
+    // (png → image/jpeg 로 재인코딩되면 400) 압축이 오히려 전송을 깬다.
+    const { uploadUrl, imageUploadId } = await requestData<
+      ChatImagePresign,
+      { fileName: string; contentType: string; fileSize: number }
+    >(apiClient, {
+      url: `/chat/rooms/${roomId}/images/presign`,
+      method: 'POST',
+      data: {
+        fileName: file.name,
+        contentType,
+        fileSize: file.size,
+      },
+    });
+    await putChatImage(uploadUrl, file, contentType);
+    return imageUploadId;
+  },
+};

--- a/src/app.feature/chat/api/chatApi.ts
+++ b/src/app.feature/chat/api/chatApi.ts
@@ -75,11 +75,13 @@ function parseRoomList(data: unknown): ChatRoomList {
 }
 
 export const chatApi = {
-  getRooms: async (): Promise<ChatRoomList> =>
+  /** archived 를 생략하면 전체(보관 포함)를 준다. */
+  getRooms: async (params?: { archived?: boolean }): Promise<ChatRoomList> =>
     parseRoomList(
       await requestData<unknown>(apiClient, {
         url: '/chat/rooms',
         method: 'GET',
+        params,
       })
     ),
 

--- a/src/app.feature/chat/components/ChallengeChatEntry.tsx
+++ b/src/app.feature/chat/components/ChallengeChatEntry.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { useNativeCapability } from '@module/hooks/useNativeCapability';
+import { cn } from '@module/utils/cn';
+import { isNativeChatAvailable } from '@module/utils/nativeBridge';
+import { MessageCircle } from 'lucide-react';
+import Link from 'next/link';
+import React from 'react';
+
+import { useChatRoomForChallenge } from '../hooks/useChatQueries';
+
+/**
+ * 챌린지 상세에서 그 챌린지의 채팅방으로 들어간다.
+ *
+ * 방은 그룹 챌린지당 하나씩 서버가 자동으로 만든다 — 클라가 방을 만들거나
+ * 참여시키지 않는다. 그래서 방이 아직 없으면(개인 챌린지·미참여) 아무것도
+ * 그리지 않는다.
+ */
+export function ChallengeChatEntry({
+  challengeId,
+  enabled,
+}: {
+  challengeId: number;
+  /** 참여 중인 그룹 챌린지일 때만 방 목록을 조회한다. */
+  enabled: boolean;
+}): React.ReactElement | null {
+  const nativeChat = useNativeCapability(isNativeChatAvailable);
+  const roomId = useChatRoomForChallenge(challengeId, {
+    enabled: enabled && !nativeChat,
+  });
+
+  if (!enabled || nativeChat || roomId == null) {
+    return null;
+  }
+
+  return (
+    <Link
+      href={`/chat/rooms/${roomId}`}
+      className={cn(
+        'flex items-center justify-center gap-1.5 rounded-xl border',
+        'border-gray-200 bg-white py-2.5 text-gray-700',
+        'transition-colors hover:bg-gray-50'
+      )}
+    >
+      <MessageCircle className="h-4 w-4" />
+      <Text size="caption1" weight="bold" className="text-inherit">
+        채팅방 열기
+      </Text>
+    </Link>
+  );
+}

--- a/src/app.feature/chat/components/ChatComposer.tsx
+++ b/src/app.feature/chat/components/ChatComposer.tsx
@@ -92,8 +92,10 @@ function ShareAttachment({
 interface ChatComposerProps {
   value: string;
   onChange(value: string): void;
-  /** 방과 내 멤버십이 모두 ACTIVE 일 때만 열린다. */
+  /** 방·멤버십이 ACTIVE 이고 보관되지 않았을 때만 열린다. */
   enabled: boolean;
+  /** 잠긴 이유를 입력창이 직접 말한다(읽기 전용 / 보관). */
+  disabledPlaceholder?: string;
   sending: boolean;
   imageFile: File | null;
   share: ChatShareResolution | null;
@@ -106,6 +108,7 @@ export function ChatComposer({
   value,
   onChange,
   enabled,
+  disabledPlaceholder = '읽기 전용 채팅방입니다',
   sending,
   imageFile,
   share,
@@ -177,7 +180,7 @@ export function ChatComposer({
               }
             }
           }}
-          placeholder={enabled ? '메시지를 입력하세요' : '읽기 전용 채팅방입니다'}
+          placeholder={enabled ? '메시지를 입력하세요' : disabledPlaceholder}
           className={cn(
             'max-h-[120px] min-h-10 flex-1 resize-none rounded-[20px]',
             'bg-gray-100 px-3.5 py-2.5 leading-normal text-gray-900',

--- a/src/app.feature/chat/components/ChatComposer.tsx
+++ b/src/app.feature/chat/components/ChatComposer.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { resolveDiaryImageUrl } from '@module/utils/diaryImageUrl';
+import { ArrowUp, BookOpen, Flag, Plus, X } from 'lucide-react';
+import React, { useEffect, useMemo, useRef } from 'react';
+
+import { ChatShareResolution } from '../type/chat';
+
+/** 서버 @Size(max = 2000). */
+const MAX_LENGTH = 2000;
+
+function ImageAttachment({
+  file,
+  onRemove,
+}: {
+  file: File;
+  onRemove(): void;
+}): React.ReactElement {
+  const url = useMemo(() => URL.createObjectURL(file), [file]);
+  useEffect(() => () => URL.revokeObjectURL(url), [url]);
+  return (
+    <div className="relative w-[72px]">
+      {/* eslint-disable-next-line @next/next/no-img-element -- 로컬 blob 미리보기. */}
+      <img
+        src={url}
+        alt="보낼 사진"
+        className="h-[72px] w-[72px] rounded-[10px] object-cover"
+      />
+      <button
+        type="button"
+        aria-label="사진 빼기"
+        onClick={onRemove}
+        className={cn(
+          'absolute -top-1.5 -right-1.5 flex h-5.5 w-5.5 items-center',
+          'justify-center rounded-full bg-gray-800 text-white'
+        )}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+/** 보내기 전 챌린지·일지 미리보기. 사진 미리보기와 같은 자리·같은 빼기 버튼. */
+function ShareAttachment({
+  share,
+  onRemove,
+}: {
+  share: ChatShareResolution;
+  onRemove(): void;
+}): React.ReactElement {
+  const isDiary = share.type === 'DIARY_SHARE';
+  const TypeIcon = isDiary ? BookOpen : Flag;
+  const url = resolveDiaryImageUrl(share.share?.thumbnailUrl);
+  return (
+    <div className="flex items-center gap-2.5 rounded-xl bg-gray-100 p-2">
+      <div
+        className={cn(
+          'flex h-10 w-10 shrink-0 items-center justify-center',
+          'overflow-hidden rounded-lg bg-white'
+        )}
+      >
+        {url ? (
+          // eslint-disable-next-line @next/next/no-img-element -- S3 호스트 가변.
+          <img src={url} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <TypeIcon className="h-4 w-4 text-gray-500" />
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Text size="caption4" weight="extrabold" className="text-main-700">
+          {isDiary ? '일지' : '챌린지'}
+        </Text>
+        <Text size="caption2" weight="bold" className="truncate text-gray-900">
+          {share.share?.title ?? ''}
+        </Text>
+      </div>
+      <button
+        type="button"
+        aria-label="공유 빼기"
+        onClick={onRemove}
+        className="flex h-6 w-6 shrink-0 items-center justify-center"
+      >
+        <X className="h-3.5 w-3.5 text-gray-600" />
+      </button>
+    </div>
+  );
+}
+
+interface ChatComposerProps {
+  value: string;
+  onChange(value: string): void;
+  /** 방과 내 멤버십이 모두 ACTIVE 일 때만 열린다. */
+  enabled: boolean;
+  sending: boolean;
+  imageFile: File | null;
+  share: ChatShareResolution | null;
+  onRemoveAttachment(): void;
+  onOpenShareMenu(): void;
+  onSend(): void;
+}
+
+export function ChatComposer({
+  value,
+  onChange,
+  enabled,
+  sending,
+  imageFile,
+  share,
+  onRemoveAttachment,
+  onOpenShareMenu,
+  onSend,
+}: ChatComposerProps): React.ReactElement {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // 입력 높이를 내용에 맞춘다(최대 5줄). scrollHeight 는 렌더 후에만
+  // 정확하므로 값이 바뀔 때마다 다시 잰다.
+  useEffect(() => {
+    const node = textareaRef.current;
+    if (!node) {
+      return;
+    }
+    node.style.height = 'auto';
+    node.style.height = `${Math.min(node.scrollHeight, 120)}px`;
+  }, [value]);
+
+  // 사진만, 캡션만, 둘 다 — 셋 다 보낼 수 있다.
+  const hasContent = Boolean(value.trim() || imageFile || share);
+  const canSend = enabled && !sending && hasContent;
+
+  return (
+    <div className="shrink-0 border-t border-gray-200 bg-white px-4 py-2">
+      {imageFile ? (
+        <div className="pb-2">
+          <ImageAttachment file={imageFile} onRemove={onRemoveAttachment} />
+        </div>
+      ) : share ? (
+        <div className="pb-2">
+          <ShareAttachment share={share} onRemove={onRemoveAttachment} />
+        </div>
+      ) : null}
+
+      <div className="flex items-end gap-2">
+        <button
+          type="button"
+          aria-label="보낼 것 고르기"
+          disabled={!enabled}
+          onClick={onOpenShareMenu}
+          className={cn(
+            'flex h-10 w-9 shrink-0 items-center justify-center',
+            enabled ? 'text-gray-700' : 'text-gray-400'
+          )}
+        >
+          <Plus className="h-5 w-5" />
+        </button>
+
+        <textarea
+          ref={textareaRef}
+          value={value}
+          disabled={!enabled}
+          rows={1}
+          maxLength={MAX_LENGTH}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={(event) => {
+            // 데스크톱에서는 Enter 로 보내고 Shift+Enter 로 줄바꿈한다.
+            // 모바일 IME 조합 중 Enter 는 확정이므로 보내지 않는다.
+            if (
+              event.key === 'Enter' &&
+              !event.shiftKey &&
+              !event.nativeEvent.isComposing
+            ) {
+              event.preventDefault();
+              if (canSend) {
+                onSend();
+              }
+            }
+          }}
+          placeholder={enabled ? '메시지를 입력하세요' : '읽기 전용 채팅방입니다'}
+          className={cn(
+            'max-h-[120px] min-h-10 flex-1 resize-none rounded-[20px]',
+            'bg-gray-100 px-3.5 py-2.5 leading-normal text-gray-900',
+            'placeholder:text-gray-500 focus:outline-none',
+            'disabled:cursor-not-allowed'
+          )}
+        />
+
+        <button
+          type="button"
+          aria-label="보내기"
+          disabled={!canSend}
+          onClick={onSend}
+          className={cn(
+            'flex h-10 w-10 shrink-0 items-center justify-center',
+            'rounded-full text-white transition-colors',
+            canSend ? 'bg-main-600' : 'bg-gray-300'
+          )}
+        >
+          <ArrowUp className="h-4.5 w-4.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/chat/components/ChatEntryButton.tsx
+++ b/src/app.feature/chat/components/ChatEntryButton.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { useNativeCapability } from '@module/hooks/useNativeCapability';
+import { cn } from '@module/utils/cn';
+import { isNativeChatAvailable } from '@module/utils/nativeBridge';
+import { MessageCircle } from 'lucide-react';
+import Link from 'next/link';
+import React from 'react';
+
+import { useChatUnreadTotal } from '../hooks/useChatQueries';
+
+/**
+ * 헤더의 채팅 진입 버튼. 방 전체 안 읽음 합을 배지로 얹는다.
+ *
+ * 네이티브 쉘이 자기 채팅을 갖고 있으면 아무것도 그리지 않는다 — 같은
+ * 기능이 두 벌 보이지 않게.
+ */
+export function ChatEntryButton({
+  className,
+}: {
+  className?: string;
+}): React.ReactElement | null {
+  const isLoggedIn = useIsLoggedIn();
+  const nativeChat = useNativeCapability(isNativeChatAvailable);
+  const unread = useChatUnreadTotal({ enabled: isLoggedIn && !nativeChat });
+
+  if (!isLoggedIn || nativeChat) {
+    return null;
+  }
+
+  return (
+    <Link
+      href="/chat"
+      aria-label={unread > 0 ? `채팅 (안 읽음 ${unread}건)` : '채팅'}
+      className={cn(
+        'relative flex h-9 w-9 items-center justify-center',
+        'rounded-2 bg-gray-100 text-gray-700 transition hover:bg-gray-200',
+        className
+      )}
+    >
+      <MessageCircle className="h-4 w-4" />
+      {unread > 0 ? (
+        <span
+          className={cn(
+            'bg-main-600 absolute -top-1 -right-1 inline-flex min-w-4',
+            'items-center justify-center rounded-full px-1',
+            'text-[10px] leading-4 font-extrabold text-white'
+          )}
+        >
+          {unread > 99 ? '99+' : unread}
+        </span>
+      ) : null}
+    </Link>
+  );
+}

--- a/src/app.feature/chat/components/ChatLinkifiedText.tsx
+++ b/src/app.feature/chat/components/ChatLinkifiedText.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+import { CHAT_URL_PATTERN, trimUrlTail } from '../utils/chatShareLink';
+
+interface ChatLinkifiedTextProps {
+  value: string;
+  /** 내 말풍선은 주황 바탕이라 흰 글씨에 밑줄, 상대는 브랜드 링크색. */
+  isMine: boolean;
+}
+
+/** 본문 안의 URL 을 눌러 열 수 있게 자른다. 링크가 없으면 글 그대로. */
+export function ChatLinkifiedText({
+  value,
+  isMine,
+}: ChatLinkifiedTextProps): React.ReactNode {
+  const matches = Array.from(value.matchAll(CHAT_URL_PATTERN));
+  if (matches.length === 0) {
+    return value;
+  }
+
+  const linkClass = cn(
+    'break-all underline underline-offset-2',
+    isMine ? 'text-white decoration-white/70' : 'text-main-700'
+  );
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  matches.forEach((match, index) => {
+    const [raw] = match;
+    const start = match.index ?? 0;
+    if (start > cursor) {
+      nodes.push(value.slice(cursor, start));
+    }
+    const url = trimUrlTail(raw);
+    nodes.push(
+      <a
+        key={`${url}-${index}`}
+        href={url}
+        target="_blank"
+        rel="noreferrer noopener"
+        className={linkClass}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {url}
+      </a>
+    );
+    // 잘라 낸 꼬리는 일반 글자로 되돌린다.
+    if (url.length < raw.length) {
+      nodes.push(raw.slice(url.length));
+    }
+    cursor = start + raw.length;
+  });
+  if (cursor < value.length) {
+    nodes.push(value.slice(cursor));
+  }
+  return nodes;
+}

--- a/src/app.feature/chat/components/ChatMessageBubble.tsx
+++ b/src/app.feature/chat/components/ChatMessageBubble.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { resolveDiaryImageUrl } from '@module/utils/diaryImageUrl';
+import { openNativeImageViewer } from '@module/utils/nativeBridge';
+import { ImageOff } from 'lucide-react';
+import React, { useState } from 'react';
+
+import { ChatMessage } from '../type/chat';
+import { formatBubbleTime } from '../utils/chatFormat';
+import { ChatLinkifiedText } from './ChatLinkifiedText';
+import {
+  ChatLinkPreviewCard,
+  ChatShareCard,
+  hasLinkPreviewContent,
+} from './ChatShareCard';
+
+/**
+ * 사진 말풍선. 세로로 긴 사진이 말풍선을 화면 높이만큼 밀어내지 않도록
+ * 정사각 썸네일로 자른다 — 원본 비율은 눌러서 본다.
+ *
+ * ponytail: 웹 라이트박스는 두지 않는다. 네이티브 쉘에서는 Flutter 뷰어가
+ * 열리고, 브라우저에서는 새 탭으로 원본을 연다. 여러 장 넘겨 보기가
+ * 필요해지면 그때 DiaryImageGallery 의 라이트박스를 공용으로 뽑는다.
+ */
+function ImageBody({ message }: { message: ChatMessage }): React.ReactElement {
+  const [broken, setBroken] = useState(false);
+  const url = resolveDiaryImageUrl(message.imageUrl);
+  const frame = 'h-[200px] w-[200px] overflow-hidden rounded-[10px] bg-gray-100';
+
+  // 아직 업로드 중이면 URL 이 없다 — 자리를 잡아 두고 진행 표시.
+  if (!url) {
+    return (
+      <div className={cn(frame, 'flex items-center justify-center')}>
+        <span
+          className={cn(
+            'h-4 w-4 animate-spin rounded-full border-2',
+            'border-gray-300 border-t-transparent'
+          )}
+        />
+      </div>
+    );
+  }
+
+  if (broken) {
+    return (
+      <div className={cn(frame, 'flex items-center justify-center')}>
+        <ImageOff className="h-5 w-5 text-gray-500" />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="사진 크게 보기"
+      className={cn(frame, 'block cursor-zoom-in')}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (!openNativeImageViewer([url], 0)) {
+          window.open(url, '_blank', 'noopener,noreferrer');
+        }
+      }}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element -- S3 호스트가
+          환경마다 달라 next/image remotePatterns 로 고정할 수 없다. */}
+      <img
+        src={url}
+        alt="채팅 사진"
+        loading="lazy"
+        className="h-full w-full object-cover"
+        onError={() => setBroken(true)}
+      />
+    </button>
+  );
+}
+
+function BubbleText({
+  value,
+  isMine,
+  muted = false,
+}: {
+  value: string;
+  isMine: boolean;
+  muted?: boolean;
+}): React.ReactElement {
+  return (
+    <Text
+      as="p"
+      size="body2"
+      className={cn(
+        'break-words whitespace-pre-wrap',
+        muted ? 'text-gray-500 italic' : isMine ? 'text-white' : 'text-gray-900'
+      )}
+    >
+      <ChatLinkifiedText value={value} isMine={isMine} />
+    </Text>
+  );
+}
+
+/**
+ * 말풍선 본문 — 타입별 렌더.
+ *
+ * 모르는 타입은 빈 말풍선 대신 안내를 그린다. 서버가 새 타입을 먼저
+ * 배포해도 구버전 클라가 조용히 깨지지 않게 하기 위한 것이다.
+ */
+export function ChatBubbleBody({
+  message,
+  isMine,
+}: {
+  message: ChatMessage;
+  isMine: boolean;
+}): React.ReactElement {
+  if (message.status === 'HIDDEN') {
+    // HIDDEN 은 관리자가 신고를 승인해 가린 것 하나뿐이다 — 채팅에는
+    // 작성자 삭제 경로가 없다. "삭제된 메시지" 는 틀린 설명이다.
+    return (
+      <BubbleText
+        value="신고가 접수되어 제한된 채팅입니다."
+        isMine={isMine}
+        muted
+      />
+    );
+  }
+
+  const caption = message.content?.trim();
+  const withCaption = (card: React.ReactNode): React.ReactElement => (
+    <div className="flex flex-col items-start">
+      {card}
+      {caption ? (
+        <div className="px-1 pt-1.5">
+          <BubbleText value={caption} isMine={isMine} />
+        </div>
+      ) : null}
+    </div>
+  );
+
+  switch (message.type) {
+    case 'CHALLENGE_SHARE':
+    case 'DIARY_SHARE':
+      return withCaption(<ChatShareCard message={message} />);
+    case 'IMAGE':
+      return withCaption(<ImageBody message={message} />);
+    case 'TEXT': {
+      const preview = message.linkPreview;
+      if (!hasLinkPreviewContent(preview)) {
+        return <BubbleText value={message.content ?? ''} isMine={isMine} />;
+      }
+      return (
+        <div className="flex flex-col items-start gap-2">
+          <BubbleText value={message.content ?? ''} isMine={isMine} />
+          <ChatLinkPreviewCard preview={preview!} />
+        </div>
+      );
+    }
+    default:
+      return (
+        <BubbleText value="지원하지 않는 메시지입니다." isMine={isMine} muted />
+      );
+  }
+}
+
+function TimeLabel({
+  message,
+  onRetry,
+}: {
+  message: ChatMessage;
+  onRetry?(): void;
+}): React.ReactElement {
+  if (message.failed) {
+    return onRetry ? (
+      <button
+        type="button"
+        onClick={onRetry}
+        className="text-red-500 underline underline-offset-2"
+      >
+        <Text size="caption4" weight="bold" className="text-inherit">
+          전송 실패 · 다시 보내기
+        </Text>
+      </button>
+    ) : (
+      <Text size="caption4" className="text-red-500">
+        전송 실패
+      </Text>
+    );
+  }
+  return (
+    <Text size="caption4" className="text-gray-500">
+      {message.pending ? '보내는 중' : formatBubbleTime(message.createdAt)}
+    </Text>
+  );
+}
+
+const LONG_PRESS_MS = 450;
+
+/** 터치 롱프레스. 스크롤로 손가락이 움직이면 취소한다. */
+function useLongPress(onLongPress: () => void): {
+  onTouchStart(): void;
+  onTouchEnd(): void;
+  onTouchMove(): void;
+} {
+  const timer = React.useRef<number | null>(null);
+  const clear = (): void => {
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+  return {
+    onTouchStart: () => {
+      clear();
+      timer.current = window.setTimeout(onLongPress, LONG_PRESS_MS);
+    },
+    onTouchEnd: clear,
+    onTouchMove: clear,
+  };
+}
+
+interface ChatMessageBubbleProps {
+  message: ChatMessage;
+  isMine: boolean;
+  /** 연속 발화의 첫 줄에만 닉네임을 보여 준다. */
+  showSender: boolean;
+  /** 공지로 지정된 메시지는 본문에서도 구분되게 한다. */
+  isNotice: boolean;
+  /** 원본 이동 직후 잠깐 강조. */
+  highlighted?: boolean;
+  onRetry?(): void;
+  onOpenActions?(message: ChatMessage): void;
+}
+
+export function ChatMessageBubble({
+  message,
+  isMine,
+  showSender,
+  isNotice,
+  highlighted = false,
+  onRetry,
+  onOpenActions,
+}: ChatMessageBubbleProps): React.ReactElement {
+  const hidden = message.status === 'HIDDEN';
+  const isImage = message.type === 'IMAGE' && !hidden;
+
+  // 롱프레스(모바일) 와 우클릭(데스크톱) 이 같은 메뉴를 연다.
+  const longPress = useLongPress(() => onOpenActions?.(message));
+
+  return (
+    <div
+      // 공지 원본으로 보낼 때 scrollIntoView 로 찾는다.
+      id={message.id > 0 ? `chat-message-${message.id}` : undefined}
+      className={cn(
+        'flex flex-col pb-2',
+        isMine ? 'items-end' : 'items-start',
+        highlighted && 'bg-main-100/60 -mx-2 rounded-xl px-2 py-1'
+      )}
+    >
+      {!isMine && showSender ? (
+        <Text size="caption3" weight="medium" className="pb-1 pl-1 text-gray-600">
+          {message.senderNickname}
+        </Text>
+      ) : null}
+      <div
+        className={cn(
+          'flex max-w-[80%] items-end gap-1.5',
+          isMine ? 'flex-row' : 'flex-row-reverse'
+        )}
+      >
+        <div className="shrink-0 pb-0.5">
+          <TimeLabel message={message} onRetry={onRetry} />
+        </div>
+        <div
+          role={onOpenActions ? 'button' : undefined}
+          tabIndex={onOpenActions ? 0 : undefined}
+          onContextMenu={(event) => {
+            if (!onOpenActions) {
+              return;
+            }
+            event.preventDefault();
+            onOpenActions(message);
+          }}
+          {...longPress}
+          className={cn(
+            'min-w-0 overflow-hidden rounded-[14px]',
+            isImage ? 'p-1.5' : 'px-3 py-2.5',
+            hidden
+              ? 'bg-gray-100'
+              : isMine
+                ? 'bg-main-600'
+                : 'border border-gray-200 bg-white',
+            isNotice && 'border-main-600 border-[1.5px]',
+            message.pending && 'opacity-70'
+          )}
+        >
+          <ChatBubbleBody message={message} isMine={isMine} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/chat/components/ChatMessageList.tsx
+++ b/src/app.feature/chat/components/ChatMessageList.tsx
@@ -49,6 +49,8 @@ interface ChatMessageListProps {
   topInset: number;
   /** 이 방에 쓸 수 있는가. 빈 화면 문구가 갈린다. */
   canSend: boolean;
+  /** 보관된 방인가. 빈 화면 문구가 한 번 더 갈린다. */
+  archived?: boolean;
   noticeId?: number | null;
   highlightId?: number | null;
   onRetry(message: ChatMessage): void;
@@ -68,6 +70,7 @@ export function ChatMessageList({
   fetchNextPage,
   topInset,
   canSend,
+  archived = false,
   noticeId,
   highlightId,
   onRetry,
@@ -88,7 +91,9 @@ export function ChatMessageList({
           {/* 못 보내는 방에서 "첫 메시지를 보내 보세요" 는 모순이다. */}
           {canSend
             ? '아직 대화가 없어요.\n첫 메시지를 보내 보세요.'
-            : '아직 대화가 없어요.'}
+            : archived
+              ? '대화 없이 보관된 채팅방이에요.'
+              : '아직 대화가 없어요.'}
         </Text>
       </div>
     );

--- a/src/app.feature/chat/components/ChatMessageList.tsx
+++ b/src/app.feature/chat/components/ChatMessageList.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { useInViewObserver } from '@module/hooks/useInViewObserver';
+import { cn } from '@module/utils/cn';
+import React, { useEffect } from 'react';
+
+import { ChatMessage } from '../type/chat';
+import { formatDateDivider, isSameChatDay } from '../utils/chatFormat';
+import { ChatMessageBubble } from './ChatMessageBubble';
+
+/** 시스템 안내. 대화가 아니라 표시이므로 가운데 칩으로 그린다. */
+function SystemChip({ text }: { text: string }): React.ReactElement {
+  return (
+    <div className="flex justify-center py-1.5">
+      <span className="bg-main-200 rounded-full px-3 py-1.5">
+        <Text
+          size="caption3"
+          weight="medium"
+          className="text-main-800 text-center"
+        >
+          {text}
+        </Text>
+      </span>
+    </div>
+  );
+}
+
+function DateDivider({ value }: { value: string }): React.ReactElement {
+  return (
+    <div className="flex justify-center pt-1 pb-3">
+      <span className="rounded-full bg-gray-100 px-3 py-1">
+        <Text size="caption3" weight="medium" className="text-gray-600">
+          {formatDateDivider(value)}
+        </Text>
+      </span>
+    </div>
+  );
+}
+
+interface ChatMessageListProps {
+  messages: ChatMessage[];
+  /** 내 것인지 판정할 닉네임. 웹은 자기 memberId 를 받지 않는다. */
+  myNickname?: string;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage(): void;
+  /** 떠 있는 배너에 가리지 않도록 리스트 위에 비워 둘 높이(실측값). */
+  topInset: number;
+  /** 이 방에 쓸 수 있는가. 빈 화면 문구가 갈린다. */
+  canSend: boolean;
+  noticeId?: number | null;
+  highlightId?: number | null;
+  onRetry(message: ChatMessage): void;
+  onOpenActions(message: ChatMessage): void;
+}
+
+/**
+ * 역방향 리스트. 서버 내역이 최신순으로 오므로 그대로 앞에서부터 그리고,
+ * `flex-col-reverse` 로 뒤집어 새 메시지가 아래에 쌓이게 한다 — 새 메시지가
+ * 와도 스크롤이 튀지 않는다.
+ */
+export function ChatMessageList({
+  messages,
+  myNickname,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+  topInset,
+  canSend,
+  noticeId,
+  highlightId,
+  onRetry,
+  onOpenActions,
+}: ChatMessageListProps): React.ReactElement {
+  const { ref, inView } = useInViewObserver();
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-6">
+        <Text size="body2" className="text-center whitespace-pre-line text-gray-600">
+          {/* 못 보내는 방에서 "첫 메시지를 보내 보세요" 는 모순이다. */}
+          {canSend
+            ? '아직 대화가 없어요.\n첫 메시지를 보내 보세요.'
+            : '아직 대화가 없어요.'}
+        </Text>
+      </div>
+    );
+  }
+
+  const children: React.ReactNode[] = [];
+  messages.forEach((message, index) => {
+    // 최신순이라 index+1 이 시간상 **이전** 메시지다.
+    const previous = messages[index + 1];
+    // 날짜가 바뀌는 첫 메시지 위에 구분선. 가장 오래된 메시지도 위에
+    // 아무것도 없으니 날짜를 보여 준다.
+    const startsNewDay =
+      !previous || !isSameChatDay(previous.createdAt, message.createdAt);
+
+    children.push(
+      message.type === 'SYSTEM' ? (
+        <SystemChip key={`m-${message.id}-${index}`} text={message.content ?? ''} />
+      ) : (
+        <ChatMessageBubble
+          key={message.clientMessageId ?? `m-${message.id}-${index}`}
+          message={message}
+          isMine={
+            Boolean(message.pending) ||
+            (Boolean(myNickname) && message.senderNickname === myNickname)
+          }
+          // 날짜가 갈리면 같은 사람이어도 닉네임을 다시 보여 준다.
+          showSender={startsNewDay || previous.senderId !== message.senderId}
+          isNotice={noticeId != null && message.id === noticeId}
+          highlighted={highlightId != null && message.id === highlightId}
+          onRetry={message.failed ? () => onRetry(message) : undefined}
+          onOpenActions={onOpenActions}
+        />
+      )
+    );
+
+    if (startsNewDay) {
+      // flex-col-reverse 라 DOM 상 뒤에 둔 것이 화면에서는 위에 온다.
+      children.push(
+        <DateDivider key={`d-${message.id}-${index}`} value={message.createdAt} />
+      );
+    }
+  });
+
+  return (
+    <div
+      className={cn(
+        'flex h-full flex-col-reverse overflow-y-auto overscroll-contain',
+        'px-4 pb-3'
+      )}
+      style={{ paddingTop: topInset + 12 }}
+    >
+      {children}
+      {hasNextPage ? (
+        <div ref={ref} className="flex justify-center py-4">
+          <span
+            className={cn(
+              'h-4 w-4 animate-spin rounded-full border-2',
+              'border-gray-300 border-t-transparent'
+            )}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app.feature/chat/components/ChatRoomListItem.tsx
+++ b/src/app.feature/chat/components/ChatRoomListItem.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import React from 'react';
 
 import { canSendInRoom, ChatRoom } from '../type/chat';
+import { isChatArchived } from '../utils/chatArchive';
 import { formatRoomTime, roomPreview } from '../utils/chatFormat';
 import { ChatRoomThumbnail } from './ChatRoomThumbnail';
 
@@ -51,7 +52,12 @@ function RoomChip({
 }
 
 function StateChip({ room }: { room: ChatRoom }): React.ReactElement | null {
-  // 종료와 읽기 전용은 다르다 — 종료돼도 방은 그대로 쓴다. 둘은 배타다.
+  // 셋은 배타다. 아카이브는 이미 "종료 + 읽기 전용" 이라, 셋을 나란히
+  // 세우면 같은 사실을 세 번 말하게 된다.
+  if (isChatArchived(room)) {
+    return <RoomChip label="아카이브됨" tone="state" />;
+  }
+  // 종료와 읽기 전용은 다르다 — 종료 후 일주일은 그대로 쓸 수 있다.
   if (room.challengeEnded) {
     return <RoomChip label="종료" tone="state" />;
   }
@@ -72,6 +78,7 @@ export function ChatRoomListItem({
 }: ChatRoomListItemProps): React.ReactElement {
   const unread = room.unreadCount;
   const BellIcon = room.pushEnabled ? Bell : BellOff;
+  const archived = isChatArchived(room);
 
   return (
     <div
@@ -79,9 +86,12 @@ export function ChatRoomListItem({
         'relative flex items-center gap-3 rounded-2xl border px-3.5 py-3',
         'transition-colors',
         // 안 읽은 방은 살짝 물들여 눈에 띄게 한다. 그림자는 쓰지 않는다.
-        unread > 0
+        unread > 0 && !archived
           ? 'bg-main-100 border-main-200'
-          : 'border-gray-200 bg-white hover:bg-gray-50'
+          : 'border-gray-200 bg-white hover:bg-gray-50',
+        // 보관된 방은 한 단계 물러나 보이게 한다. 내용은 그대로 읽을 수
+        // 있으므로 아주 흐리게 만들지는 않는다.
+        archived && 'opacity-60'
       )}
     >
       {/* 카드 전체가 링크지만 종 버튼은 그 위에 따로 얹는다 — 링크 안에

--- a/src/app.feature/chat/components/ChatRoomListItem.tsx
+++ b/src/app.feature/chat/components/ChatRoomListItem.tsx
@@ -6,8 +6,8 @@ import { Bell, BellOff, BookOpen, Flag, ImageIcon } from 'lucide-react';
 import Link from 'next/link';
 import React from 'react';
 
-import { canSendInRoom, ChatRoom } from '../type/chat';
-import { isChatArchived } from '../utils/chatArchive';
+import { ChatRoom } from '../type/chat';
+import { canSendInChatRoom, isChatArchived } from '../utils/chatArchive';
 import { formatRoomTime, roomPreview } from '../utils/chatFormat';
 import { ChatRoomThumbnail } from './ChatRoomThumbnail';
 
@@ -61,7 +61,7 @@ function StateChip({ room }: { room: ChatRoom }): React.ReactElement | null {
   if (room.challengeEnded) {
     return <RoomChip label="종료" tone="state" />;
   }
-  if (!canSendInRoom(room)) {
+  if (!canSendInChatRoom(room)) {
     return <RoomChip label="읽기 전용" tone="state" />;
   }
   return null;

--- a/src/app.feature/chat/components/ChatRoomListItem.tsx
+++ b/src/app.feature/chat/components/ChatRoomListItem.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { Bell, BellOff, BookOpen, Flag, ImageIcon } from 'lucide-react';
+import Link from 'next/link';
+import React from 'react';
+
+import { canSendInRoom, ChatRoom } from '../type/chat';
+import { formatRoomTime, roomPreview } from '../utils/chatFormat';
+import { ChatRoomThumbnail } from './ChatRoomThumbnail';
+
+/**
+ * 마지막 메시지가 글이 아니면 앞에 작은 아이콘을 둔다 — 무엇이 왔는지
+ * 한눈에 보이게. 글이면 아이콘 없이 문구만(과밀 방지).
+ */
+function PreviewIcon({ room }: { room: ChatRoom }): React.ReactElement | null {
+  const className = 'h-3 w-3 shrink-0 text-gray-400';
+  switch (room.lastMessage?.type) {
+    case 'IMAGE':
+      return <ImageIcon className={className} />;
+    case 'CHALLENGE_SHARE':
+      return <Flag className={className} />;
+    case 'DIARY_SHARE':
+      return <BookOpen className={className} />;
+    default:
+      return null;
+  }
+}
+
+/** 방 이름 옆 작은 배지. 방장 표시와 상태 표시가 같은 pill 이다. */
+function RoomChip({
+  label,
+  tone,
+}: {
+  label: string;
+  tone: 'host' | 'state';
+}): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        'shrink-0 rounded-full px-1.5 py-px text-[10px] leading-4',
+        tone === 'host'
+          ? 'bg-main-200 text-main-800 font-extrabold'
+          : 'bg-gray-100 font-bold text-gray-600'
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function StateChip({ room }: { room: ChatRoom }): React.ReactElement | null {
+  // 종료와 읽기 전용은 다르다 — 종료돼도 방은 그대로 쓴다. 둘은 배타다.
+  if (room.challengeEnded) {
+    return <RoomChip label="종료" tone="state" />;
+  }
+  if (!canSendInRoom(room)) {
+    return <RoomChip label="읽기 전용" tone="state" />;
+  }
+  return null;
+}
+
+interface ChatRoomListItemProps {
+  room: ChatRoom;
+  onToggleNotification(room: ChatRoom): void;
+}
+
+export function ChatRoomListItem({
+  room,
+  onToggleNotification,
+}: ChatRoomListItemProps): React.ReactElement {
+  const unread = room.unreadCount;
+  const BellIcon = room.pushEnabled ? Bell : BellOff;
+
+  return (
+    <div
+      className={cn(
+        'relative flex items-center gap-3 rounded-2xl border px-3.5 py-3',
+        'transition-colors',
+        // 안 읽은 방은 살짝 물들여 눈에 띄게 한다. 그림자는 쓰지 않는다.
+        unread > 0
+          ? 'bg-main-100 border-main-200'
+          : 'border-gray-200 bg-white hover:bg-gray-50'
+      )}
+    >
+      {/* 카드 전체가 링크지만 종 버튼은 그 위에 따로 얹는다 — 링크 안에
+          버튼을 중첩하면 마크업이 무효가 된다. */}
+      <Link
+        href={`/chat/rooms/${room.roomId}`}
+        aria-label={`${room.challengeTitle} 채팅방 열기`}
+        className="absolute inset-0 z-0 rounded-2xl"
+      />
+
+      {/* 어느 챌린지 방인지가 먼저 읽혀야 한다. 3:2 landscape. */}
+      <ChatRoomThumbnail
+        url={room.challengeThumbnailUrl}
+        category={room.category}
+        className="pointer-events-none z-[1] h-11 w-[66px]"
+      />
+
+      <div className="pointer-events-none z-[1] flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Text size="body2" weight="bold" className="truncate text-gray-900">
+            {room.challengeTitle}
+          </Text>
+          {room.myRole === 'HOST' ? (
+            <RoomChip label="HOST" tone="host" />
+          ) : null}
+          <StateChip room={room} />
+        </div>
+        <div className="flex min-w-0 items-center gap-1">
+          <PreviewIcon room={room} />
+          <Text size="caption2" className="truncate text-gray-600">
+            {roomPreview(room)}
+          </Text>
+        </div>
+      </div>
+
+      {/* 오른쪽 요소는 한 축에 모은다 — 안읽음 뱃지와 종이 따로 놀면
+          행마다 눈이 흔들린다. */}
+      <div className="z-[1] flex shrink-0 flex-col items-end gap-1.5">
+        <Text size="caption4" className="pointer-events-none text-gray-400">
+          {room.lastMessage ? formatRoomTime(room.lastMessage.createdAt) : ''}
+        </Text>
+        <div className="flex items-center gap-1.5">
+          {unread > 0 ? (
+            <span
+              className={cn(
+                'bg-main-600 pointer-events-none inline-flex min-w-5',
+                'items-center justify-center rounded-full px-1.5 py-0.5',
+                'text-[10px] leading-4 font-extrabold text-white'
+              )}
+            >
+              {unread > 99 ? '99+' : unread}
+            </span>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => onToggleNotification(room)}
+            aria-label={room.pushEnabled ? '알림 끄기' : '알림 켜기'}
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-full',
+              'transition-colors hover:bg-white/70',
+              room.pushEnabled ? 'text-gray-500' : 'text-gray-400'
+            )}
+          >
+            <BellIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/chat/components/ChatRoomThumbnail.tsx
+++ b/src/app.feature/chat/components/ChatRoomThumbnail.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { Stripe } from '@1d1s/design-system';
+import { CategoryIcon, getCategoryStripeTone } from '@constants/categories';
+import { cn } from '@module/utils/cn';
+import { resolveDiaryImageUrl } from '@module/utils/diaryImageUrl';
+import { BookOpen, Flag } from 'lucide-react';
+import React from 'react';
+
+interface ChatRoomThumbnailProps {
+  url?: string | null;
+  /** 챌린지면 그 카테고리. 일지는 비운다 — 소속 챌린지 카테고리를 빌려 쓰면
+   *  "이 일지의 카테고리" 로 읽혀 혼동된다. */
+  category?: string | null;
+  /** 카테고리가 없을 때 그릴 아이콘. 챌린지·채팅방은 깃발, 일지는 책. */
+  fallback?: 'challenge' | 'diary';
+  className?: string;
+}
+
+/**
+ * 목록·공유 카드가 함께 쓰는 썸네일. 대표 이미지가 없으면 카테고리 기본
+ * 그림(줄무늬 + 카테고리 아이콘)을 채운다 — 에셋이 아니라 그리는 것이다.
+ *
+ * 챌린지 대표 이미지는 3:2 라 정사각에 넣으면 좌우가 잘려 답답하다.
+ * 비율은 호출부가 className 으로 준다.
+ */
+export function ChatRoomThumbnail({
+  url,
+  category,
+  fallback = 'challenge',
+  className,
+}: ChatRoomThumbnailProps): React.ReactElement {
+  const resolved = resolveDiaryImageUrl(url);
+  const FallbackIcon = fallback === 'diary' ? BookOpen : Flag;
+  const wrapper = cn(
+    'relative shrink-0 overflow-hidden rounded-[10px] bg-gray-100',
+    className
+  );
+
+  if (resolved) {
+    return (
+      <div className={wrapper}>
+        {/* eslint-disable-next-line @next/next/no-img-element -- S3 호스트가
+            환경마다 달라 next/image remotePatterns 로 고정할 수 없다. */}
+        <img
+          src={resolved}
+          alt=""
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={wrapper}>
+      <Stripe
+        tone={
+          category ? getCategoryStripeTone(category) : 'var(--color-main-300)'
+        }
+        className="absolute inset-0"
+      />
+      <div className="absolute inset-0 flex items-center justify-center">
+        {category ? (
+          <CategoryIcon category={category} className="h-4 w-4 text-white" />
+        ) : (
+          <FallbackIcon className="h-4 w-4 text-white" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app.feature/chat/components/ChatShareCard.tsx
+++ b/src/app.feature/chat/components/ChatShareCard.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { resolveDiaryImageUrl } from '@module/utils/diaryImageUrl';
+import { BookOpen, Flag, Youtube } from 'lucide-react';
+import Link from 'next/link';
+import React from 'react';
+
+import { ChatLinkPreview, ChatMessage, chatSharePath } from '../type/chat';
+import { ChatRoomThumbnail } from './ChatRoomThumbnail';
+
+// 공유 카드와 링크 미리보기의 폭. 둘이 제각각이면 말풍선 줄이 들쭉날쭉해
+// 보인다 — 한 값을 같이 쓴다.
+const CARD_CLASS = 'w-[232px] overflow-hidden rounded-[10px] border';
+
+/**
+ * 공유 카드. 볼 수 없는 대상이면 눌리지 않는다 — 보낼 땐 공개였던 일지가
+ * 나중에 비공개로 바뀌면 서버가 available=false 로 내려준다.
+ */
+export function ChatShareCard({
+  message,
+}: {
+  message: ChatMessage;
+}): React.ReactElement {
+  const share = message.share;
+  const path = chatSharePath(message);
+  const isDiary = message.type === 'DIARY_SHARE';
+  const available = share?.available ?? false;
+  const TypeIcon = isDiary ? BookOpen : Flag;
+
+  const body = (
+    <>
+      {/* 대표 이미지가 없는 일지도 있다 — 빈칸 대신 자리를 지킨다. */}
+      {available ? (
+        <ChatRoomThumbnail
+          url={share?.thumbnailUrl}
+          category={share?.category}
+          fallback={isDiary ? 'diary' : 'challenge'}
+          className="h-[116px] w-full rounded-none"
+        />
+      ) : null}
+      <div className="flex flex-col gap-1 p-2.5">
+        <div className="text-main-700 flex items-center gap-1">
+          <TypeIcon className="h-3 w-3" />
+          <Text size="caption4" weight="extrabold" className="text-inherit">
+            {isDiary ? '일지' : '챌린지'}
+          </Text>
+        </div>
+        <Text
+          size="caption2"
+          weight="bold"
+          className={cn(
+            'line-clamp-2',
+            available ? 'text-gray-900' : 'text-gray-500'
+          )}
+        >
+          {/* share 자체가 안 온 것과 "볼 권한이 없다" 는 다르다. 앞의 것을
+              "볼 수 없는 게시물" 로 단정하면 멀쩡한 내 일지가 그렇게 보인다. */}
+          {!share
+            ? isDiary
+              ? '일지'
+              : '챌린지'
+            : available
+              ? (share.title ?? '')
+              : '볼 수 없는 게시물이에요'}
+        </Text>
+        {available && share?.subtitle ? (
+          <Text size="caption3" className="truncate text-gray-500">
+            {share.subtitle}
+          </Text>
+        ) : null}
+      </div>
+    </>
+  );
+
+  const className = cn(CARD_CLASS, 'border-gray-200 bg-white text-left');
+  if (!path) {
+    return <div className={className}>{body}</div>;
+  }
+  return (
+    <Link
+      href={path}
+      className={cn(className, 'block transition-colors hover:bg-gray-50')}
+      onClick={(event) => event.stopPropagation()}
+    >
+      {body}
+    </Link>
+  );
+}
+
+/** 링크 미리보기. 탭하면 본문 링크와 같은 방식으로 연다. */
+export function ChatLinkPreviewCard({
+  preview,
+}: {
+  preview: ChatLinkPreview;
+}): React.ReactElement {
+  const image = resolveDiaryImageUrl(preview.imageUrl);
+  const siteName = preview.siteName ?? '';
+  // 유튜브 표시는 **배지에만** 빨강을 쓴다. 글씨나 테두리를 칠하지 않는다.
+  const isYoutube = siteName.toLowerCase() === 'youtube';
+
+  return (
+    <a
+      href={preview.url}
+      target="_blank"
+      rel="noreferrer noopener"
+      onClick={(event) => event.stopPropagation()}
+      className={cn(
+        CARD_CLASS,
+        'block border-gray-200 bg-white transition-colors hover:bg-gray-50'
+      )}
+    >
+      {image ? (
+        // 외부 OG 이미지라 next/image remotePatterns 로 호스트를 고정할 수 없다.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={image}
+          alt=""
+          loading="lazy"
+          className="h-[116px] w-full object-cover"
+        />
+      ) : null}
+      <div className="flex flex-col gap-1 p-2.5">
+        {siteName ? (
+          isYoutube ? (
+            <span
+              className={cn(
+                'inline-flex w-fit items-center gap-1 rounded px-1.5',
+                'bg-[#ff0000] py-0.5 text-white'
+              )}
+            >
+              <Youtube className="h-3 w-3" />
+              <Text size="caption4" weight="extrabold" className="text-inherit">
+                {siteName}
+              </Text>
+            </span>
+          ) : (
+            <Text size="caption4" weight="extrabold" className="text-gray-500">
+              {siteName}
+            </Text>
+          )
+        ) : null}
+        {preview.title ? (
+          <Text size="caption2" weight="bold" className="line-clamp-2 text-gray-900">
+            {preview.title}
+          </Text>
+        ) : null}
+        {preview.description ? (
+          <Text size="caption3" className="line-clamp-2 text-gray-500">
+            {preview.description}
+          </Text>
+        ) : null}
+      </div>
+    </a>
+  );
+}
+
+/** 보여 줄 게 있는가. url 뿐이면 본문 링크와 다를 바 없다. */
+export function hasLinkPreviewContent(
+  preview?: ChatLinkPreview | null
+): boolean {
+  return Boolean(preview && (preview.title || preview.imageUrl));
+}

--- a/src/app.feature/chat/components/ChatSharePickerSheet.tsx
+++ b/src/app.feature/chat/components/ChatSharePickerSheet.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import {
+  BottomSheet,
+  BottomSheetContent,
+  BottomSheetTitle,
+  Text,
+} from '@1d1s/design-system';
+import { useMyDiariesInfinite } from '@feature/diary/board/hooks/useDiaryQueries';
+import { useSidebar } from '@feature/member/hooks/useMemberQueries';
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+import { ChatShareResolution } from '../type/chat';
+import { ChatRoomThumbnail } from './ChatRoomThumbnail';
+
+/**
+ * 공유할 대상 고르기.
+ *
+ * ponytail: 챌린지는 **내가 참여 중인 것**만 고른다 — 사이드바 응답이 이미
+ * 그 목록을 싣고 있어 추가 요청이 없다. 앱에는 전체 챌린지 검색 탭도 있지만,
+ * 웹에서는 챌린지 링크를 그대로 붙여넣으면 서버 판정(/chat/shares/resolve)이
+ * 같은 카드를 만들어 주므로 임의 챌린지도 보낼 수 있다. 검색 탭이 실제로
+ * 아쉬워지면 그때 붙인다.
+ */
+function PickerRow({
+  title,
+  subtitle,
+  thumbnailUrl,
+  category,
+  kind,
+  onSelect,
+}: {
+  title: string;
+  subtitle?: string;
+  thumbnailUrl?: string | null;
+  category?: string | null;
+  kind: 'challenge' | 'diary';
+  onSelect(): void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-xl px-1 py-2.5 text-left',
+        'transition-colors hover:bg-gray-50'
+      )}
+    >
+      <ChatRoomThumbnail
+        url={thumbnailUrl}
+        category={category}
+        fallback={kind === 'diary' ? 'diary' : 'challenge'}
+        className="h-10 w-[60px]"
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Text size="caption1" weight="bold" className="truncate text-gray-900">
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text size="caption3" className="truncate text-gray-500">
+            {subtitle}
+          </Text>
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+interface ChatSharePickerSheetProps {
+  kind: 'challenge' | 'diary' | null;
+  onOpenChange(open: boolean): void;
+  onSelect(share: ChatShareResolution): void;
+}
+
+export function ChatSharePickerSheet({
+  kind,
+  onOpenChange,
+  onSelect,
+}: ChatSharePickerSheetProps): React.ReactElement {
+  const { data: sidebar } = useSidebar();
+  const { data: diaryPages, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useMyDiariesInfinite(20);
+
+  const challenges = sidebar?.challengeList ?? [];
+  const diaries = diaryPages?.pages.flatMap((page) => page.items) ?? [];
+  const isChallenge = kind === 'challenge';
+  const empty = isChallenge ? challenges.length === 0 : diaries.length === 0;
+
+  const choose = (
+    type: 'CHALLENGE_SHARE' | 'DIARY_SHARE',
+    targetId: number,
+    title: string,
+    thumbnailUrl?: string | null,
+    category?: string | null
+  ): void => {
+    onOpenChange(false);
+    onSelect({
+      shareable: true,
+      type,
+      targetId,
+      share: {
+        targetId,
+        title,
+        subtitle: null,
+        thumbnailUrl: thumbnailUrl ?? null,
+        category: category ?? null,
+        available: true,
+      },
+    });
+  };
+
+  return (
+    <BottomSheet open={Boolean(kind)} onOpenChange={onOpenChange}>
+      <BottomSheetContent className="px-5 pb-3">
+        <BottomSheetTitle>
+          <Text size="body1" weight="bold" className="text-gray-900">
+            {isChallenge ? '챌린지 공유' : '일지 공유'}
+          </Text>
+        </BottomSheetTitle>
+        <div className="max-h-[55vh] overflow-y-auto pt-2">
+          {empty ? (
+            <div className="py-12 text-center">
+              <Text size="body2" className="text-gray-500">
+                {isChallenge
+                  ? '참여 중인 챌린지가 없어요.'
+                  : '작성한 일지가 없어요.'}
+              </Text>
+            </div>
+          ) : isChallenge ? (
+            challenges.map((challenge) => (
+              <PickerRow
+                key={challenge.challengeId}
+                kind="challenge"
+                title={challenge.title}
+                thumbnailUrl={challenge.thumbnailImage}
+                category={challenge.category}
+                onSelect={() =>
+                  choose(
+                    'CHALLENGE_SHARE',
+                    challenge.challengeId,
+                    challenge.title,
+                    challenge.thumbnailImage,
+                    challenge.category
+                  )
+                }
+              />
+            ))
+          ) : (
+            <>
+              {diaries.map((diary) => (
+                <PickerRow
+                  key={diary.id}
+                  kind="diary"
+                  title={diary.title}
+                  subtitle={diary.challenge?.title}
+                  thumbnailUrl={diary.thumbnailUrl}
+                  onSelect={() =>
+                    choose(
+                      'DIARY_SHARE',
+                      diary.id,
+                      diary.title,
+                      diary.thumbnailUrl
+                    )
+                  }
+                />
+              ))}
+              {hasNextPage ? (
+                <button
+                  type="button"
+                  disabled={isFetchingNextPage}
+                  onClick={() => fetchNextPage()}
+                  className="w-full py-3 text-gray-500"
+                >
+                  <Text size="caption2" className="text-inherit">
+                    {isFetchingNextPage ? '불러오는 중…' : '더 보기'}
+                  </Text>
+                </button>
+              ) : null}
+            </>
+          )}
+        </div>
+      </BottomSheetContent>
+    </BottomSheet>
+  );
+}

--- a/src/app.feature/chat/components/ChatSheets.tsx
+++ b/src/app.feature/chat/components/ChatSheets.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import {
+  BottomSheet,
+  BottomSheetContent,
+  BottomSheetTitle,
+  Text,
+} from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import {
+  BookOpen,
+  Copy,
+  Flag,
+  ImageIcon,
+  Pin,
+  PinOff,
+  SquareArrowOutUpRight,
+} from 'lucide-react';
+import React from 'react';
+
+export type ChatShareKind = 'photo' | 'challenge' | 'diary';
+
+function SheetRow({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick(): void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-3.5 rounded-xl px-1 py-3.5',
+        'text-left transition-colors hover:bg-gray-50'
+      )}
+    >
+      <span className="text-gray-700">{icon}</span>
+      <Text size="body2" weight="medium" className="text-gray-900">
+        {label}
+      </Text>
+    </button>
+  );
+}
+
+function Sheet({
+  open,
+  onOpenChange,
+  title,
+  children,
+}: {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  title: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <BottomSheet open={open} onOpenChange={onOpenChange}>
+      <BottomSheetContent className="px-5 pb-3">
+        <BottomSheetTitle className="sr-only">{title}</BottomSheetTitle>
+        <div className="flex flex-col">{children}</div>
+      </BottomSheetContent>
+    </BottomSheet>
+  );
+}
+
+/** + 버튼 — 무엇을 붙일지 먼저 고른다. */
+export function ChatShareMenuSheet({
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  onSelect(kind: ChatShareKind): void;
+}): React.ReactElement {
+  const pick = (kind: ChatShareKind) => (): void => {
+    onOpenChange(false);
+    onSelect(kind);
+  };
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange} title="보낼 것 고르기">
+      <SheetRow
+        icon={<ImageIcon className="h-5 w-5" />}
+        label="사진"
+        onClick={pick('photo')}
+      />
+      <SheetRow
+        icon={<Flag className="h-5 w-5" />}
+        label="챌린지 공유"
+        onClick={pick('challenge')}
+      />
+      <SheetRow
+        icon={<BookOpen className="h-5 w-5" />}
+        label="일지 공유"
+        onClick={pick('diary')}
+      />
+    </Sheet>
+  );
+}
+
+/** 헤더 더보기 메뉴. 챌린지가 끝났어도 상세는 볼 수 있다. */
+export function ChatRoomMenuSheet({
+  open,
+  onOpenChange,
+  onOpenChallenge,
+}: {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  onOpenChallenge(): void;
+}): React.ReactElement {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange} title="채팅방 메뉴">
+      <SheetRow
+        icon={<SquareArrowOutUpRight className="h-5 w-5" />}
+        label="챌린지 상세 보기"
+        onClick={() => {
+          onOpenChange(false);
+          onOpenChallenge();
+        }}
+      />
+    </Sheet>
+  );
+}
+
+export interface ChatMessageActionsState {
+  /** 복사할 글. 없으면 복사 항목을 안 그린다. */
+  text: string;
+  /** 호스트만 공지를 걸고 푼다(서버도 403 CHAT-009 로 막는다). */
+  canEditNotice: boolean;
+  isNotice: boolean;
+}
+
+/** 말풍선 롱프레스·우클릭 메뉴. */
+export function ChatMessageActionsSheet({
+  state,
+  onOpenChange,
+  onCopy,
+  onToggleNotice,
+}: {
+  state: ChatMessageActionsState | null;
+  onOpenChange(open: boolean): void;
+  onCopy(text: string): void;
+  onToggleNotice(isNotice: boolean): void;
+}): React.ReactElement {
+  const NoticeIcon = state?.isNotice ? PinOff : Pin;
+  return (
+    <Sheet
+      open={Boolean(state)}
+      onOpenChange={onOpenChange}
+      title="메시지 메뉴"
+    >
+      {state?.text ? (
+        <SheetRow
+          icon={<Copy className="h-5 w-5" />}
+          label="복사"
+          onClick={() => {
+            onOpenChange(false);
+            onCopy(state.text);
+          }}
+        />
+      ) : null}
+      {state?.canEditNotice ? (
+        <SheetRow
+          icon={<NoticeIcon className="h-5 w-5" />}
+          label={state.isNotice ? '공지 해제' : '공지로 지정'}
+          onClick={() => {
+            onOpenChange(false);
+            onToggleNotice(state.isNotice);
+          }}
+        />
+      ) : null}
+    </Sheet>
+  );
+}

--- a/src/app.feature/chat/components/ChatTopBanners.tsx
+++ b/src/app.feature/chat/components/ChatTopBanners.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import { ChevronDown, ChevronRight, ChevronUp, PartyPopper, X } from 'lucide-react';
+import Link from 'next/link';
+import React, { useState } from 'react';
+
+import { ChatMessage } from '../type/chat';
+import { ChatBubbleBody } from './ChatMessageBubble';
+
+/**
+ * 채팅방 상단 배너들의 공통 껍데기. 화면 폭에 꽉 붙는 띠가 아니라 **떠 있는
+ * 카드**다 — 좌우·위 여백, 큰 라운드. 그림자 대신 한 톤 진한 테두리로
+ * 구분한다(배경이 옅은 브랜드 톤이라 회색 보더는 겉돈다).
+ */
+function BannerCard({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick?(): void;
+}): React.ReactElement {
+  const className = cn(
+    'border-main-300 mx-3 mt-2.5 mb-0.5 overflow-hidden rounded-2xl',
+    'border bg-[#fff4e5] text-left'
+  );
+  if (!onClick) {
+    return <div className={className}>{children}</div>;
+  }
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick();
+        }
+      }}
+      className={cn(className, 'cursor-pointer')}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** 배너 앞머리 태그 — [공지] / [미디어]. */
+function NoticeTag({
+  label,
+  brand = false,
+}: {
+  label: string;
+  brand?: boolean;
+}): React.ReactElement {
+  return (
+    <span
+      className={cn(
+        'shrink-0 rounded-full px-1.5 py-px text-[10px] leading-5',
+        'font-extrabold',
+        brand
+          ? 'bg-main-600 text-white'
+          : 'border border-gray-200 bg-white text-gray-600'
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface ChatNoticeBannerProps {
+  notice: ChatMessage;
+  /** 호스트에게만 해제 버튼을 준다. */
+  canEdit: boolean;
+  onClear(): void;
+  /** 원본이 이미 화면에 있으면 그리로 보낸다. 없으면 버튼을 안 그린다. */
+  onJumpToOrigin?(): void;
+}
+
+/** 방 상단 고정 공지. */
+export function ChatNoticeBanner({
+  notice,
+  canEdit,
+  onClear,
+  onJumpToOrigin,
+}: ChatNoticeBannerProps): React.ReactElement {
+  const [expanded, setExpanded] = useState(false);
+  const text = notice.content?.trim() ?? '';
+  // 사진이든 공유 카드든 "글 말고 뭔가 더 있다" 는 표시가 필요하다.
+  const hasMedia =
+    notice.type === 'IMAGE' ||
+    notice.type === 'CHALLENGE_SHARE' ||
+    notice.type === 'DIARY_SHARE';
+  const Chevron = expanded ? ChevronUp : ChevronDown;
+
+  return (
+    <BannerCard onClick={() => setExpanded((value) => !value)}>
+      <div
+        className={cn(
+          'flex gap-1.5 px-3.5 py-3',
+          expanded ? 'items-start' : 'items-center'
+        )}
+      >
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <NoticeTag label="공지" brand />
+            {hasMedia ? <NoticeTag label="미디어" /> : null}
+            {text && !expanded ? (
+              <Text size="caption2" className="truncate text-gray-800">
+                {text.replace(/\n/g, ' ')}
+              </Text>
+            ) : null}
+          </div>
+          {expanded ? (
+            <>
+              <Text size="caption3" weight="bold" className="text-gray-500">
+                {notice.senderNickname}
+              </Text>
+              {/* 미디어 공지는 본문 렌더가 캡션까지 그린다 — 여기서 또
+                  그리면 같은 글이 두 번 나온다. */}
+              {hasMedia ? (
+                <div className="pt-1">
+                  <ChatBubbleBody message={notice} isMine={false} />
+                </div>
+              ) : text ? (
+                <Text
+                  size="caption2"
+                  className="whitespace-pre-wrap text-gray-800"
+                >
+                  {text}
+                </Text>
+              ) : null}
+              {onJumpToOrigin ? (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onJumpToOrigin();
+                  }}
+                  className="text-main-700 flex w-fit items-center gap-0.5 pt-1"
+                >
+                  <Text size="caption3" weight="bold" className="text-inherit">
+                    원본 보기
+                  </Text>
+                  <ChevronRight className="h-3 w-3" />
+                </button>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+        <Chevron className="mt-1 h-3.5 w-3.5 shrink-0 text-gray-500" />
+        {canEdit ? (
+          <button
+            type="button"
+            aria-label="공지 해제"
+            onClick={(event) => {
+              event.stopPropagation();
+              onClear();
+            }}
+            className="flex h-7 w-7 shrink-0 items-center justify-center"
+          >
+            <X className="h-3.5 w-3.5 text-gray-600" />
+          </button>
+        ) : null}
+      </div>
+    </BannerCard>
+  );
+}
+
+/**
+ * 종료된 챌린지 안내. 종료돼도 방은 그대로 쓴다 — 입력창을 잠그지 않는다.
+ * 대신 한 번 권하고, 접거나 아주 끄면 물러난다.
+ */
+export function ChatEndedBanner({
+  onDismiss,
+}: {
+  onDismiss(): void;
+}): React.ReactElement {
+  const [collapsed, setCollapsed] = useState(false);
+  const Chevron = collapsed ? ChevronDown : ChevronUp;
+
+  return (
+    <BannerCard>
+      <div
+        className={cn(
+          'flex gap-2 px-3.5 py-3',
+          collapsed ? 'items-center' : 'items-start'
+        )}
+      >
+        <PartyPopper className="text-main-600 mt-0.5 h-3.5 w-3.5 shrink-0" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <Text size="caption2" weight="bold" className="truncate text-gray-800">
+            챌린지가 종료되었습니다!
+          </Text>
+          {!collapsed ? (
+            <>
+              <Text size="caption3" className="text-gray-600">
+                새로운 챌린지를 진행해보는건 어떠신가요?
+              </Text>
+              <div className="flex items-center gap-2 pt-2">
+                <Link
+                  href="/challenge"
+                  className={cn(
+                    'bg-main-600 rounded-lg px-2.5 py-1.5 text-white'
+                  )}
+                >
+                  <Text size="caption4" weight="extrabold" className="text-inherit">
+                    챌린지 둘러보기
+                  </Text>
+                </Link>
+                <button
+                  type="button"
+                  onClick={onDismiss}
+                  className={cn(
+                    'rounded-lg border border-gray-200 bg-white px-2.5 py-1.5',
+                    'text-gray-700'
+                  )}
+                >
+                  <Text size="caption4" weight="extrabold" className="text-inherit">
+                    다시 보지 않기
+                  </Text>
+                </button>
+              </div>
+            </>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          aria-label={collapsed ? '펼치기' : '접기'}
+          onClick={() => setCollapsed((value) => !value)}
+          className="flex h-7 w-7 shrink-0 items-center justify-center"
+        >
+          <Chevron className="h-3.5 w-3.5 text-gray-500" />
+        </button>
+      </div>
+    </BannerCard>
+  );
+}
+
+/**
+ * 구독이 거절된 상태 안내. **재접속 트리거가 아니다** — 서버는 구독만 막고
+ * 세션은 살려 두므로, 여기서 재연결하면 거절 루프가 무한히 돈다.
+ */
+export function ChatNoticeMessageBanner({
+  text,
+}: {
+  text: string;
+}): React.ReactElement {
+  return (
+    <BannerCard>
+      <div className="px-3.5 py-2.5">
+        <Text size="caption2" className="text-gray-800">
+          {text}
+        </Text>
+      </div>
+    </BannerCard>
+  );
+}

--- a/src/app.feature/chat/components/ChatTopBanners.tsx
+++ b/src/app.feature/chat/components/ChatTopBanners.tsx
@@ -2,7 +2,14 @@
 
 import { Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
-import { ChevronDown, ChevronRight, ChevronUp, PartyPopper, X } from 'lucide-react';
+import {
+  Archive,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  PartyPopper,
+  X,
+} from 'lucide-react';
 import Link from 'next/link';
 import React, { useState } from 'react';
 
@@ -169,13 +176,17 @@ export function ChatNoticeBanner({
 }
 
 /**
- * 종료된 챌린지 안내. 종료돼도 방은 그대로 쓴다 — 입력창을 잠그지 않는다.
- * 대신 한 번 권하고, 접거나 아주 끄면 물러난다.
+ * 종료된 챌린지 안내. 종료돼도 방은 **일주일 더** 그대로 쓴다 — 그동안은
+ * 입력창을 잠그지 않는다. 대신 언제까지 쓸 수 있는지 알리고, 접거나 아주
+ * 끄면 물러난다.
  */
 export function ChatEndedBanner({
   onDismiss,
+  /** 전송이 막히기까지 남은 기간("6일"·"3시간"). 서버가 안 주면 생략. */
+  closesIn,
 }: {
   onDismiss(): void;
+  closesIn?: string | null;
 }): React.ReactElement {
   const [collapsed, setCollapsed] = useState(false);
   const Chevron = collapsed ? ChevronDown : ChevronUp;
@@ -195,6 +206,11 @@ export function ChatEndedBanner({
           </Text>
           {!collapsed ? (
             <>
+              <Text size="caption3" className="text-gray-600">
+                {closesIn
+                  ? `채팅방은 ${closesIn} 뒤 보관돼요. 그 뒤로는 메시지를 보낼 수 없고 지난 대화만 볼 수 있어요.`
+                  : '채팅방은 종료 후 일주일간 유지돼요. 그 뒤로는 메시지를 보낼 수 없고 지난 대화만 볼 수 있어요.'}
+              </Text>
               <Text size="caption3" className="text-gray-600">
                 새로운 챌린지를 진행해보는건 어떠신가요?
               </Text>
@@ -233,6 +249,31 @@ export function ChatEndedBanner({
         >
           <Chevron className="h-3.5 w-3.5 text-gray-500" />
         </button>
+      </div>
+    </BannerCard>
+  );
+}
+
+/**
+ * 보관된 방 안내. 종료 후 일주일이 지나 전송이 잠긴 상태다.
+ *
+ * 종료 배너와 달리 끌 수 없다 — 왜 입력창이 잠겼는지 설명하는 유일한
+ * 자리라, 끄면 사용자는 고장으로 읽는다.
+ */
+export function ChatArchivedBanner(): React.ReactElement {
+  return (
+    <BannerCard>
+      <div className="flex items-start gap-2 px-3.5 py-3">
+        <Archive className="mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-500" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <Text size="caption2" weight="bold" className="text-gray-800">
+            보관된 채팅방이에요
+          </Text>
+          <Text size="caption3" className="text-gray-600">
+            챌린지 종료 후 일주일이 지나 더는 메시지를 보낼 수 없어요. 지난
+            대화는 계속 볼 수 있어요.
+          </Text>
+        </div>
       </div>
     </BannerCard>
   );

--- a/src/app.feature/chat/consts/queryKeys.ts
+++ b/src/app.feature/chat/consts/queryKeys.ts
@@ -1,6 +1,10 @@
 export const CHAT_QUERY_KEYS = {
   all: ['chat'] as const,
+  // 목록은 archived 필터별로 따로 캐시한다. 읽음·알림 토글 뒤 무효화는
+  // rooms() 프리픽스로 걸어 세 갈래를 한 번에 턴다.
   rooms: () => [...CHAT_QUERY_KEYS.all, 'rooms'] as const,
+  roomList: (archived?: boolean) =>
+    [...CHAT_QUERY_KEYS.rooms(), archived ?? 'all'] as const,
   messages: (roomId: number) =>
     [...CHAT_QUERY_KEYS.all, 'messages', roomId] as const,
 };

--- a/src/app.feature/chat/consts/queryKeys.ts
+++ b/src/app.feature/chat/consts/queryKeys.ts
@@ -1,0 +1,9 @@
+export const CHAT_QUERY_KEYS = {
+  all: ['chat'] as const,
+  rooms: () => [...CHAT_QUERY_KEYS.all, 'rooms'] as const,
+  messages: (roomId: number) =>
+    [...CHAT_QUERY_KEYS.all, 'messages', roomId] as const,
+};
+
+/** 내역 한 페이지 크기. 앱과 같은 값(ChatApi.fetchMessages 기본 size). */
+export const CHAT_PAGE_SIZE = 30;

--- a/src/app.feature/chat/hooks/chatCache.test.ts
+++ b/src/app.feature/chat/hooks/chatCache.test.ts
@@ -1,0 +1,118 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import { CHAT_QUERY_KEYS } from '../consts/queryKeys';
+import { ChatMessage, ChatMessagePage } from '../type/chat';
+import { chatShareLinkIn, trimUrlTail } from '../utils/chatShareLink';
+import { mergeLatestMessages, upsertChatMessage } from './chatCache';
+
+const ROOM_ID = 7;
+
+function message(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: 0,
+    roomId: ROOM_ID,
+    senderId: 1,
+    senderNickname: '나',
+    clientMessageId: null,
+    type: 'TEXT',
+    content: '안녕',
+    imageUrl: null,
+    status: 'ACTIVE',
+    createdAt: '2026-08-17T10:00:00',
+    ...overrides,
+  };
+}
+
+function seed(items: ChatMessage[]): QueryClient {
+  const client = new QueryClient();
+  client.setQueryData(CHAT_QUERY_KEYS.messages(ROOM_ID), {
+    pages: [{ items, pageInfo: { hasNextPage: false } }],
+    pageParams: [null],
+  });
+  return client;
+}
+
+function read(client: QueryClient): ChatMessage[] {
+  const cache = client.getQueryData<{ pages: ChatMessagePage[] }>(
+    CHAT_QUERY_KEYS.messages(ROOM_ID)
+  );
+  return cache?.pages.flatMap((page) => page.items) ?? [];
+}
+
+describe('upsertChatMessage', () => {
+  it('같은 clientMessageId 의 낙관적 말풍선을 확정본으로 교체한다', () => {
+    const client = seed([
+      message({ id: 0, clientMessageId: 'abc', pending: true }),
+    ]);
+
+    upsertChatMessage(
+      client,
+      ROOM_ID,
+      message({ id: 91, clientMessageId: 'abc' })
+    );
+
+    const items = read(client);
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe(91);
+    expect(items[0].pending).toBeUndefined();
+  });
+
+  it('REST 응답과 브로드캐스트가 겹쳐도 같은 id 를 두 번 넣지 않는다', () => {
+    const client = seed([message({ id: 91, clientMessageId: 'abc' })]);
+
+    upsertChatMessage(
+      client,
+      ROOM_ID,
+      message({ id: 91, clientMessageId: 'abc' })
+    );
+
+    expect(read(client)).toHaveLength(1);
+  });
+
+  it('새 메시지는 맨 앞(최신)에 붙인다', () => {
+    const client = seed([message({ id: 10 })]);
+
+    upsertChatMessage(client, ROOM_ID, message({ id: 11 }));
+
+    expect(read(client).map((item) => item.id)).toEqual([11, 10]);
+  });
+});
+
+describe('mergeLatestMessages', () => {
+  it('끊긴 동안 온 것만 끼워 넣고 최신순을 유지한다', () => {
+    const client = seed([
+      message({ id: 10, createdAt: '2026-08-17T10:00:00' }),
+    ]);
+
+    mergeLatestMessages(client, ROOM_ID, [
+      message({ id: 12, createdAt: '2026-08-17T10:02:00' }),
+      message({ id: 10, createdAt: '2026-08-17T10:00:00' }),
+      message({ id: 11, createdAt: '2026-08-17T10:01:00' }),
+    ]);
+
+    expect(read(client).map((item) => item.id)).toEqual([12, 11, 10]);
+  });
+});
+
+describe('chatShareLinkIn', () => {
+  it('통째로 우리 공유 링크 하나일 때만 알아본다', () => {
+    expect(chatShareLinkIn('https://1day1streak.com/challenge/12')).toBe(
+      'https://1day1streak.com/challenge/12'
+    );
+    expect(chatShareLinkIn('https://dev.1day1streak.com/diary/3')).toBe(
+      'https://dev.1day1streak.com/diary/3'
+    );
+    // 글 중간에 섞인 링크는 건드리지 않는다 — 하고 싶던 말이 사라진다.
+    expect(chatShareLinkIn('이거 봐 https://1day1streak.com/diary/3')).toBeNull();
+    expect(chatShareLinkIn('https://1day1streak.com/mypage')).toBeNull();
+    expect(chatShareLinkIn('https://example.com/challenge/12')).toBeNull();
+  });
+});
+
+describe('trimUrlTail', () => {
+  it('주소 끝에 붙은 문장부호를 떼되 짝지은 괄호는 남긴다', () => {
+    expect(trimUrlTail('https://a.com/x.')).toBe('https://a.com/x');
+    expect(trimUrlTail('https://a.com/x(y)')).toBe('https://a.com/x(y)');
+  });
+});

--- a/src/app.feature/chat/hooks/chatCache.ts
+++ b/src/app.feature/chat/hooks/chatCache.ts
@@ -1,0 +1,182 @@
+import { InfiniteData, QueryClient } from '@tanstack/react-query';
+
+import { CHAT_QUERY_KEYS } from '../consts/queryKeys';
+import { ChatLinkPreview, ChatMessage, ChatMessagePage } from '../type/chat';
+
+type MessageCache = InfiniteData<ChatMessagePage> | undefined;
+
+/** 내역은 최신순이라 page 0 의 맨 앞이 가장 새 메시지다. */
+function mapPages(
+  cache: MessageCache,
+  map: (items: ChatMessage[], pageIndex: number) => ChatMessage[]
+): MessageCache {
+  if (!cache) {
+    return cache;
+  }
+  return {
+    ...cache,
+    pages: cache.pages.map((page, index) => ({
+      ...page,
+      items: map(page.items, index),
+    })),
+  };
+}
+
+function forEachMessage(
+  cache: MessageCache,
+  visit: (message: ChatMessage) => boolean
+): boolean {
+  return (cache?.pages ?? []).some((page) => page.items.some(visit));
+}
+
+function update(
+  client: QueryClient,
+  roomId: number,
+  updater: (cache: MessageCache) => MessageCache
+): void {
+  client.setQueryData<InfiniteData<ChatMessagePage>>(
+    CHAT_QUERY_KEYS.messages(roomId),
+    (cache) => updater(cache) as InfiniteData<ChatMessagePage>
+  );
+}
+
+/**
+ * 브로드캐스트·REST 응답·낙관적 말풍선이 모두 지나는 한 곳.
+ *
+ * ① 같은 clientMessageId 의 내 낙관적 말풍선이 있으면 서버 확정본으로
+ *    갈아 끼운다. ② 같은 id 가 이미 있으면(재연결 직후, REST 응답과
+ *    브로드캐스트가 겹칠 때) 넣지 않는다. ③ 그 외에는 맨 앞에 붙인다.
+ */
+export function upsertChatMessage(
+  client: QueryClient,
+  roomId: number,
+  message: ChatMessage
+): void {
+  update(client, roomId, (cache) => {
+    if (!cache) {
+      return cache;
+    }
+    const clientId = message.clientMessageId;
+    const hasPending =
+      clientId != null &&
+      forEachMessage(
+        cache,
+        (item) => item.clientMessageId === clientId && Boolean(item.pending)
+      );
+    if (hasPending) {
+      return mapPages(cache, (items) =>
+        items.map((item) =>
+          item.clientMessageId === clientId && item.pending ? message : item
+        )
+      );
+    }
+    const duplicated =
+      message.id > 0 && forEachMessage(cache, (item) => item.id === message.id);
+    if (duplicated) {
+      return cache;
+    }
+    return mapPages(cache, (items, index) =>
+      index === 0 ? [message, ...items] : items
+    );
+  });
+}
+
+/** 전송 실패 표시. 사용자가 탭해 다시 보낼 수 있다. */
+export function markChatMessageFailed(
+  client: QueryClient,
+  roomId: number,
+  clientMessageId: string
+): void {
+  update(client, roomId, (cache) =>
+    mapPages(cache, (items) =>
+      items.map((item) =>
+        item.clientMessageId === clientMessageId && item.pending
+          ? { ...item, pending: false, failed: true }
+          : item
+      )
+    )
+  );
+}
+
+/** 재전송 시작 — 실패 표시를 걷고 다시 보내는 중으로 되돌린다. */
+export function markChatMessagePending(
+  client: QueryClient,
+  roomId: number,
+  clientMessageId: string
+): void {
+  update(client, roomId, (cache) =>
+    mapPages(cache, (items) =>
+      items.map((item) =>
+        item.clientMessageId === clientMessageId
+          ? { ...item, pending: true, failed: false }
+          : item
+      )
+    )
+  );
+}
+
+/** 링크 프리뷰가 뒤늦게 왔다 — 그 말풍선만 갈아 끼운다. */
+export function applyChatLinkPreview(
+  client: QueryClient,
+  roomId: number,
+  messageId: number,
+  linkPreview: ChatLinkPreview
+): void {
+  update(client, roomId, (cache) =>
+    mapPages(cache, (items) =>
+      items.map((item) =>
+        item.id === messageId ? { ...item, linkPreview } : item
+      )
+    )
+  );
+}
+
+/** 내역에서 그 메시지를 찾는다. 공지 본문을 세울 때 쓴다. */
+export function findChatMessage(
+  cache: MessageCache,
+  messageId: number
+): ChatMessage | null {
+  for (const page of cache?.pages ?? []) {
+    const found = page.items.find((item) => item.id === messageId);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * 끊긴 동안 온 메시지를 채운다. 토픽은 지나간 것을 다시 주지 않으므로
+ * 재연결 시 최신 페이지를 받아 **없는 것만** 끼워 넣는다. 쌓인 페이지를
+ * 통째로 다시 받지 않는다.
+ */
+export function mergeLatestMessages(
+  client: QueryClient,
+  roomId: number,
+  latest: ChatMessage[]
+): void {
+  update(client, roomId, (cache) => {
+    if (!cache) {
+      return cache;
+    }
+    const known = new Set<number>();
+    cache.pages.forEach((page) =>
+      page.items.forEach((item) => {
+        if (item.id > 0) {
+          known.add(item.id);
+        }
+      })
+    );
+    const missing = latest.filter((item) => !known.has(item.id));
+    if (missing.length === 0) {
+      return cache;
+    }
+    return mapPages(cache, (items, index) =>
+      index === 0
+        ? [...missing, ...items].sort((left, right) =>
+            right.createdAt.localeCompare(left.createdAt)
+          )
+        : items
+    );
+  });
+}

--- a/src/app.feature/chat/hooks/chatCache.ts
+++ b/src/app.feature/chat/hooks/chatCache.ts
@@ -131,20 +131,6 @@ export function applyChatLinkPreview(
   );
 }
 
-/** 내역에서 그 메시지를 찾는다. 공지 본문을 세울 때 쓴다. */
-export function findChatMessage(
-  cache: MessageCache,
-  messageId: number
-): ChatMessage | null {
-  for (const page of cache?.pages ?? []) {
-    const found = page.items.find((item) => item.id === messageId);
-    if (found) {
-      return found;
-    }
-  }
-  return null;
-}
-
 /**
  * 끊긴 동안 온 메시지를 채운다. 토픽은 지나간 것을 다시 주지 않으므로
  * 재연결 시 최신 페이지를 받아 **없는 것만** 끼워 넣는다. 쌓인 페이지를

--- a/src/app.feature/chat/hooks/useChatMutations.ts
+++ b/src/app.feature/chat/hooks/useChatMutations.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import type { UseMutationResult } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { chatApi } from '../api/chatApi';
+import { CHAT_QUERY_KEYS } from '../consts/queryKeys';
+import { ChatRoomList } from '../type/chat';
+
+/**
+ * 방별 푸시 알림 토글 — 낙관적.
+ *
+ * 목록을 invalidate 하면 리스트 전체가 다시 그려지며 페이드가 걸린다. 종
+ * 하나 눌렀을 뿐인데 화면이 깜빡이므로, 캐시의 그 방만 갈아 끼우고
+ * 실패했을 때만 되돌린다.
+ */
+export function useToggleChatPush(): UseMutationResult<
+  void,
+  Error,
+  { roomId: number; enabled: boolean },
+  { previous?: ChatRoomList }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ roomId, enabled }) =>
+      chatApi.setNotifications(roomId, enabled),
+    onMutate: async ({ roomId, enabled }) => {
+      await queryClient.cancelQueries({ queryKey: CHAT_QUERY_KEYS.rooms() });
+      const previous = queryClient.getQueryData<ChatRoomList>(
+        CHAT_QUERY_KEYS.rooms()
+      );
+      queryClient.setQueryData<ChatRoomList>(
+        CHAT_QUERY_KEYS.rooms(),
+        (cache) =>
+          cache && {
+            ...cache,
+            rooms: cache.rooms.map((room) =>
+              room.roomId === roomId
+                ? { ...room, pushEnabled: enabled }
+                : room
+            ),
+          }
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(CHAT_QUERY_KEYS.rooms(), context.previous);
+      }
+    },
+  });
+}
+
+/** 공지 지정 — 호스트만. 아니면 403 CHAT-009. */
+export function useSetChatNotice(): UseMutationResult<
+  void,
+  Error,
+  { roomId: number; messageId: number }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ roomId, messageId }) => chatApi.setNotice(roomId, messageId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: CHAT_QUERY_KEYS.rooms(),
+      });
+    },
+  });
+}
+
+export function useClearChatNotice(): UseMutationResult<
+  void,
+  Error,
+  { roomId: number }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ roomId }) => chatApi.clearNotice(roomId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: CHAT_QUERY_KEYS.rooms(),
+      });
+    },
+  });
+}

--- a/src/app.feature/chat/hooks/useChatMutations.ts
+++ b/src/app.feature/chat/hooks/useChatMutations.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { UseMutationResult } from '@tanstack/react-query';
+import type { QueryKey, UseMutationResult } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { chatApi } from '../api/chatApi';
@@ -18,35 +18,35 @@ export function useToggleChatPush(): UseMutationResult<
   void,
   Error,
   { roomId: number; enabled: boolean },
-  { previous?: ChatRoomList }
+  { previous: Array<[QueryKey, ChatRoomList | undefined]> }
 > {
   const queryClient = useQueryClient();
+  // 목록은 archived 필터별로 따로 캐시된다(전체·진행 중·아카이브). 한 갈래만
+  // 고치면 필터를 바꿨을 때 종이 도로 뒤집힌 것처럼 보인다 — 전부 손본다.
+  const filter = { queryKey: CHAT_QUERY_KEYS.rooms() };
   return useMutation({
     mutationFn: ({ roomId, enabled }) =>
       chatApi.setNotifications(roomId, enabled),
     onMutate: async ({ roomId, enabled }) => {
-      await queryClient.cancelQueries({ queryKey: CHAT_QUERY_KEYS.rooms() });
-      const previous = queryClient.getQueryData<ChatRoomList>(
-        CHAT_QUERY_KEYS.rooms()
-      );
-      queryClient.setQueryData<ChatRoomList>(
-        CHAT_QUERY_KEYS.rooms(),
+      await queryClient.cancelQueries(filter);
+      const previous =
+        queryClient.getQueriesData<ChatRoomList>(filter);
+      queryClient.setQueriesData<ChatRoomList>(
+        filter,
         (cache) =>
           cache && {
             ...cache,
             rooms: cache.rooms.map((room) =>
-              room.roomId === roomId
-                ? { ...room, pushEnabled: enabled }
-                : room
+              room.roomId === roomId ? { ...room, pushEnabled: enabled } : room
             ),
           }
       );
       return { previous };
     },
     onError: (_error, _variables, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(CHAT_QUERY_KEYS.rooms(), context.previous);
-      }
+      context?.previous.forEach(([key, value]) => {
+        queryClient.setQueryData(key, value);
+      });
     },
   });
 }

--- a/src/app.feature/chat/hooks/useChatQueries.ts
+++ b/src/app.feature/chat/hooks/useChatQueries.ts
@@ -44,6 +44,20 @@ export function useChatUnreadTotal(options?: { enabled?: boolean }): number {
 }
 
 /**
+ * 챌린지에 딸린 방. 없으면 null — 아직 참여하지 않았거나 개인 챌린지다.
+ * 챌린지 상세 응답에는 roomId 가 없어 방 목록으로 찾는다(챌린지 1 : 방 1).
+ */
+export function useChatRoomForChallenge(
+  challengeId: number,
+  options?: { enabled?: boolean }
+): number | null {
+  const { data } = useChatRooms(options);
+  return (
+    data?.rooms.find((room) => room.challengeId === challengeId)?.roomId ?? null
+  );
+}
+
+/**
  * 방 내역. 커서형·최신순이라 페이지를 이어 붙이면 그대로 "위로 갈수록
  * 과거" 가 된다. 화면은 column-reverse 로 그린다.
  */

--- a/src/app.feature/chat/hooks/useChatQueries.ts
+++ b/src/app.feature/chat/hooks/useChatQueries.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  UseInfiniteQueryResult,
+  useQuery,
+  UseQueryResult,
+} from '@tanstack/react-query';
+
+import { FRESH_ON_RETURN } from '@/app.lib/refetchPolicy';
+
+import { chatApi } from '../api/chatApi';
+import { CHAT_PAGE_SIZE, CHAT_QUERY_KEYS } from '../consts/queryKeys';
+import { ChatMessagePage, ChatRoomList } from '../type/chat';
+
+const EMPTY_ROOMS: ChatRoomList = { rooms: [], hiddenMemberIds: [] };
+
+/**
+ * 방 목록. 안 읽음 배지와 challengeId → roomId 매핑이 여기서 나온다.
+ *
+ * noPersist: 안 읽음 수와 마지막 메시지는 실시간으로 흐르는 값이라, 복원된
+ * 스냅샷을 잠깐이라도 보여 주면 이미 읽은 방에 배지가 다시 뜬다.
+ */
+export function useChatRooms(options?: {
+  enabled?: boolean;
+}): UseQueryResult<ChatRoomList, Error> {
+  return useQuery({
+    queryKey: CHAT_QUERY_KEYS.rooms(),
+    queryFn: () => chatApi.getRooms(),
+    enabled: options?.enabled ?? true,
+    meta: { noPersist: true },
+    ...FRESH_ON_RETURN,
+  });
+}
+
+/** 헤더 배지 — 방 전체 안 읽음 합. */
+export function useChatUnreadTotal(options?: { enabled?: boolean }): number {
+  const { data } = useChatRooms(options);
+  return (data ?? EMPTY_ROOMS).rooms.reduce(
+    (sum, room) => sum + room.unreadCount,
+    0
+  );
+}
+
+/**
+ * 방 내역. 커서형·최신순이라 페이지를 이어 붙이면 그대로 "위로 갈수록
+ * 과거" 가 된다. 화면은 column-reverse 로 그린다.
+ */
+export function useChatMessages(
+  roomId: number
+): UseInfiniteQueryResult<InfiniteData<ChatMessagePage>, Error> {
+  return useInfiniteQuery({
+    queryKey: CHAT_QUERY_KEYS.messages(roomId),
+    queryFn: ({ pageParam }) =>
+      chatApi.getMessages(roomId, {
+        cursor: pageParam ?? undefined,
+        size: CHAT_PAGE_SIZE,
+      }),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) =>
+      lastPage.pageInfo.hasNextPage
+        ? (lastPage.pageInfo.nextCursor ?? undefined)
+        : undefined,
+    meta: { noPersist: true },
+    // 방을 다시 열면 끊긴 동안 온 메시지를 채워야 한다(토픽은 지나간 것을
+    // 다시 주지 않는다). 마운트 시점엔 페이지가 하나뿐이라 이 재요청은
+    // 한 번이면 끝난다. 스크롤 도중의 갭 보충은 useChatRoom 의
+    // refreshLatest 가 맡는다 — focus refetch 로 두면 쌓인 페이지를 전부
+    // 다시 받는다.
+    staleTime: 0,
+    refetchOnMount: 'always',
+  });
+}

--- a/src/app.feature/chat/hooks/useChatQueries.ts
+++ b/src/app.feature/chat/hooks/useChatQueries.ts
@@ -24,10 +24,14 @@ const EMPTY_ROOMS: ChatRoomList = { rooms: [], hiddenMemberIds: [] };
  */
 export function useChatRooms(options?: {
   enabled?: boolean;
+  /** 생략하면 전체(보관 포함). 서버가 `?archived=` 로 걸러 준다. */
+  archived?: boolean;
 }): UseQueryResult<ChatRoomList, Error> {
+  const archived = options?.archived;
   return useQuery({
-    queryKey: CHAT_QUERY_KEYS.rooms(),
-    queryFn: () => chatApi.getRooms(),
+    queryKey: CHAT_QUERY_KEYS.roomList(archived),
+    queryFn: () =>
+      chatApi.getRooms(archived === undefined ? undefined : { archived }),
     enabled: options?.enabled ?? true,
     meta: { noPersist: true },
     ...FRESH_ON_RETURN,

--- a/src/app.feature/chat/hooks/useChatRoom.ts
+++ b/src/app.feature/chat/hooks/useChatRoom.ts
@@ -1,0 +1,330 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { chatApi } from '../api/chatApi';
+import { CHAT_QUERY_KEYS } from '../consts/queryKeys';
+import {
+  blocksMessages,
+  ChatRoomHandlers,
+  subscribeChatRoom,
+} from '../socket/chatSocket';
+import {
+  ChatMessage,
+  ChatMessageType,
+  ChatShareResolution,
+  ChatSocketError,
+} from '../type/chat';
+import {
+  applyChatLinkPreview,
+  markChatMessageFailed,
+  markChatMessagePending,
+  mergeLatestMessages,
+  upsertChatMessage,
+} from './chatCache';
+import { useChatMessages } from './useChatQueries';
+
+/** 구독이 거절됐을 때 화면에 세울 문구. */
+function subscriptionMessage(
+  error: ChatSocketError,
+  challengeEnded: boolean
+): string {
+  switch (error.code) {
+    case 'CHAT-002':
+      // 종료된 챌린지 방은 "참여하고 있지 않다" 가 아니다 — 호스트로 멀쩡히
+      // 남아 있어도 종료되면 막힐 수 있다.
+      return challengeEnded
+        ? '종료된 챌린지라 새 메시지를 받을 수 없습니다.'
+        : '이 채팅방에 참여하고 있지 않아 새 메시지를 받을 수 없습니다.';
+    case 'UNAUTHORIZED':
+    case 'AUTH-010':
+      return '로그인이 만료되어 실시간 연결이 끊겼습니다.';
+    case 'CHAT-015':
+      return '접속이 몰려 잠시 후 다시 연결합니다.';
+    default:
+      return `${error.message} 새 메시지는 실시간으로 오지 않습니다.`;
+  }
+}
+
+interface SendOptions {
+  type: ChatMessageType;
+  content?: string;
+  imageUploadId?: string;
+  sharedTargetId?: number;
+}
+
+export interface UseChatRoomResult {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage(): void;
+  /** 실시간 수신이 끊겼다는 안내. 내역은 그대로 볼 수 있다. */
+  subscriptionError: string | null;
+  /** 서버가 방에서 빠졌다고 답했다(CHAT-002) — 입력창도 닫는다. */
+  kickedOut: boolean;
+  /** 실시간으로 받은 공지 id. null 이면 해제, undefined 면 통지 없음. */
+  noticeUpdate: number | null | undefined;
+  sendText(content: string): Promise<void>;
+  sendImage(file: File, caption?: string): Promise<void>;
+  sendShare(
+    resolution: ChatShareResolution,
+    caption?: string
+  ): Promise<void>;
+  retry(message: ChatMessage): Promise<void>;
+}
+
+/**
+ * 방 하나의 화면 상태. 내역(커서 페이징) + 실시간 수신 + 낙관적 전송.
+ *
+ * 전송은 REST 다(계약 A). 소켓 SEND 와 달리 실패가 응답으로 바로 돌아오고,
+ * 소켓이 아직 안 붙었어도 나간다 — 대기열·재전송 타이머가 필요 없다.
+ * 응답과 브로드캐스트가 두 번 도착하지만 clientMessageId 로 합쳐진다.
+ */
+export function useChatRoom(
+  roomId: number,
+  options: { myNickname?: string; challengeEnded?: boolean } = {}
+): UseChatRoomResult {
+  const { myNickname, challengeEnded = false } = options;
+  const queryClient = useQueryClient();
+  const query = useChatMessages(roomId);
+  const [socketError, setSocketError] = useState<ChatSocketError | null>(null);
+  const [noticeUpdate, setNoticeUpdate] = useState<number | null | undefined>(
+    undefined
+  );
+  /** 서버에 올린 마지막 읽음 위치. 같은 값을 반복해 올리지 않는다. */
+  const lastReadSent = useRef(0);
+
+  const messages = useMemo(
+    () => query.data?.pages.flatMap((page) => page.items) ?? [],
+    [query.data]
+  );
+
+  const markRead = useCallback(
+    (messageId: number) => {
+      if (messageId <= 0 || messageId <= lastReadSent.current) {
+        return;
+      }
+      lastReadSent.current = messageId;
+      chatApi
+        .markRead(roomId, messageId)
+        .then(() =>
+          queryClient.invalidateQueries({ queryKey: CHAT_QUERY_KEYS.rooms() })
+        )
+        .catch(() => {
+          // 실패하면 다음 메시지에서 다시 시도할 수 있게 되돌린다.
+          if (lastReadSent.current === messageId) {
+            lastReadSent.current = 0;
+          }
+        });
+    },
+    [queryClient, roomId]
+  );
+
+  // 방을 열었으면 거기까지는 읽은 것이다. 최신순이라 첫 항목이 최신.
+  const latestId = messages.find((message) => message.id > 0)?.id ?? 0;
+  useEffect(() => {
+    markRead(latestId);
+  }, [latestId, markRead]);
+
+  // 실시간 콜백은 매 렌더 바뀌지만 구독은 방마다 한 번만 건다. 최신 콜백을
+  // ref 로 들고 있어 재구독 없이 최신 상태를 본다.
+  const handlersRef = useRef<ChatRoomHandlers>({});
+  useEffect(() => {
+    handlersRef.current = {
+      onMessage: (message) => {
+        upsertChatMessage(queryClient, roomId, message);
+        setSocketError(null);
+      },
+      onNotice: (update) => {
+        if (update.systemMessage) {
+          upsertChatMessage(queryClient, roomId, update.systemMessage);
+        }
+        setNoticeUpdate(update.noticeMessageId ?? null);
+        // 내 내역에 없는 옛 메시지를 공지로 걸었으면 방 목록이 실어다 준다.
+        void queryClient.invalidateQueries({
+          queryKey: CHAT_QUERY_KEYS.rooms(),
+        });
+      },
+      onUpdate: (update) => {
+        if (update.linkPreview) {
+          applyChatLinkPreview(
+            queryClient,
+            roomId,
+            update.messageId,
+            update.linkPreview
+          );
+        }
+      },
+      onError: (error) => {
+        // 곁가지 채널(/notice·/updates)이 막힌 건 메시지 수신과 무관하다.
+        // 그걸로 "새 메시지가 안 온다" 배너를 세우면 거짓말이다.
+        if (!blocksMessages(error)) {
+          return;
+        }
+        setSocketError(error);
+      },
+      onReconnect: () => {
+        chatApi
+          .getMessages(roomId)
+          .then((page) => mergeLatestMessages(queryClient, roomId, page.items))
+          .catch(() => undefined);
+      },
+    };
+  }, [queryClient, roomId]);
+
+  useEffect(() => {
+    if (!Number.isFinite(roomId) || roomId <= 0) {
+      return undefined;
+    }
+    return subscribeChatRoom(roomId, {
+      onMessage: (message) => handlersRef.current.onMessage?.(message),
+      onNotice: (update) => handlersRef.current.onNotice?.(update),
+      onUpdate: (update) => handlersRef.current.onUpdate?.(update),
+      onError: (error) => handlersRef.current.onError?.(error),
+      onReconnect: () => handlersRef.current.onReconnect?.(),
+    });
+  }, [roomId]);
+
+  const send = useCallback(
+    async (
+      clientMessageId: string,
+      optimistic: ChatMessage,
+      resolve: () => Promise<SendOptions>
+    ) => {
+      upsertChatMessage(queryClient, roomId, optimistic);
+      try {
+        const options = await resolve();
+        const sent = await chatApi.sendMessage(roomId, {
+          clientMessageId,
+          ...options,
+        });
+        upsertChatMessage(queryClient, roomId, sent);
+      } catch (error) {
+        markChatMessageFailed(queryClient, roomId, clientMessageId);
+        throw error;
+      }
+    },
+    [queryClient, roomId]
+  );
+
+  const optimisticMessage = useCallback(
+    (
+      clientMessageId: string,
+      type: ChatMessageType,
+      content?: string
+    ): ChatMessage => ({
+      id: 0,
+      roomId,
+      // senderId 는 알 수 없다 — 웹은 자기 memberId 를 받지 않는다. 내 것인지는
+      // 닉네임으로 가른다(가입 시 유일성이 보장된다).
+      senderId: 0,
+      senderNickname: myNickname ?? '',
+      clientMessageId,
+      type,
+      content: content ?? null,
+      imageUrl: null,
+      status: 'ACTIVE',
+      createdAt: new Date().toISOString(),
+      pending: true,
+    }),
+    [myNickname, roomId]
+  );
+
+  const sendText = useCallback(
+    async (raw: string) => {
+      const content = raw.trim();
+      if (!content) {
+        return;
+      }
+      const clientMessageId = crypto.randomUUID();
+      await send(
+        clientMessageId,
+        optimisticMessage(clientMessageId, 'TEXT', content),
+        async () => ({ type: 'TEXT', content })
+      );
+    },
+    [optimisticMessage, send]
+  );
+
+  const sendImage = useCallback(
+    async (file: File, caption?: string) => {
+      const clientMessageId = crypto.randomUUID();
+      await send(
+        clientMessageId,
+        optimisticMessage(clientMessageId, 'IMAGE', caption),
+        async () => ({
+          type: 'IMAGE',
+          content: caption?.trim() || undefined,
+          imageUploadId: await chatApi.uploadImage(roomId, file),
+        })
+      );
+    },
+    [optimisticMessage, roomId, send]
+  );
+
+  const sendShare = useCallback(
+    async (resolution: ChatShareResolution, caption?: string) => {
+      const type = resolution.type;
+      const targetId = resolution.targetId;
+      if (!type || targetId == null) {
+        return;
+      }
+      const clientMessageId = crypto.randomUUID();
+      const optimistic = optimisticMessage(clientMessageId, type, caption);
+      await send(
+        clientMessageId,
+        { ...optimistic, share: resolution.share ?? null },
+        async () => ({
+          type,
+          content: caption?.trim() || undefined,
+          sharedTargetId: targetId,
+        })
+      );
+    },
+    [optimisticMessage, send]
+  );
+
+  const retry = useCallback(
+    async (message: ChatMessage) => {
+      const clientMessageId = message.clientMessageId;
+      // 글만 다시 보낼 수 있다. 사진은 업로드 식별자가, 공유는 대상 id 가
+      // 낙관적 말풍선에 남아 있지 않아 다시 고르는 편이 정확하다.
+      if (!clientMessageId || message.type !== 'TEXT' || !message.content) {
+        return;
+      }
+      markChatMessagePending(queryClient, roomId, clientMessageId);
+      try {
+        // clientMessageId 를 그대로 쓰므로 서버 unique 제약이 중복을 막는다.
+        const sent = await chatApi.sendMessage(roomId, {
+          clientMessageId,
+          type: 'TEXT',
+          content: message.content,
+        });
+        upsertChatMessage(queryClient, roomId, sent);
+      } catch (error) {
+        markChatMessageFailed(queryClient, roomId, clientMessageId);
+        throw error;
+      }
+    },
+    [queryClient, roomId]
+  );
+
+  return {
+    messages,
+    isLoading: query.isLoading,
+    hasNextPage: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    fetchNextPage: query.fetchNextPage,
+    subscriptionError: socketError
+      ? subscriptionMessage(socketError, challengeEnded)
+      : null,
+    kickedOut: socketError?.code === 'CHAT-002',
+    noticeUpdate,
+    sendText,
+    sendImage,
+    sendShare,
+    retry,
+  };
+}

--- a/src/app.feature/chat/hooks/useEndedBannerDismissal.ts
+++ b/src/app.feature/chat/hooks/useEndedBannerDismissal.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = '1d1s:chat:endedBannerDismissed';
+
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// 스냅샷은 참조가 안정적이어야 한다 — 배열을 새로 만들면 매 렌더 갱신으로
+// 읽혀 무한 루프가 된다. 원본 문자열을 그대로 스냅샷으로 쓴다.
+function getSnapshot(): string {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+// SSR 에서는 아직 모른다. 껐던 배너가 하이드레이션 직후 번쩍이지 않도록
+// null 로 두고, 클라이언트가 읽은 뒤에만 판정한다.
+function getServerSnapshot(): null {
+  return null;
+}
+
+/** "다시 보지 않기" 를 누른 방들. 기기에 남긴다. */
+export function useEndedBannerDismissal(roomId: number): {
+  /** null 이면 아직 모름 — 그동안은 배너를 그리지 않는다. */
+  dismissed: boolean | null;
+  dismiss(): void;
+} {
+  const raw = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const dismissed = useMemo(() => {
+    if (raw === null) {
+      return null;
+    }
+    try {
+      const parsed: unknown = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) && parsed.includes(roomId);
+    } catch {
+      return false;
+    }
+  }, [raw, roomId]);
+
+  const dismiss = useCallback(() => {
+    try {
+      const parsed: unknown = JSON.parse(getSnapshot() || '[]');
+      const current = Array.isArray(parsed) ? parsed : [];
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(Array.from(new Set([...current, roomId])))
+      );
+    } catch {
+      // 저장 실패는 그대로 둔다 — 다음 진입에 배너가 다시 보일 뿐이다.
+    }
+    listeners.forEach((listener) => listener());
+  }, [roomId]);
+
+  return { dismissed, dismiss };
+}

--- a/src/app.feature/chat/hooks/useMeasuredHeight.ts
+++ b/src/app.feature/chat/hooks/useMeasuredHeight.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * 요소의 실제 높이를 잰다.
+ *
+ * 떠 있는 배너가 리스트를 가리지 않게 그만큼 비워 둬야 하는데, 배너는 두
+ * 개일 수도 접혔다 펴질 수도 있다 — 상수로 박으면 배너가 바뀔 때마다
+ * 어긋난다. ResizeObserver 로 실측한다.
+ */
+export function useMeasuredHeight(): {
+  ref(node: HTMLElement | null): void;
+  height: number;
+} {
+  const [height, setHeight] = useState(0);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  useEffect(
+    () => () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+    },
+    []
+  );
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    observerRef.current?.disconnect();
+    if (!node) {
+      setHeight(0);
+      return;
+    }
+    const observer = new ResizeObserver(([entry]) => {
+      setHeight(entry.contentRect.height);
+    });
+    observer.observe(node);
+    observerRef.current = observer;
+    setHeight(node.getBoundingClientRect().height);
+  }, []);
+
+  return { ref, height };
+}

--- a/src/app.feature/chat/screen/ChatRoomListScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomListScreen.tsx
@@ -39,18 +39,20 @@ function ListSkeleton(): React.ReactElement {
   );
 }
 
+// value 가 그대로 서버 파라미터다 — undefined 면 생략(전체).
 const FILTERS = [
-  { value: 'all', label: '전체' },
-  { value: 'active', label: '진행 중' },
-  { value: 'archived', label: '아카이브' },
+  { key: 'all', label: '전체', archived: undefined },
+  { key: 'active', label: '진행 중', archived: false },
+  { key: 'archived', label: '아카이브', archived: true },
 ] as const;
 
-type ChatRoomFilter = (typeof FILTERS)[number]['value'];
+type ChatRoomFilterKey = (typeof FILTERS)[number]['key'];
 
 export function ChatRoomListScreen(): React.ReactElement {
   const handleBack = useSafeBack('/');
-  const [filter, setFilter] = useState<ChatRoomFilter>('all');
-  const { data, isLoading, isError, refetch } = useChatRooms();
+  const [filterKey, setFilterKey] = useState<ChatRoomFilterKey>('all');
+  const archived = FILTERS.find((item) => item.key === filterKey)?.archived;
+  const { data, isLoading, isError, refetch } = useChatRooms({ archived });
   // 재조회 중에도 값이 있으면 목록을 그대로 둔다. isLoading 만 보면 갱신될
   // 때마다 스켈레톤으로 갔다 돌아와 리스트 전체가 페이드된다.
   const showSkeleton = useMinimumLoading(isLoading && !data);
@@ -69,18 +71,12 @@ export function ChatRoomListScreen(): React.ReactElement {
     );
   };
 
-  const allRooms = data?.rooms ?? [];
-  // ponytail: 지금은 클라에서 거른다 — 방 목록은 참여 중인 그룹 챌린지 수만큼
-  // 이라 한 화면에 다 온다. 서버가 목록 아카이브 필터를 열면 이 두 줄이
-  // queryKey 파라미터로 바뀐다.
-  const rooms = allRooms.filter((room) => {
-    if (filter === 'all') {
-      return true;
-    }
-    return isChatArchived(room) === (filter === 'archived');
-  });
-  // 보관된 방이 하나도 없으면 필터 자체가 군더더기다.
-  const hasArchived = allRooms.some((room) => isChatArchived(room));
+  const rooms = data?.rooms ?? [];
+  // 보관된 방이 하나도 없으면 필터 줄은 군더더기다. 다만 '전체' 가 아닌
+  // 필터를 이미 고른 뒤에는 응답에 보관 방이 없어도 줄을 유지해야 한다 —
+  // 안 그러면 '진행 중' 을 누르는 순간 필터가 사라져 되돌아갈 길이 없다.
+  const showFilters =
+    filterKey !== 'all' || rooms.some((room) => isChatArchived(room));
 
   return (
     <SubPageShell
@@ -107,14 +103,14 @@ export function ChatRoomListScreen(): React.ReactElement {
         </div>
       ) : (
         <div className="flex flex-col gap-3">
-          {hasArchived ? (
+          {showFilters ? (
             <div className="flex items-center gap-2">
               {FILTERS.map((option) => (
                 <FilterChip
-                  key={option.value}
+                  key={option.key}
                   size="sm"
-                  active={filter === option.value}
-                  onClick={() => setFilter(option.value)}
+                  active={filterKey === option.key}
+                  onClick={() => setFilterKey(option.key)}
                 >
                   {option.label}
                 </FilterChip>
@@ -126,14 +122,14 @@ export function ChatRoomListScreen(): React.ReactElement {
             <EmptyState
               variant="challenge"
               title={
-                filter === 'archived'
+                filterKey === 'archived'
                   ? '보관된 채팅방이 없어요'
-                  : allRooms.length === 0
-                    ? '참여 중인 그룹 채팅이 없어요'
-                    : '진행 중인 채팅방이 없어요'
+                  : filterKey === 'active'
+                    ? '진행 중인 채팅방이 없어요'
+                    : '참여 중인 그룹 채팅이 없어요'
               }
               description={
-                allRooms.length === 0
+                filterKey === 'all'
                   ? '그룹 챌린지에 참여하면 채팅방이 열려요.'
                   : undefined
               }

--- a/src/app.feature/chat/screen/ChatRoomListScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomListScreen.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import EmptyState from '@component/EmptyState';
+import { SubPageShell } from '@component/layout/SubPageShell';
+import { Skeleton } from '@component/Skeleton';
+import { useSafeBack } from '@module/hooks/useSafeBack';
+import { useSignalPageReady } from '@module/hooks/useSignalPageReady';
+import { toast } from '@module/providers/toast';
+import { cn } from '@module/utils/cn';
+import { useMinimumLoading } from '@module/utils/useMinimumLoading';
+import React from 'react';
+
+import { ChatRoomListItem } from '../components/ChatRoomListItem';
+import { useToggleChatPush } from '../hooks/useChatMutations';
+import { useChatRooms } from '../hooks/useChatQueries';
+import { ChatRoom } from '../type/chat';
+
+function ListSkeleton(): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-2.5">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div
+          key={index}
+          className={cn(
+            'flex items-center gap-3 rounded-2xl border border-gray-200',
+            'px-3.5 py-3'
+          )}
+        >
+          <Skeleton shape="rounded" className="h-11 w-[66px] rounded-[10px]" />
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <Skeleton shape="text" className="h-3.5 w-[55%]" />
+            <Skeleton shape="text" className="h-3 w-[75%]" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ChatRoomListScreen(): React.ReactElement {
+  const handleBack = useSafeBack('/');
+  const { data, isLoading, isError, refetch } = useChatRooms();
+  // 재조회 중에도 값이 있으면 목록을 그대로 둔다. isLoading 만 보면 갱신될
+  // 때마다 스켈레톤으로 갔다 돌아와 리스트 전체가 페이드된다.
+  const showSkeleton = useMinimumLoading(isLoading && !data);
+  useSignalPageReady('chat', !showSkeleton);
+  const { mutate: togglePush } = useToggleChatPush();
+
+  const handleToggle = (room: ChatRoom): void => {
+    const enabled = !room.pushEnabled;
+    togglePush(
+      { roomId: room.roomId, enabled },
+      {
+        onSuccess: () =>
+          toast.success(enabled ? '알림을 켰어요.' : '알림을 껐어요.'),
+        onError: () => toast.error('알림 설정을 바꾸지 못했습니다.'),
+      }
+    );
+  };
+
+  const rooms = data?.rooms ?? [];
+
+  return (
+    <SubPageShell
+      title="채팅"
+      description="참여 중인 그룹 챌린지의 채팅방이에요."
+      onBack={handleBack}
+    >
+      {showSkeleton ? (
+        <ListSkeleton />
+      ) : isError ? (
+        <div className="flex flex-col items-center gap-3 py-20">
+          <Text size="body2" className="text-gray-600">
+            채팅방을 불러오지 못했습니다.
+          </Text>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="text-main-800 underline underline-offset-4"
+          >
+            <Text size="body2" weight="medium" className="text-inherit">
+              다시 시도
+            </Text>
+          </button>
+        </div>
+      ) : rooms.length === 0 ? (
+        <EmptyState
+          variant="challenge"
+          title="참여 중인 그룹 채팅이 없어요"
+          description="그룹 챌린지에 참여하면 채팅방이 열려요."
+        />
+      ) : (
+        // 카드 사이 간격이 구분 역할을 하므로 divider 를 두지 않는다.
+        <div className="flex flex-col gap-2.5">
+          {rooms.map((room) => (
+            <ChatRoomListItem
+              key={room.roomId}
+              room={room}
+              onToggleNotification={handleToggle}
+            />
+          ))}
+        </div>
+      )}
+    </SubPageShell>
+  );
+}

--- a/src/app.feature/chat/screen/ChatRoomListScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomListScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Text } from '@1d1s/design-system';
+import { FilterChip, Text } from '@1d1s/design-system';
 import EmptyState from '@component/EmptyState';
 import { SubPageShell } from '@component/layout/SubPageShell';
 import { Skeleton } from '@component/Skeleton';
@@ -9,12 +9,13 @@ import { useSignalPageReady } from '@module/hooks/useSignalPageReady';
 import { toast } from '@module/providers/toast';
 import { cn } from '@module/utils/cn';
 import { useMinimumLoading } from '@module/utils/useMinimumLoading';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { ChatRoomListItem } from '../components/ChatRoomListItem';
 import { useToggleChatPush } from '../hooks/useChatMutations';
 import { useChatRooms } from '../hooks/useChatQueries';
 import { ChatRoom } from '../type/chat';
+import { isChatArchived } from '../utils/chatArchive';
 
 function ListSkeleton(): React.ReactElement {
   return (
@@ -38,8 +39,17 @@ function ListSkeleton(): React.ReactElement {
   );
 }
 
+const FILTERS = [
+  { value: 'all', label: '전체' },
+  { value: 'active', label: '진행 중' },
+  { value: 'archived', label: '아카이브' },
+] as const;
+
+type ChatRoomFilter = (typeof FILTERS)[number]['value'];
+
 export function ChatRoomListScreen(): React.ReactElement {
   const handleBack = useSafeBack('/');
+  const [filter, setFilter] = useState<ChatRoomFilter>('all');
   const { data, isLoading, isError, refetch } = useChatRooms();
   // 재조회 중에도 값이 있으면 목록을 그대로 둔다. isLoading 만 보면 갱신될
   // 때마다 스켈레톤으로 갔다 돌아와 리스트 전체가 페이드된다.
@@ -59,7 +69,18 @@ export function ChatRoomListScreen(): React.ReactElement {
     );
   };
 
-  const rooms = data?.rooms ?? [];
+  const allRooms = data?.rooms ?? [];
+  // ponytail: 지금은 클라에서 거른다 — 방 목록은 참여 중인 그룹 챌린지 수만큼
+  // 이라 한 화면에 다 온다. 서버가 목록 아카이브 필터를 열면 이 두 줄이
+  // queryKey 파라미터로 바뀐다.
+  const rooms = allRooms.filter((room) => {
+    if (filter === 'all') {
+      return true;
+    }
+    return isChatArchived(room) === (filter === 'archived');
+  });
+  // 보관된 방이 하나도 없으면 필터 자체가 군더더기다.
+  const hasArchived = allRooms.some((room) => isChatArchived(room));
 
   return (
     <SubPageShell
@@ -84,22 +105,51 @@ export function ChatRoomListScreen(): React.ReactElement {
             </Text>
           </button>
         </div>
-      ) : rooms.length === 0 ? (
-        <EmptyState
-          variant="challenge"
-          title="참여 중인 그룹 채팅이 없어요"
-          description="그룹 챌린지에 참여하면 채팅방이 열려요."
-        />
       ) : (
-        // 카드 사이 간격이 구분 역할을 하므로 divider 를 두지 않는다.
-        <div className="flex flex-col gap-2.5">
-          {rooms.map((room) => (
-            <ChatRoomListItem
-              key={room.roomId}
-              room={room}
-              onToggleNotification={handleToggle}
+        <div className="flex flex-col gap-3">
+          {hasArchived ? (
+            <div className="flex items-center gap-2">
+              {FILTERS.map((option) => (
+                <FilterChip
+                  key={option.value}
+                  size="sm"
+                  active={filter === option.value}
+                  onClick={() => setFilter(option.value)}
+                >
+                  {option.label}
+                </FilterChip>
+              ))}
+            </div>
+          ) : null}
+
+          {rooms.length === 0 ? (
+            <EmptyState
+              variant="challenge"
+              title={
+                filter === 'archived'
+                  ? '보관된 채팅방이 없어요'
+                  : allRooms.length === 0
+                    ? '참여 중인 그룹 채팅이 없어요'
+                    : '진행 중인 채팅방이 없어요'
+              }
+              description={
+                allRooms.length === 0
+                  ? '그룹 챌린지에 참여하면 채팅방이 열려요.'
+                  : undefined
+              }
             />
-          ))}
+          ) : (
+            // 카드 사이 간격이 구분 역할을 하므로 divider 를 두지 않는다.
+            <div className="flex flex-col gap-2.5">
+              {rooms.map((room) => (
+                <ChatRoomListItem
+                  key={room.roomId}
+                  room={room}
+                  onToggleNotification={handleToggle}
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </SubPageShell>

--- a/src/app.feature/chat/screen/ChatRoomScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomScreen.tsx
@@ -1,0 +1,497 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { useSidebar } from '@feature/member/hooks/useMemberQueries';
+import { useSafeBack } from '@module/hooks/useSafeBack';
+import { useSignalPageReady } from '@module/hooks/useSignalPageReady';
+import { toast } from '@module/providers/toast';
+import { cn } from '@module/utils/cn';
+import { ArrowLeft, Bell, BellOff, MoreVertical, Users } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import { chatApi, chatImageContentType } from '../api/chatApi';
+import { ChatComposer } from '../components/ChatComposer';
+import { ChatMessageList } from '../components/ChatMessageList';
+import { ChatSharePickerSheet } from '../components/ChatSharePickerSheet';
+import {
+  ChatMessageActionsSheet,
+  type ChatMessageActionsState,
+  ChatRoomMenuSheet,
+  type ChatShareKind,
+  ChatShareMenuSheet,
+} from '../components/ChatSheets';
+import {
+  ChatEndedBanner,
+  ChatNoticeBanner,
+  ChatNoticeMessageBanner,
+} from '../components/ChatTopBanners';
+import {
+  useClearChatNotice,
+  useSetChatNotice,
+  useToggleChatPush,
+} from '../hooks/useChatMutations';
+import { useChatRooms } from '../hooks/useChatQueries';
+import { useChatRoom } from '../hooks/useChatRoom';
+import { useEndedBannerDismissal } from '../hooks/useEndedBannerDismissal';
+import { useMeasuredHeight } from '../hooks/useMeasuredHeight';
+import { canSendInRoom, ChatMessage, ChatShareResolution } from '../type/chat';
+import { chatShareLinkIn } from '../utils/chatShareLink';
+
+const LINK_RESOLVE_DELAY_MS = 400;
+
+function HeaderIconButton({
+  label,
+  onClick,
+  children,
+  muted = false,
+}: {
+  label: string;
+  onClick(): void;
+  children: React.ReactNode;
+  muted?: boolean;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      className={cn(
+        'flex h-9 w-9 items-center justify-center rounded-full',
+        'transition-colors hover:bg-gray-100',
+        muted ? 'text-gray-400' : 'text-gray-700'
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ChatRoomScreen({
+  roomId,
+}: {
+  roomId: number;
+}): React.ReactElement {
+  const router = useRouter();
+  const handleBack = useSafeBack('/chat');
+  const { data: sidebar } = useSidebar();
+  const { data: roomList } = useChatRooms();
+  const room = roomList?.rooms.find((item) => item.roomId === roomId);
+
+  const {
+    messages,
+    isLoading,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    subscriptionError,
+    kickedOut,
+    noticeUpdate,
+    sendText,
+    sendImage,
+    sendShare,
+    retry,
+  } = useChatRoom(roomId, {
+    myNickname: sidebar?.nickname,
+    challengeEnded: room?.challengeEnded,
+  });
+
+  useSignalPageReady('chat-room', !isLoading);
+
+  const [draft, setDraft] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [share, setShare] = useState<ChatShareResolution | null>(null);
+  /** 지금 카드로 바뀌어 있는 링크. 카드를 지우면 이 글을 되돌려 준다. */
+  const [linkShareUrl, setLinkShareUrl] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [shareMenuOpen, setShareMenuOpen] = useState(false);
+  const [roomMenuOpen, setRoomMenuOpen] = useState(false);
+  const [pickerKind, setPickerKind] = useState<'challenge' | 'diary' | null>(
+    null
+  );
+  const [actions, setActions] = useState<ChatMessageActionsState | null>(null);
+  const [actionTarget, setActionTarget] = useState<ChatMessage | null>(null);
+  const [highlightId, setHighlightId] = useState<number | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  /** 이미 물어본 링크. 같은 글을 다시 물어보지 않는다. */
+  const lastResolvedUrl = useRef<string | null>(null);
+
+  const { ref: bannerRef, height: bannerInset } = useMeasuredHeight();
+  const { mutate: togglePush } = useToggleChatPush();
+  const { mutate: setNotice } = useSetChatNotice();
+  const { mutate: clearNotice } = useClearChatNotice();
+  const ended = room?.challengeEnded ?? false;
+  const { dismissed, dismiss } = useEndedBannerDismissal(roomId);
+
+  const canSend = (!room || canSendInRoom(room)) && !kickedOut;
+
+  // 실시간 공지 통지가 방 목록보다 우선한다. 통지에는 본문이 안 실려 오므로
+  // (뷰어별 권한 때문에 서버가 id 만 준다) 내 내역에서 찾고, 없으면 방
+  // 목록이 실어다 준 값을 쓴다.
+  const notice = useMemo(() => {
+    if (noticeUpdate === undefined) {
+      return room?.notice ?? null;
+    }
+    if (noticeUpdate === null) {
+      return null;
+    }
+    if (room?.notice?.id === noticeUpdate) {
+      return room.notice;
+    }
+    return messages.find((message) => message.id === noticeUpdate) ?? null;
+  }, [messages, noticeUpdate, room]);
+
+  // 붙여넣은 우리 링크를 공유 카드로 바꾼다. 판정은 서버가 한다 —
+  // 못 바꾸는 링크는 막지 않고 그냥 글로 나간다.
+  useEffect(() => {
+    const url = chatShareLinkIn(draft);
+    if (!url || url === lastResolvedUrl.current) {
+      return undefined;
+    }
+    // 사진·공유가 이미 달려 있으면 자리를 뺏지 않는다.
+    if (imageFile || share) {
+      return undefined;
+    }
+    const timer = window.setTimeout(() => {
+      lastResolvedUrl.current = url;
+      void chatApi.resolveShare(url).then((resolution) => {
+        if (!resolution.shareable) {
+          // 우리 링크인데 못 보내는 것(삭제·비공개·차단·남의 일지)만 알린다.
+          if (resolution.type) {
+            toast.info('공유할 수 없는 링크예요. 글로 보낼게요.');
+          }
+          return;
+        }
+        setShare(resolution);
+        setLinkShareUrl(url);
+        // 카드가 대신하므로 글은 비운다 — 링크와 카드가 같이 나가면 중복이다.
+        setDraft('');
+      });
+    }, LINK_RESOLVE_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [draft, imageFile, share]);
+
+  /** 링크에서 만든 카드를 지우면 원래 글을 돌려준다. */
+  const clearAttachment = (): void => {
+    setImageFile(null);
+    setShare(null);
+    if (linkShareUrl) {
+      setDraft(linkShareUrl);
+      // 같은 링크를 곧바로 다시 카드로 만들지 않는다.
+      lastResolvedUrl.current = linkShareUrl;
+      setLinkShareUrl(null);
+    }
+  };
+
+  const handleSend = async (): Promise<void> => {
+    const text = draft.trim();
+    const pendingImage = imageFile;
+    const pendingShare = share;
+    if (!text && !pendingImage && !pendingShare) {
+      return;
+    }
+    setDraft('');
+    setImageFile(null);
+    setShare(null);
+    setLinkShareUrl(null);
+    setSending(true);
+    try {
+      if (pendingShare) {
+        // 공유는 사진과 같은 규칙이다 — 캡션은 선택.
+        await sendShare(pendingShare, text || undefined);
+        return;
+      }
+      if (pendingImage) {
+        await sendImage(pendingImage, text || undefined);
+        return;
+      }
+      await sendText(text);
+    } catch (error) {
+      // 판정과 전송 사이에 대상이 지워질 수 있다(CHAT-014). 링크에서 온
+      // 카드면 원래 하려던 것 — 링크 보내기 — 로 되돌린다.
+      if (pendingShare && linkShareUrl) {
+        await sendText(linkShareUrl).catch(() => undefined);
+        return;
+      }
+      toast.error(
+        error instanceof Error ? error.message : '메시지를 보내지 못했습니다.'
+      );
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleShareKind = (kind: ChatShareKind): void => {
+    if (kind === 'photo') {
+      fileInputRef.current?.click();
+      return;
+    }
+    setPickerKind(kind);
+  };
+
+  const handlePickFile = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const file = event.target.files?.[0];
+    // 같은 파일을 다시 고를 수 있게 값을 비운다.
+    event.target.value = '';
+    if (!file) {
+      return;
+    }
+    if (!chatImageContentType(file.name)) {
+      toast.error('jpg · png · heic 만 보낼 수 있습니다.');
+      return;
+    }
+    setImageFile(file);
+    setShare(null);
+    setLinkShareUrl(null);
+  };
+
+  const handleToggleNotifications = (): void => {
+    if (!room) {
+      return;
+    }
+    const enabled = !room.pushEnabled;
+    togglePush(
+      { roomId, enabled },
+      {
+        onSuccess: () =>
+          toast.success(enabled ? '알림을 켰습니다.' : '알림을 껐습니다.'),
+        onError: () => toast.error('알림 설정을 바꾸지 못했습니다.'),
+      }
+    );
+  };
+
+  const openActions = (message: ChatMessage): void => {
+    if (message.id <= 0 || message.status === 'HIDDEN') {
+      return;
+    }
+    const text = message.content?.trim() ?? '';
+    const canEditNotice = room?.myRole === 'HOST';
+    if (!text && !canEditNotice) {
+      return;
+    }
+    setActionTarget(message);
+    setActions({
+      text,
+      canEditNotice,
+      isNotice: notice?.id === message.id,
+    });
+  };
+
+  const handleToggleNotice = (isNotice: boolean): void => {
+    const target = actionTarget;
+    setActionTarget(null);
+    if (isNotice) {
+      clearNotice(
+        { roomId },
+        {
+          onSuccess: () => toast.success('공지를 해제했습니다.'),
+          onError: () => toast.error('공지를 해제하지 못했습니다.'),
+        }
+      );
+      return;
+    }
+    if (!target) {
+      return;
+    }
+    setNotice(
+      { roomId, messageId: target.id },
+      {
+        onSuccess: () => toast.success('공지로 지정했습니다.'),
+        onError: () => toast.error('공지를 지정하지 못했습니다.'),
+      }
+    );
+  };
+
+  // 공지 원본이 이미 불러온 페이지에 있으면 잠깐 강조해 알려 준다.
+  // 아직 안 받은 옛 공지는 버튼을 그리지 않는다 — 커서를 따라 몇 페이지를
+  // 더 받을지 알 수 없어, 눌러도 아무 일이 없는 버튼이 되는 편이 나쁘다.
+  const noticeLoaded =
+    notice != null && messages.some((message) => message.id === notice.id);
+  const jumpToNotice = (): void => {
+    if (!notice) {
+      return;
+    }
+    setHighlightId(notice.id);
+    window.setTimeout(() => setHighlightId(null), 1600);
+    document
+      .getElementById(`chat-message-${notice.id}`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-[760px] flex-col bg-gray-50">
+      <header
+        className={cn(
+          'flex shrink-0 items-center gap-1 border-b border-gray-200',
+          'bg-white px-2 py-2'
+        )}
+      >
+        <button
+          type="button"
+          aria-label="뒤로가기"
+          onClick={handleBack}
+          className="flex h-9 w-9 items-center justify-center rounded-full"
+        >
+          <ArrowLeft className="h-5 w-5 text-gray-700" />
+        </button>
+        <Text
+          size="body2"
+          weight="extrabold"
+          className="min-w-0 flex-1 truncate text-gray-900"
+        >
+          {room?.challengeTitle ?? '채팅'}
+        </Text>
+        {room ? (
+          <div className="flex shrink-0 items-center">
+            {/* 채팅 전용 참여자 API 가 없어 챌린지 참여자 화면을 그대로 쓴다. */}
+            <Link
+              href={`/challenge/${room.challengeId}/participants`}
+              aria-label="참여자 보기"
+              className={cn(
+                'flex h-9 w-9 items-center justify-center rounded-full',
+                'text-gray-700 transition-colors hover:bg-gray-100'
+              )}
+            >
+              <Users className="h-4.5 w-4.5" />
+            </Link>
+            <HeaderIconButton
+              label={room.pushEnabled ? '알림 끄기' : '알림 켜기'}
+              muted={!room.pushEnabled}
+              onClick={handleToggleNotifications}
+            >
+              {room.pushEnabled ? (
+                <Bell className="h-4.5 w-4.5" />
+              ) : (
+                <BellOff className="h-4.5 w-4.5" />
+              )}
+            </HeaderIconButton>
+            <HeaderIconButton
+              label="더보기"
+              onClick={() => setRoomMenuOpen(true)}
+            >
+              <MoreVertical className="h-4.5 w-4.5" />
+            </HeaderIconButton>
+          </div>
+        ) : null}
+      </header>
+
+      <div className="relative min-h-0 flex-1">
+        {/* 배너는 메시지 **위에 떠 있다**. Column 에서 자리를 차지하면
+            리스트를 밀어내 공유 카드가 배너에 잘려 보였다. */}
+        <div ref={bannerRef} className="absolute inset-x-0 top-0 z-10">
+          {ended && dismissed === false ? (
+            <ChatEndedBanner onDismiss={dismiss} />
+          ) : null}
+          {notice ? (
+            <ChatNoticeBanner
+              notice={notice}
+              canEdit={room?.myRole === 'HOST'}
+              onClear={() =>
+                clearNotice(
+                  { roomId },
+                  {
+                    onSuccess: () => toast.success('공지를 해제했습니다.'),
+                    onError: () => toast.error('공지를 해제하지 못했습니다.'),
+                  }
+                )
+              }
+              onJumpToOrigin={noticeLoaded ? jumpToNotice : undefined}
+            />
+          ) : null}
+          {subscriptionError ? (
+            <ChatNoticeMessageBanner text={subscriptionError} />
+          ) : null}
+        </div>
+
+        {isLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <span
+              className={cn(
+                'h-5 w-5 animate-spin rounded-full border-2',
+                'border-gray-300 border-t-transparent'
+              )}
+            />
+          </div>
+        ) : (
+          <ChatMessageList
+            messages={messages}
+            myNickname={sidebar?.nickname}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            fetchNextPage={fetchNextPage}
+            topInset={bannerInset}
+            canSend={canSend}
+            noticeId={notice?.id}
+            highlightId={highlightId}
+            onRetry={(message) => void retry(message)}
+            onOpenActions={openActions}
+          />
+        )}
+      </div>
+
+      <ChatComposer
+        value={draft}
+        onChange={setDraft}
+        enabled={canSend}
+        sending={sending}
+        imageFile={imageFile}
+        share={share}
+        onRemoveAttachment={clearAttachment}
+        onOpenShareMenu={() => setShareMenuOpen(true)}
+        onSend={() => void handleSend()}
+      />
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/heic,.jpg,.jpeg,.png,.heic"
+        className="hidden"
+        onChange={handlePickFile}
+      />
+
+      <ChatShareMenuSheet
+        open={shareMenuOpen}
+        onOpenChange={setShareMenuOpen}
+        onSelect={handleShareKind}
+      />
+      <ChatSharePickerSheet
+        kind={pickerKind}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPickerKind(null);
+          }
+        }}
+        onSelect={(picked) => {
+          setShare(picked);
+          setImageFile(null);
+          setLinkShareUrl(null);
+        }}
+      />
+      <ChatRoomMenuSheet
+        open={roomMenuOpen}
+        onOpenChange={setRoomMenuOpen}
+        onOpenChallenge={() =>
+          room ? router.push(`/challenge/${room.challengeId}`) : undefined
+        }
+      />
+      <ChatMessageActionsSheet
+        state={actions}
+        onOpenChange={(open) => {
+          if (!open) {
+            setActions(null);
+            setActionTarget(null);
+          }
+        }}
+        onCopy={(text) => {
+          void navigator.clipboard
+            .writeText(text)
+            .then(() => toast.success('복사했습니다.'))
+            .catch(() => toast.error('복사하지 못했습니다.'));
+        }}
+        onToggleNotice={handleToggleNotice}
+      />
+    </div>
+  );
+}

--- a/src/app.feature/chat/screen/ChatRoomScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomScreen.tsx
@@ -23,6 +23,7 @@ import {
   ChatShareMenuSheet,
 } from '../components/ChatSheets';
 import {
+  ChatArchivedBanner,
   ChatEndedBanner,
   ChatNoticeBanner,
   ChatNoticeMessageBanner,
@@ -36,7 +37,12 @@ import { useChatRooms } from '../hooks/useChatQueries';
 import { useChatRoom } from '../hooks/useChatRoom';
 import { useEndedBannerDismissal } from '../hooks/useEndedBannerDismissal';
 import { useMeasuredHeight } from '../hooks/useMeasuredHeight';
-import { canSendInRoom, ChatMessage, ChatShareResolution } from '../type/chat';
+import { ChatMessage, ChatShareResolution } from '../type/chat';
+import {
+  canSendInChatRoom,
+  formatChatClosesIn,
+  isChatArchived,
+} from '../utils/chatArchive';
 import { chatShareLinkIn } from '../utils/chatShareLink';
 
 const LINK_RESOLVE_DELAY_MS = 400;
@@ -122,10 +128,14 @@ export function ChatRoomScreen({
   const { mutate: togglePush } = useToggleChatPush();
   const { mutate: setNotice } = useSetChatNotice();
   const { mutate: clearNotice } = useClearChatNotice();
-  const ended = room?.challengeEnded ?? false;
+  // 보관 = 종료 + 7일 경과 읽기 전용. 판정은 chatArchive 한 곳에서만 한다.
+  const archived = room ? isChatArchived(room) : false;
+  // 종료 배너는 아직 보낼 수 있는 동안만 — 보관되면 보관 배너가 대신한다.
+  const ended = (room?.challengeEnded ?? false) && !archived;
+  const closesIn = formatChatClosesIn(room?.chatClosesAt);
   const { dismissed, dismiss } = useEndedBannerDismissal(roomId);
 
-  const canSend = (!room || canSendInRoom(room)) && !kickedOut;
+  const canSend = (!room || canSendInChatRoom(room)) && !kickedOut;
 
   // 실시간 공지 통지가 방 목록보다 우선한다. 통지에는 본문이 안 실려 오므로
   // (뷰어별 권한 때문에 서버가 id 만 준다) 내 내역에서 찾고, 없으면 방
@@ -381,8 +391,9 @@ export function ChatRoomScreen({
         {/* 배너는 메시지 **위에 떠 있다**. Column 에서 자리를 차지하면
             리스트를 밀어내 공유 카드가 배너에 잘려 보였다. */}
         <div ref={bannerRef} className="absolute inset-x-0 top-0 z-10">
+          {archived ? <ChatArchivedBanner /> : null}
           {ended && dismissed === false ? (
-            <ChatEndedBanner onDismiss={dismiss} />
+            <ChatEndedBanner onDismiss={dismiss} closesIn={closesIn} />
           ) : null}
           {notice ? (
             <ChatNoticeBanner
@@ -423,6 +434,7 @@ export function ChatRoomScreen({
             fetchNextPage={fetchNextPage}
             topInset={bannerInset}
             canSend={canSend}
+            archived={archived}
             noticeId={notice?.id}
             highlightId={highlightId}
             onRetry={(message) => void retry(message)}
@@ -435,6 +447,9 @@ export function ChatRoomScreen({
         value={draft}
         onChange={setDraft}
         enabled={canSend}
+        disabledPlaceholder={
+          archived ? '보관된 채팅방이에요' : '읽기 전용 채팅방입니다'
+        }
         sending={sending}
         imageFile={imageFile}
         share={share}

--- a/src/app.feature/chat/screen/ChatRoomScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomScreen.tsx
@@ -2,10 +2,12 @@
 
 import { Text } from '@1d1s/design-system';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
+import { getApiErrorCode } from '@module/api/error';
 import { useSafeBack } from '@module/hooks/useSafeBack';
 import { useSignalPageReady } from '@module/hooks/useSignalPageReady';
 import { toast } from '@module/providers/toast';
 import { cn } from '@module/utils/cn';
+import { useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Bell, BellOff, MoreVertical, Users } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -28,6 +30,7 @@ import {
   ChatNoticeBanner,
   ChatNoticeMessageBanner,
 } from '../components/ChatTopBanners';
+import { CHAT_QUERY_KEYS } from '../consts/queryKeys';
 import {
   useClearChatNotice,
   useSetChatNotice,
@@ -80,6 +83,7 @@ export function ChatRoomScreen({
   roomId: number;
 }): React.ReactElement {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const handleBack = useSafeBack('/chat');
   const { data: sidebar } = useSidebar();
   const { data: roomList } = useChatRooms();
@@ -219,6 +223,15 @@ export function ChatRoomScreen({
       }
       await sendText(text);
     } catch (error) {
+      // 보고 있는 사이에 보관 시각이 지났다(CHAT-017). 목록을 새로 받아
+      // 입력창을 잠근다 — 안 그러면 계속 "보낼 수 있는 척" 한다.
+      if (getApiErrorCode(error) === 'CHAT-017') {
+        toast.error('보관된 채팅방이에요. 더는 메시지를 보낼 수 없어요.');
+        void queryClient.invalidateQueries({
+          queryKey: CHAT_QUERY_KEYS.rooms(),
+        });
+        return;
+      }
       // 판정과 전송 사이에 대상이 지워질 수 있다(CHAT-014). 링크에서 온
       // 카드면 원래 하려던 것 — 링크 보내기 — 로 되돌린다.
       if (pendingShare && linkShareUrl) {

--- a/src/app.feature/chat/socket/chatSocket.ts
+++ b/src/app.feature/chat/socket/chatSocket.ts
@@ -1,0 +1,291 @@
+import { API_BASE_URL } from '@module/api/config';
+import { refreshAccessTokenOnce } from '@module/api/tokenRefresh';
+import { Client, type IMessage, type StompSubscription } from '@stomp/stompjs';
+
+import {
+  ChatMessage,
+  ChatMessageUpdate,
+  ChatNoticeUpdate,
+  ChatSocketError,
+} from '../type/chat';
+
+/**
+ * 채팅 STOMP 연결. **탭 전체에서 하나만** 살아 있고, 화면들은 그 위에 방
+ * 구독을 붙였다 뗀다. 모듈 스코프 싱글턴 + 리스너 refcount 라 StrictMode
+ * 이중 마운트나 HMR 로도 연결이 두 개 생기지 않는다.
+ *
+ * 인증은 **쿠키**다. 브라우저는 STOMP CONNECT 에 Authorization 네이티브
+ * 헤더를 실을 수는 있지만 그러려면 토큰 값을 JS 가 읽어야 하는데, 상용
+ * accessToken 은 httpOnly 라 읽을 수 없다. 서버가 /ws/chat 을 permitAll 로
+ * 열고 JwtAuthenticationFilter 가 핸드셰이크 HTTP 요청에서 쿠키를
+ * (Authorization 헤더보다 먼저) 파싱해 SecurityContext 를 채우면,
+ * ChatStompAuthInterceptor 가 그 principal 을 그대로 쓴다. 즉 WebSocket
+ * 핸드셰이크에 쿠키만 실리면 인증이 끝난다.
+ *
+ * 서버 계약:
+ *   수신  /topic/chat/rooms/{roomId}            본문
+ *         /topic/chat/rooms/{roomId}/notice     공지 설정·해제
+ *         /topic/chat/rooms/{roomId}/updates    링크 프리뷰 지연 완성
+ *   에러  /user/queue/chat-errors  {code,message} + x-failed-destination
+ *
+ * 전송은 소켓이 아니라 REST(POST /chat/rooms/{id}/messages)다 — 소켓이 아직
+ * 안 붙었을 때를 위한 대기열이 필요 없고, 실패가 응답으로 바로 돌아온다.
+ */
+
+const ERROR_QUEUE = '/user/queue/chat-errors';
+const FAILED_DESTINATION_HEADER = 'x-failed-destination';
+const HEARTBEAT_MS = 10_000;
+
+export interface ChatRoomHandlers {
+  onMessage?(message: ChatMessage): void;
+  onNotice?(update: ChatNoticeUpdate): void;
+  onUpdate?(update: ChatMessageUpdate): void;
+  /** 이 방과 관련된 구독 거절. 방과 무관한 에러는 오지 않는다. */
+  onError?(error: ChatSocketError): void;
+  /**
+   * 구독이 (다시) 붙었다. 끊겨 있던 동안 온 메시지는 토픽으로 다시 오지
+   * 않으므로, 이 시점에 최신 페이지를 받아 갭을 메운다.
+   */
+  onReconnect?(): void;
+}
+
+type RoomChannel = '' | '/notice' | '/updates';
+
+const ROOM_CHANNELS: RoomChannel[] = ['', '/notice', '/updates'];
+
+const roomListeners = new Map<number, Set<ChatRoomHandlers>>();
+const subscriptions = new Map<string, StompSubscription>();
+
+let client: Client | null = null;
+/** 한 번이라도 CONNECTED 를 받았는가. 못 받으면 세션을 의심한다. */
+let connectedOnce = false;
+/** 연결 시도 횟수. 두 번째 시도부터가 "직전에 실패한" 상황이다. */
+let attempts = 0;
+/** 세션 갱신을 무한 반복하지 않도록 연결 성공 전까지 1회만. */
+let refreshAttempted = false;
+
+function socketUrl(): string {
+  const base = new URL(API_BASE_URL);
+  base.protocol = base.protocol === 'http:' ? 'ws:' : 'wss:';
+  base.pathname = '/ws/chat';
+  base.search = '';
+  return base.toString();
+}
+
+function parseError(frame: IMessage): ChatSocketError {
+  let body: Partial<ChatSocketError> = {};
+  try {
+    const decoded: unknown = JSON.parse(frame.body || '{}');
+    if (decoded && typeof decoded === 'object') {
+      body = decoded as Partial<ChatSocketError>;
+    }
+  } catch {
+    // 본문이 JSON 이 아니면 코드 없이 통지한다.
+  }
+  return {
+    code: body.code ?? 'UNKNOWN',
+    message: body.message ?? '채팅 서버 오류가 발생했습니다.',
+    failedDestination: frame.headers[FAILED_DESTINATION_HEADER],
+    retryAfterSeconds: body.retryAfterSeconds,
+  };
+}
+
+/** 거절된 destination 에서 방 번호를 뽑는다. 방과 무관한 에러면 null. */
+export function failedRoomId(error: ChatSocketError): number | null {
+  const match = /^\/topic\/chat\/rooms\/(\d+)(\/.*)?$/.exec(
+    error.failedDestination ?? ''
+  );
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * 본문 토픽이 막혔는가. 곁가지 채널(/notice·/updates)만 막힌 것은 메시지
+ * 수신과 무관하다 — 그걸로 "새 메시지가 안 온다" 고 알리면 거짓말이 된다.
+ */
+export function blocksMessages(error: ChatSocketError): boolean {
+  if (!error.failedDestination) {
+    return true;
+  }
+  return /^\/topic\/chat\/rooms\/\d+$/.test(error.failedDestination);
+}
+
+function parseJson<T>(frame: IMessage): T | null {
+  try {
+    const decoded: unknown = JSON.parse(frame.body || '');
+    return decoded && typeof decoded === 'object' ? (decoded as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+function notifyRoom(
+  roomId: number,
+  visit: (handlers: ChatRoomHandlers) => void
+): void {
+  roomListeners.get(roomId)?.forEach(visit);
+}
+
+function subscribeChannel(roomId: number, channel: RoomChannel): void {
+  const active = client;
+  const destination = `/topic/chat/rooms/${roomId}${channel}`;
+  if (!active?.connected || subscriptions.has(destination)) {
+    return;
+  }
+  subscriptions.set(
+    destination,
+    active.subscribe(destination, (frame) => {
+      if (channel === '') {
+        const message = parseJson<ChatMessage>(frame);
+        if (message) {
+          notifyRoom(roomId, (entry) => entry.onMessage?.(message));
+        }
+        return;
+      }
+      if (channel === '/notice') {
+        const update = parseJson<ChatNoticeUpdate>(frame);
+        if (update) {
+          notifyRoom(roomId, (entry) => entry.onNotice?.(update));
+        }
+        return;
+      }
+      const update = parseJson<ChatMessageUpdate>(frame);
+      if (update) {
+        notifyRoom(roomId, (entry) => entry.onUpdate?.(update));
+      }
+    })
+  );
+}
+
+function subscribeRoomChannels(roomId: number): void {
+  ROOM_CHANNELS.forEach((channel) => subscribeChannel(roomId, channel));
+}
+
+function holdReconnect(delayMs: number): void {
+  const held = client;
+  if (!held) {
+    return;
+  }
+  void held.deactivate();
+  window.setTimeout(() => {
+    if (client === held && roomListeners.size > 0) {
+      held.activate();
+    }
+  }, delayMs);
+}
+
+function onErrorFrame(frame: IMessage): void {
+  const error = parseError(frame);
+  // 거절된 구독은 죽은 상태다. 그 핸들만 버리고 **재접속하지 않는다** —
+  // 재접속하면 권한 없는 방 하나 때문에 연결→거절→재접속이 무한히 돈다.
+  if (error.failedDestination) {
+    subscriptions.delete(error.failedDestination);
+  }
+  // 동시 연결 한도. 지금 다시 붙어도 또 막히므로 서버가 알려 준 시간만큼
+  // 쉬었다 붙는다(계약 EG).
+  if (error.code === 'CHAT-015') {
+    holdReconnect((error.retryAfterSeconds ?? 5) * 1000);
+  }
+  const roomId = failedRoomId(error);
+  if (roomId == null) {
+    roomListeners.forEach((handlers) =>
+      handlers.forEach((entry) => entry.onError?.(error))
+    );
+    return;
+  }
+  notifyRoom(roomId, (entry) => entry.onError?.(error));
+}
+
+function ensureClient(): Client {
+  if (client) {
+    return client;
+  }
+  const next = new Client({
+    brokerURL: socketUrl(),
+    // 3초. 서버 하트비트가 10초라 죽은 세션은 그 안에 정리된다.
+    reconnectDelay: 3_000,
+    heartbeatIncoming: HEARTBEAT_MS,
+    heartbeatOutgoing: HEARTBEAT_MS,
+    // 붙기 전에 세션이 만료됐을 수 있다. 첫 연결이 CONNECTED 없이 끊긴
+    // 뒤라면 재시도 전에 쿠키를 한 번 갱신한다 — 갱신된 쿠키는 다음
+    // 핸드셰이크에 자동으로 실린다.
+    beforeConnect: async () => {
+      attempts += 1;
+      if (attempts === 1 || connectedOnce || refreshAttempted) {
+        return;
+      }
+      refreshAttempted = true;
+      try {
+        await refreshAccessTokenOnce();
+      } catch {
+        // 갱신 실패는 그대로 둔다 — 어차피 CONNECT 가 거절된다.
+      }
+    },
+    onConnect: () => {
+      // 첫 연결은 갭이 없다 — 화면이 방금 내역을 받았다.
+      const isReconnect = connectedOnce;
+      connectedOnce = true;
+      refreshAttempted = false;
+      subscriptions.clear();
+      // 에러 큐를 **먼저** 건다. 방 토픽을 먼저 걸면 그 구독이 거절될 때
+      // 통지를 받을 구독처가 아직 없어 조용히 사라진다.
+      subscriptions.set(ERROR_QUEUE, next.subscribe(ERROR_QUEUE, onErrorFrame));
+      roomListeners.forEach((handlers, roomId) => {
+        subscribeRoomChannels(roomId);
+        if (isReconnect) {
+          handlers.forEach((handler) => handler.onReconnect?.());
+        }
+      });
+    },
+    onWebSocketClose: () => {
+      subscriptions.clear();
+    },
+  });
+  client = next;
+  next.activate();
+  return next;
+}
+
+/**
+ * 방 수신 시작. 반환된 함수를 호출하면 이 리스너만 떨어진다. 마지막
+ * 리스너가 빠지면 그 방 구독을 끊되 연결은 유지한다 — 화면을 오갈 때마다
+ * 핸드셰이크를 반복하지 않기 위해서다.
+ */
+export function subscribeChatRoom(
+  roomId: number,
+  handlers: ChatRoomHandlers
+): () => void {
+  const existing = roomListeners.get(roomId);
+  const set = existing ?? new Set<ChatRoomHandlers>();
+  set.add(handlers);
+  roomListeners.set(roomId, set);
+  ensureClient();
+  subscribeRoomChannels(roomId);
+
+  return () => {
+    const current = roomListeners.get(roomId);
+    if (!current) {
+      return;
+    }
+    current.delete(handlers);
+    if (current.size > 0) {
+      return;
+    }
+    roomListeners.delete(roomId);
+    ROOM_CHANNELS.forEach((channel) => {
+      const destination = `/topic/chat/rooms/${roomId}${channel}`;
+      subscriptions.get(destination)?.unsubscribe();
+      subscriptions.delete(destination);
+    });
+  };
+}
+
+/** 로그아웃 등에서 연결 자체를 접는다. */
+export function closeChatSocket(): void {
+  roomListeners.clear();
+  subscriptions.clear();
+  connectedOnce = false;
+  refreshAttempted = false;
+  attempts = 0;
+  void client?.deactivate();
+  client = null;
+}

--- a/src/app.feature/chat/type/chat.ts
+++ b/src/app.feature/chat/type/chat.ts
@@ -84,17 +84,20 @@ export interface ChatRoom {
   challengeEnded: boolean;
 
   /**
-   * 보관 상태(챌린지 종료 후 7일 경과). ⚠️ 서버가 아직 확정하지 않은
-   * 잠정 이름이다 — 확정되면 `utils/chatArchive.ts` 만 고치면 된다.
-   * 화면은 이 필드를 직접 읽지 않는다.
+   * 보관 상태 — 챌린지 종료 후 7일 경과(endDate+8일 00:00 KST 부터).
+   * **status 는 보관돼도 ACTIVE 그대로다** — 보관 판정에 status 를 쓰면 안 된다.
+   * 태그·필터가 이 값을 쓴다. 화면은 `utils/chatArchive.ts` 를 거쳐 읽는다.
    */
   archived?: boolean;
 
-  /**
-   * 전송이 막히는 시각(종료 + 7일). ⚠️ 위와 같은 잠정 이름.
-   * 남은 기간 안내에 쓴다.
-   */
+  /** 전송이 막히는 시각(종료 + 7일). 남은 기간 안내에 쓴다. */
   chatClosesAt?: string | null;
+
+  /**
+   * 서버의 최종 전송 가능 판정(= status ACTIVE && 멤버십 ACTIVE && !archived).
+   * **입력창 잠금은 이 값이 정본이다** — 클라가 조건을 다시 조립하지 않는다.
+   */
+  canSend?: boolean;
 }
 
 export interface ChatRoomList {

--- a/src/app.feature/chat/type/chat.ts
+++ b/src/app.feature/chat/type/chat.ts
@@ -1,0 +1,163 @@
+// 그룹 챌린지 채팅 계약. 앱(_1d1s_app/lib/features/chat/data/chat_api.dart)과
+// 같은 서버 DTO 를 본다 — 이름/옵셔널 여부를 앱 쪽과 어긋나게 두지 않는다.
+
+export const CHAT_MESSAGE_TYPES = [
+  'TEXT',
+  'IMAGE',
+  'CHALLENGE_SHARE',
+  'DIARY_SHARE',
+  // 공지 설정/해제 안내. 클라가 보내면 서버가 CHAT-005 로 막는다.
+  'SYSTEM',
+] as const;
+
+export type ChatMessageType = (typeof CHAT_MESSAGE_TYPES)[number];
+
+/** 공유 카드 내용(ChatShareResponse). */
+export interface ChatShare {
+  targetId: number;
+  title?: string | null;
+  subtitle?: string | null;
+  thumbnailUrl?: string | null;
+  /** 대표 이미지가 없을 때 쓸 카테고리. 일지는 속한 챌린지 카테고리. */
+  category?: string | null;
+  /** false 면 삭제·비공개·차단 — 제목·썸네일이 오지 않는다. */
+  available: boolean;
+}
+
+/** 본문 링크 미리보기(ChatLinkPreviewResponse). */
+export interface ChatLinkPreview {
+  url: string;
+  title?: string | null;
+  description?: string | null;
+  imageUrl?: string | null;
+  siteName?: string | null;
+}
+
+export interface ChatMessage {
+  id: number;
+  roomId: number;
+  senderId: number;
+  senderNickname: string;
+  /** 전송 멱등키. 낙관적 말풍선을 서버 확정본으로 교체할 때 쓴다. */
+  clientMessageId?: string | null;
+  type: ChatMessageType;
+  content?: string | null;
+  imageUrl?: string | null;
+  /** ACTIVE | HIDDEN — HIDDEN 이면 content/imageUrl 이 null 이다. */
+  status: 'ACTIVE' | 'HIDDEN';
+  createdAt: string;
+  share?: ChatShare | null;
+  linkPreview?: ChatLinkPreview | null;
+  /** 서버 응답에는 없는 클라 전용 표시. */
+  pending?: boolean;
+  failed?: boolean;
+}
+
+/** 방 목록 미리보기(ChatLastMessageResponse). preview 는 서버가 완성한다. */
+export interface ChatLastMessage {
+  messageId: number;
+  type: ChatMessageType;
+  preview: string;
+  senderNickname: string;
+  createdAt: string;
+}
+
+export interface ChatRoom {
+  roomId: number;
+  challengeId: number;
+  challengeTitle: string;
+  challengeThumbnailUrl?: string | null;
+  category?: string | null;
+  /** ACTIVE | READ_ONLY — 방 자체가 읽기 전용인지. */
+  status: 'ACTIVE' | 'READ_ONLY';
+  myRole: 'HOST' | 'MEMBER';
+  /** ACTIVE | READ_ONLY — 내 멤버십. */
+  myMembershipStatus: 'ACTIVE' | 'READ_ONLY';
+  pushEnabled: boolean;
+  unreadCount: number;
+  notice?: ChatMessage | null;
+  lastMessage?: ChatLastMessage | null;
+  /**
+   * 챌린지가 끝났는가. 자연 종료 방은 READ_ONLY 로 잠기지 않으므로
+   * status 로는 알 수 없다 — 서버가 주는 이 값이 정본이다.
+   */
+  challengeEnded: boolean;
+}
+
+export interface ChatRoomList {
+  rooms: ChatRoom[];
+  /** 실시간 수신 필터용(내가 차단 ∪ 나를 차단). */
+  hiddenMemberIds: number[];
+}
+
+/** 메시지 내역 한 페이지. 커서형이고 최신순이다. */
+export interface ChatMessagePage {
+  items: ChatMessage[];
+  pageInfo: {
+    limit?: number;
+    hasNextPage: boolean;
+    nextCursor?: string | null;
+  };
+}
+
+/** 붙여넣은 링크가 공유 카드가 될 수 있는지에 대한 서버 판정. */
+export interface ChatShareResolution {
+  shareable: boolean;
+  /** CHALLENGE_SHARE | DIARY_SHARE. 우리 링크가 아니면 없다. */
+  type?: 'CHALLENGE_SHARE' | 'DIARY_SHARE' | null;
+  targetId?: number | null;
+  share?: ChatShare | null;
+}
+
+export interface ChatSendRequest {
+  clientMessageId: string;
+  type: ChatMessageType;
+  content?: string;
+  imageUploadId?: string;
+  sharedTargetId?: number;
+}
+
+export interface ChatImagePresign {
+  uploadUrl: string;
+  imageUploadId: string;
+}
+
+/** 공지 변경 통지(/topic/chat/rooms/{id}/notice). 해제면 id 가 null. */
+export interface ChatNoticeUpdate {
+  noticeMessageId?: number | null;
+  systemMessage?: ChatMessage | null;
+}
+
+/** 링크 프리뷰 지연 완성 통지(/topic/chat/rooms/{id}/updates). */
+export interface ChatMessageUpdate {
+  messageId: number;
+  linkPreview?: ChatLinkPreview | null;
+}
+
+/** 구독이 거절됐을 때 개인 큐(/user/queue/chat-errors)로 오는 것. */
+export interface ChatSocketError {
+  code: string;
+  message: string;
+  /** 거절된 SUBSCRIBE destination(네이티브 헤더 x-failed-destination). */
+  failedDestination?: string;
+  retryAfterSeconds?: number;
+}
+
+/** 입력창을 열어도 되는가. 방과 내 멤버십이 모두 ACTIVE 여야 한다. */
+export function canSendInRoom(room: Pick<
+  ChatRoom,
+  'status' | 'myMembershipStatus'
+>): boolean {
+  return room.status === 'ACTIVE' && room.myMembershipStatus === 'ACTIVE';
+}
+
+/** 공유 대상 상세 경로. 볼 수 없는 대상이면 null. */
+export function chatSharePath(message: ChatMessage): string | null {
+  const share = message.share;
+  if (!share || !share.available) {
+    return null;
+  }
+  return message.type === 'DIARY_SHARE'
+    ? `/diary/${share.targetId}`
+    : `/challenge/${share.targetId}`;
+}

--- a/src/app.feature/chat/type/chat.ts
+++ b/src/app.feature/chat/type/chat.ts
@@ -82,6 +82,19 @@ export interface ChatRoom {
    * status 로는 알 수 없다 — 서버가 주는 이 값이 정본이다.
    */
   challengeEnded: boolean;
+
+  /**
+   * 보관 상태(챌린지 종료 후 7일 경과). ⚠️ 서버가 아직 확정하지 않은
+   * 잠정 이름이다 — 확정되면 `utils/chatArchive.ts` 만 고치면 된다.
+   * 화면은 이 필드를 직접 읽지 않는다.
+   */
+  archived?: boolean;
+
+  /**
+   * 전송이 막히는 시각(종료 + 7일). ⚠️ 위와 같은 잠정 이름.
+   * 남은 기간 안내에 쓴다.
+   */
+  chatClosesAt?: string | null;
 }
 
 export interface ChatRoomList {

--- a/src/app.feature/chat/utils/chatArchive.test.ts
+++ b/src/app.feature/chat/utils/chatArchive.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChatRoom } from '../type/chat';
+import {
+  canSendInChatRoom,
+  formatChatClosesIn,
+  isChatArchived,
+} from './chatArchive';
+
+const NOW = new Date('2026-08-17T12:00:00');
+
+function room(overrides: Partial<ChatRoom> = {}): ChatRoom {
+  return {
+    roomId: 1,
+    challengeId: 2,
+    challengeTitle: '아침 러닝',
+    status: 'ACTIVE',
+    myRole: 'MEMBER',
+    myMembershipStatus: 'ACTIVE',
+    pushEnabled: true,
+    unreadCount: 0,
+    challengeEnded: false,
+    ...overrides,
+  };
+}
+
+describe('isChatArchived', () => {
+  it('서버가 준 archived 가 정본이다', () => {
+    expect(isChatArchived(room({ archived: true }), NOW)).toBe(true);
+    // 파생 조건이 성립해도 서버가 false 라면 false.
+    expect(
+      isChatArchived(
+        room({ archived: false, challengeEnded: true, status: 'READ_ONLY' }),
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('archived 가 없으면 chatClosesAt 경과 여부로 본다', () => {
+    expect(
+      isChatArchived(room({ chatClosesAt: '2026-08-18T12:00:00' }), NOW)
+    ).toBe(false);
+    expect(
+      isChatArchived(room({ chatClosesAt: '2026-08-16T12:00:00' }), NOW)
+    ).toBe(true);
+  });
+
+  it('둘 다 없으면 종료 + 방 자체가 READ_ONLY 일 때만 보관이다', () => {
+    // 종료 후 일주일 안 — 아직 보낼 수 있다.
+    expect(isChatArchived(room({ challengeEnded: true }), NOW)).toBe(false);
+    expect(
+      isChatArchived(room({ challengeEnded: true, status: 'READ_ONLY' }), NOW)
+    ).toBe(true);
+    // 내가 방에서 빠진 것은 방이 보관된 것과 다르다.
+    expect(
+      isChatArchived(
+        room({ challengeEnded: true, myMembershipStatus: 'READ_ONLY' }),
+        NOW
+      )
+    ).toBe(false);
+  });
+});
+
+describe('canSendInChatRoom', () => {
+  it('종료 후 일주일 동안은 그대로 보낼 수 있다', () => {
+    expect(canSendInChatRoom(room({ challengeEnded: true }), NOW)).toBe(true);
+  });
+
+  it('보관되면 못 보낸다', () => {
+    expect(canSendInChatRoom(room({ archived: true }), NOW)).toBe(false);
+  });
+});
+
+describe('formatChatClosesIn', () => {
+  it('하루 이상 남으면 일, 아니면 시간으로 말한다', () => {
+    expect(formatChatClosesIn('2026-08-20T12:00:00', NOW)).toBe('3일');
+    expect(formatChatClosesIn('2026-08-17T15:00:00', NOW)).toBe('3시간');
+  });
+
+  it('이미 지났거나 값이 없으면 아무 말도 하지 않는다', () => {
+    expect(formatChatClosesIn('2026-08-16T12:00:00', NOW)).toBeNull();
+    expect(formatChatClosesIn(null, NOW)).toBeNull();
+    expect(formatChatClosesIn(undefined, NOW)).toBeNull();
+  });
+});

--- a/src/app.feature/chat/utils/chatArchive.test.ts
+++ b/src/app.feature/chat/utils/chatArchive.test.ts
@@ -45,7 +45,16 @@ describe('isChatArchived', () => {
     ).toBe(true);
   });
 
-  it('둘 다 없으면 종료 + 방 자체가 READ_ONLY 일 때만 보관이다', () => {
+  it('보관돼도 status 는 ACTIVE 그대로다 — status 로 판정하지 않는다', () => {
+    expect(
+      isChatArchived(
+        room({ archived: true, status: 'ACTIVE', challengeEnded: true }),
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('과도기 폴백: 둘 다 없으면 종료 + 방 자체가 READ_ONLY 일 때만', () => {
     // 종료 후 일주일 안 — 아직 보낼 수 있다.
     expect(isChatArchived(room({ challengeEnded: true }), NOW)).toBe(false);
     expect(
@@ -62,11 +71,18 @@ describe('isChatArchived', () => {
 });
 
 describe('canSendInChatRoom', () => {
-  it('종료 후 일주일 동안은 그대로 보낼 수 있다', () => {
-    expect(canSendInChatRoom(room({ challengeEnded: true }), NOW)).toBe(true);
+  it('서버 canSend 가 정본이다', () => {
+    expect(canSendInChatRoom(room({ canSend: false }), NOW)).toBe(false);
+    // 보관 방이라도 서버가 보낼 수 있다고 하면 그 말을 따른다 — 잠금 규칙을
+    // 클라가 다시 조립하지 않는다.
+    expect(
+      canSendInChatRoom(room({ canSend: true, archived: true }), NOW)
+    ).toBe(true);
   });
 
-  it('보관되면 못 보낸다', () => {
+  it('과도기 폴백: canSend 가 없으면 상태 + 보관으로 판단한다', () => {
+    // 종료 후 일주일 동안은 그대로 보낼 수 있다.
+    expect(canSendInChatRoom(room({ challengeEnded: true }), NOW)).toBe(true);
     expect(canSendInChatRoom(room({ archived: true }), NOW)).toBe(false);
   });
 });

--- a/src/app.feature/chat/utils/chatArchive.ts
+++ b/src/app.feature/chat/utils/chatArchive.ts
@@ -5,23 +5,20 @@ import { parseChatDate } from './chatFormat';
  * 채팅방 보관(아카이브) 판정 — **화면은 여기만 본다**.
  *
  * 정책: 챌린지가 끝나도 채팅방은 7일 더 살아 있고(그동안은 그대로 전송
- * 가능), 7일이 지나면 읽기 전용으로 잠긴다. 그 잠긴 상태가 "아카이브" 다.
- * 즉 **아카이브 = 종료 + 7일 경과 읽기 전용**이라, 리스트 배지에서
- * `종료`·`읽기 전용` 과 나란히 서지 않고 그 둘을 대신한다.
+ * 가능), 종료 후 7일이 지나면(endDate+8일 00:00 KST) 보관된다. 보관은
+ * 이미 "종료 + 읽기 전용" 이라, 리스트 배지에서 `종료`·`읽기 전용` 과
+ * 나란히 서지 않고 그 둘을 대신한다.
  *
- * ⚠️ 서버가 `ChatRoomResponse` 에 보관 필드를 확정하는 중이다. 확정된
- * 이름이 오면 아래 두 곳(`room.archived`, `room.chatClosesAt`)만 바꾸면
- * 되고, 호출부는 손대지 않는다.
- *
- * 확정 전에도 오늘 있는 필드로 정확히 판정된다: 서버가 7일이 지난 방을
- * READ_ONLY 로 잠그므로 `challengeEnded && status === 'READ_ONLY'` 가 곧
- * 보관 상태다. `myMembershipStatus` 는 보지 않는다 — 내가 방에서 빠진 것과
- * 방이 보관된 것은 다른 일이다.
+ * ⚠️ **`status` 로 판정하지 않는다.** 서버는 보관돼도 status 를 ACTIVE 로
+ * 둔다 — 보관 여부는 `archived` 가 정본이고, 전송 가능 여부는 `canSend` 가
+ * 정본이다(`canSendInChatRoom`).
  */
 export function isChatArchived(room: ChatRoom, now = new Date()): boolean {
   if (typeof room.archived === 'boolean') {
     return room.archived;
   }
+  // 아래 둘은 과도기용이다. `archived` 를 아직 안 싣는 배포에 붙었을 때만
+  // 쓰이고, 그 배포에서는 보관 방이 READ_ONLY 로 잠겨 있었다.
   if (room.chatClosesAt) {
     const closesAt = parseChatDate(room.chatClosesAt);
     if (!Number.isNaN(closesAt.getTime())) {
@@ -32,10 +29,17 @@ export function isChatArchived(room: ChatRoom, now = new Date()): boolean {
 }
 
 /**
- * 이 방에 지금 보낼 수 있는가. `canSendInRoom`(방·멤버십 상태)에 보관
- * 여부를 얹은 최종 판정이다 — 화면은 이것만 쓴다.
+ * 이 방에 지금 보낼 수 있는가 — **입력창 잠금은 이것만 쓴다**.
+ *
+ * 서버 `canSend` 가 정본이다(status·멤버십·보관을 서버가 이미 합쳐 준다).
+ * 클라가 같은 조건을 다시 조립하면 규칙이 두 벌이 되고, 한쪽만 바뀌는 날
+ * 입력창이 "보낼 수 있는 척" 하거나 멀쩡한 방을 잠근다.
  */
 export function canSendInChatRoom(room: ChatRoom, now = new Date()): boolean {
+  if (typeof room.canSend === 'boolean') {
+    return room.canSend;
+  }
+  // 과도기 폴백 — canSend 를 아직 안 싣는 배포용.
   return canSendInRoom(room) && !isChatArchived(room, now);
 }
 

--- a/src/app.feature/chat/utils/chatArchive.ts
+++ b/src/app.feature/chat/utils/chatArchive.ts
@@ -1,0 +1,69 @@
+import { canSendInRoom, ChatRoom } from '../type/chat';
+import { parseChatDate } from './chatFormat';
+
+/**
+ * 채팅방 보관(아카이브) 판정 — **화면은 여기만 본다**.
+ *
+ * 정책: 챌린지가 끝나도 채팅방은 7일 더 살아 있고(그동안은 그대로 전송
+ * 가능), 7일이 지나면 읽기 전용으로 잠긴다. 그 잠긴 상태가 "아카이브" 다.
+ * 즉 **아카이브 = 종료 + 7일 경과 읽기 전용**이라, 리스트 배지에서
+ * `종료`·`읽기 전용` 과 나란히 서지 않고 그 둘을 대신한다.
+ *
+ * ⚠️ 서버가 `ChatRoomResponse` 에 보관 필드를 확정하는 중이다. 확정된
+ * 이름이 오면 아래 두 곳(`room.archived`, `room.chatClosesAt`)만 바꾸면
+ * 되고, 호출부는 손대지 않는다.
+ *
+ * 확정 전에도 오늘 있는 필드로 정확히 판정된다: 서버가 7일이 지난 방을
+ * READ_ONLY 로 잠그므로 `challengeEnded && status === 'READ_ONLY'` 가 곧
+ * 보관 상태다. `myMembershipStatus` 는 보지 않는다 — 내가 방에서 빠진 것과
+ * 방이 보관된 것은 다른 일이다.
+ */
+export function isChatArchived(room: ChatRoom, now = new Date()): boolean {
+  if (typeof room.archived === 'boolean') {
+    return room.archived;
+  }
+  if (room.chatClosesAt) {
+    const closesAt = parseChatDate(room.chatClosesAt);
+    if (!Number.isNaN(closesAt.getTime())) {
+      return now.getTime() >= closesAt.getTime();
+    }
+  }
+  return room.challengeEnded && room.status === 'READ_ONLY';
+}
+
+/**
+ * 이 방에 지금 보낼 수 있는가. `canSendInRoom`(방·멤버십 상태)에 보관
+ * 여부를 얹은 최종 판정이다 — 화면은 이것만 쓴다.
+ */
+export function canSendInChatRoom(room: ChatRoom, now = new Date()): boolean {
+  return canSendInRoom(room) && !isChatArchived(room, now);
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * 전송이 막히기까지 남은 기간. 서버가 `chatClosesAt` 을 아직 안 주면
+ * null — 그때는 배너가 기간 없이 정책만 안내한다.
+ */
+export function formatChatClosesIn(
+  chatClosesAt?: string | null,
+  now = new Date()
+): string | null {
+  if (!chatClosesAt) {
+    return null;
+  }
+  const closesAt = parseChatDate(chatClosesAt);
+  if (Number.isNaN(closesAt.getTime())) {
+    return null;
+  }
+  const remaining = closesAt.getTime() - now.getTime();
+  if (remaining <= 0) {
+    return null;
+  }
+  if (remaining >= DAY_MS) {
+    return `${Math.ceil(remaining / DAY_MS)}일`;
+  }
+  // 하루가 안 남았으면 "0일" 이 아니라 시간으로 말한다.
+  return `${Math.max(1, Math.ceil(remaining / HOUR_MS))}시간`;
+}

--- a/src/app.feature/chat/utils/chatFormat.ts
+++ b/src/app.feature/chat/utils/chatFormat.ts
@@ -1,0 +1,80 @@
+import { ChatRoom } from '../type/chat';
+
+function isSameDay(left: Date, right: Date): boolean {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+/**
+ * 서버는 LocalDateTime 을 타임존 없이 보낸다. `new Date('...')` 는 그런
+ * 문자열을 (ISO 로 보고) UTC 로 읽어 9시간 어긋난다 — 로컬로 파싱한다.
+ */
+export function parseChatDate(value: string): Date {
+  const hasZone = /[Zz]|[+-]\d{2}:?\d{2}$/.test(value);
+  return new Date(hasZone ? value : `${value.replace(' ', 'T')}`);
+}
+
+/** 마지막 메시지 시각 — 카톡 관행(오늘은 시각, 어제는 "어제", 그 밖은 날짜). */
+export function formatRoomTime(value: string, now = new Date()): string {
+  const at = parseChatDate(value);
+  if (Number.isNaN(at.getTime())) {
+    return '';
+  }
+  if (isSameDay(at, now)) {
+    const hour12 = at.getHours() % 12 === 0 ? 12 : at.getHours() % 12;
+    const period = at.getHours() < 12 ? '오전' : '오후';
+    const minute = String(at.getMinutes()).padStart(2, '0');
+    return `${period} ${hour12}:${minute}`;
+  }
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  if (isSameDay(at, yesterday)) {
+    return '어제';
+  }
+  return `${at.getMonth() + 1}월 ${at.getDate()}일`;
+}
+
+/** 말풍선 옆 시각. 날짜 구분선이 날짜를 맡으므로 시:분만 쓴다. */
+export function formatBubbleTime(value: string): string {
+  const at = parseChatDate(value);
+  if (Number.isNaN(at.getTime())) {
+    return '';
+  }
+  const hour12 = at.getHours() % 12 === 0 ? 12 : at.getHours() % 12;
+  const period = at.getHours() < 12 ? '오전' : '오후';
+  return `${period} ${hour12}:${String(at.getMinutes()).padStart(2, '0')}`;
+}
+
+/** 날짜 구분선 라벨. */
+export function formatDateDivider(value: string): string {
+  const at = parseChatDate(value);
+  if (Number.isNaN(at.getTime())) {
+    return '';
+  }
+  const weekday = ['일', '월', '화', '수', '목', '금', '토'][at.getDay()];
+  return `${at.getFullYear()}년 ${at.getMonth() + 1}월 ${at.getDate()}일 (${weekday})`;
+}
+
+/** 같은 날인지 — 날짜 구분선을 넣을 자리를 가른다. */
+export function isSameChatDay(left: string, right: string): boolean {
+  return isSameDay(parseChatDate(left), parseChatDate(right));
+}
+
+/**
+ * 방 한 줄에 뭘 보여 줄지. 마지막 메시지 > 공지 > 안내 순서다 — 대화가
+ * 오간 방에서 공지가 계속 자리를 차지하면 목록이 안 움직인다.
+ */
+export function roomPreview(room: ChatRoom): string {
+  const last = room.lastMessage;
+  if (last && last.preview.trim()) {
+    return `${last.senderNickname}: ${last.preview.replace(/\n/g, ' ')}`;
+  }
+  const notice = room.notice?.content;
+  if (notice && notice.trim()) {
+    return `공지 · ${notice.replace(/\n/g, ' ')}`;
+  }
+  return '메시지를 보내 대화를 시작해 보세요';
+}

--- a/src/app.feature/chat/utils/chatShareLink.ts
+++ b/src/app.feature/chat/utils/chatShareLink.ts
@@ -1,0 +1,68 @@
+// 붙여넣은 1D1S 링크를 알아본다.
+//
+// 판정 자체는 서버가 한다(POST /chat/shares/resolve) — 삭제됐는지, 비공개인지,
+// 남의 일지인지는 클라가 알 수 없다. 여기서 하는 일은 **물어볼 가치가 있는
+// 링크인가** 하나다. 아무 링크나 서버에 물으면 붙여넣기마다 왕복이 는다.
+
+const SHARE_HOSTS = new Set([
+  '1day1streak.com',
+  'www.1day1streak.com',
+  'dev.1day1streak.com',
+  'local.1day1streak.com',
+  'local.dev.1day1streak.com',
+]);
+
+const SHARE_PATHS = new Set(['challenge', 'diary']);
+
+/**
+ * 이 글이 통째로 우리 공유 링크 하나인가. 맞으면 그 URL, 아니면 null.
+ *
+ * 글 중간에 섞인 링크는 건드리지 않는다 — "이거 봐 <링크> 어때?" 를
+ * 공유 카드로 바꿔 버리면 하고 싶던 말이 사라진다.
+ */
+export function chatShareLinkIn(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed || /\s/.test(trimmed)) {
+    return null;
+  }
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return null;
+  }
+  if (!SHARE_HOSTS.has(url.hostname.toLowerCase())) {
+    return null;
+  }
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length < 2 || !SHARE_PATHS.has(segments[0])) {
+    return null;
+  }
+  return Number.isInteger(Number(segments[1])) && segments[1] !== ''
+    ? trimmed
+    : null;
+}
+
+/** 본문 안의 URL. 링크가 없으면 대부분의 메시지처럼 그냥 글로 그린다. */
+export const CHAT_URL_PATTERN = /(https?:\/\/[^\s<>"]+)/gi;
+
+/** 링크 끝에 붙은 문장부호는 주소가 아니다 — "…watch?v=abc." 의 마침표. */
+export function trimUrlTail(url: string): string {
+  const trailing = '.,;:!?)]}\'"';
+  let end = url.length;
+  while (end > 0 && trailing.includes(url[end - 1])) {
+    // 괄호가 짝을 이루면 주소의 일부다(위키 링크 등).
+    if (url[end - 1] === ')') {
+      const opens = (url.match(/\(/g) ?? []).length;
+      const closes = (url.slice(0, end).match(/\)/g) ?? []).length;
+      if (opens >= closes) {
+        break;
+      }
+    }
+    end -= 1;
+  }
+  return url.slice(0, end);
+}

--- a/src/app.feature/home/components/HomeMobileHeader.tsx
+++ b/src/app.feature/home/components/HomeMobileHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Icon } from '@1d1s/design-system';
+import { ChatEntryButton } from '@feature/chat/components/ChatEntryButton';
 import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
 import { useUnreadCount } from '@feature/notification/hooks/useNotificationQueries';
 import { cn } from '@module/utils/cn';
@@ -36,26 +37,30 @@ export default function HomeMobileHeader(): React.ReactElement {
         </span>
       </Link>
 
-      <Link
-        href="/notification"
-        aria-label="알림"
-        className={cn(
-          'relative flex h-9 w-9 items-center justify-center',
-          'rounded-2 bg-gray-100 text-gray-700',
-          'transition hover:bg-gray-200'
-        )}
-      >
-        <Icon name="Bell" size={16} />
-        {hasUnread ? (
-          <span
-            aria-hidden
-            className={cn(
-              'absolute top-2 right-2 h-1.5 w-1.5',
-              'bg-brand rounded-full'
-            )}
-          />
-        ) : null}
-      </Link>
+      <div className="flex items-center gap-2">
+        <ChatEntryButton />
+
+        <Link
+          href="/notification"
+          aria-label="알림"
+          className={cn(
+            'relative flex h-9 w-9 items-center justify-center',
+            'rounded-2 bg-gray-100 text-gray-700',
+            'transition hover:bg-gray-200'
+          )}
+        >
+          <Icon name="Bell" size={16} />
+          {hasUnread ? (
+            <span
+              aria-hidden
+              className={cn(
+                'absolute top-2 right-2 h-1.5 w-1.5',
+                'bg-brand rounded-full'
+              )}
+            />
+          ) : null}
+        </Link>
+      </div>
     </header>
   );
 }

--- a/src/app.feature/install/components/AppInstallPrompt.tsx
+++ b/src/app.feature/install/components/AppInstallPrompt.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import {
+  BottomSheet,
+  BottomSheetContent,
+  BottomSheetTitle,
+  Button,
+  Text,
+} from '@1d1s/design-system';
+import {
+  APP_STORE_URL,
+  buildAndroidIntentUrl,
+  isDeepLinkablePath,
+  PLAY_STORE_URL,
+} from '@constants/appStore';
+import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
+import {
+  type MobilePlatform,
+  useMobilePlatform,
+} from '@module/hooks/useMobilePlatform';
+import { cn } from '@module/utils/cn';
+import { usePathname } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+
+// 한 번 닫으면 이 탭을 닫을 때까지 다시 뜨지 않는다. localStorage 로 영구
+// 저장하면 "앱을 깔았다가 지운" 사용자에게 영영 안 뜬다 — 세션이 맞다.
+const DISMISS_KEY = '1d1s:appPrompt:dismissed';
+
+// 진입 직후 곧바로 시트를 덮으면 사용자가 무엇을 보러 왔는지 알기도 전에
+// 선택을 강요받는다. 화면이 한 번 그려질 틈을 준다.
+const SHOW_DELAY_MS = 1200;
+
+// 로그인·가입 흐름 중에는 띄우지 않는다 — 진행 중인 절차를 끊는다.
+const SUPPRESSED_PREFIXES = ['/login', '/signup', '/auth', '/install'];
+
+function wasDismissed(): boolean {
+  try {
+    return window.sessionStorage.getItem(DISMISS_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function rememberDismissal(): void {
+  try {
+    window.sessionStorage.setItem(DISMISS_KEY, '1');
+  } catch {
+    // 저장이 막힌 환경(프라이빗 모드 등)이면 이번 화면에서만 닫힌다.
+  }
+}
+
+/**
+ * 앱을 연다.
+ *
+ * Android 는 `intent://` 가 **설치 여부를 브라우저가 판단**해 준다 —
+ * 있으면 앱, 없으면 스토어. iOS 는 설치 여부를 알아낼 방법이 없어(스킴
+ * 시도 + 타이머 트릭은 오탐이 잦고 Safari 가 경고창을 띄운다) 스토어로
+ * 보낸다. Universal Links(FR) 가 올라가면 링크 탭 자체가 앱으로 열리므로
+ * 이 버튼의 역할은 미설치 사용자 안내로 좁혀진다.
+ */
+function openApp(platform: MobilePlatform, pathname: string): void {
+  if (platform === 'android') {
+    const target = new URL(window.location.href);
+    // 앱이 받지 못하는 경로는 앱 홈으로 보낸다 — 앱만 열리고 엉뚱한 화면에
+    // 떨어지는 것보다 낫다.
+    if (!isDeepLinkablePath(pathname)) {
+      target.pathname = '/';
+      target.search = '';
+    }
+    window.location.href = buildAndroidIntentUrl(target);
+    return;
+  }
+  window.location.href = APP_STORE_URL;
+}
+
+/**
+ * 모바일 웹으로 들어온 사용자에게 앱을 권하는 바텀시트.
+ *
+ * 데스크톱·네이티브 웹뷰·홈 화면 PWA 에서는 뜨지 않는다.
+ */
+export function AppInstallPrompt({
+  isNativeApp: isNativeAppFromServer = false,
+}: {
+  isNativeApp?: boolean;
+}): React.ReactElement | null {
+  const platform = useMobilePlatform();
+  const isNativeApp = useIsNativeApp(isNativeAppFromServer);
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  const suppressed =
+    isNativeApp ||
+    platform === null ||
+    SUPPRESSED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+
+  useEffect(() => {
+    if (suppressed || wasDismissed()) {
+      return undefined;
+    }
+    const timer = window.setTimeout(() => setOpen(true), SHOW_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [suppressed]);
+
+  if (suppressed) {
+    return null;
+  }
+
+  const close = (): void => {
+    rememberDismissal();
+    setOpen(false);
+  };
+
+  const storeUrl = platform === 'android' ? PLAY_STORE_URL : APP_STORE_URL;
+
+  return (
+    <BottomSheet
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          close();
+        }
+      }}
+    >
+      <BottomSheetContent className="px-5 pb-4">
+        <BottomSheetTitle>
+          <Text size="body1" weight="extrabold" className="text-gray-900">
+            앱에서 더 편하게 이용해 보세요
+          </Text>
+        </BottomSheetTitle>
+        <Text size="body2" className="pt-1.5 text-gray-600">
+          1D1S 앱이 있어요. 알림과 홈 화면 위젯으로 스트릭을 놓치지 않게
+          도와드려요.
+        </Text>
+
+        <div className="flex flex-col gap-2 pt-5">
+          <Button
+            size="lg"
+            fullWidth
+            onClick={() => {
+              rememberDismissal();
+              openApp(platform, pathname);
+            }}
+          >
+            앱으로 열기
+          </Button>
+          <a
+            href={storeUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            onClick={rememberDismissal}
+            className={cn(
+              'flex h-11 items-center justify-center rounded-xl',
+              'text-gray-600 transition-colors hover:bg-gray-50'
+            )}
+          >
+            <Text size="body2" weight="medium" className="text-inherit">
+              {platform === 'android' ? 'Play 스토어' : 'App Store'}에서 보기
+            </Text>
+          </a>
+          <button
+            type="button"
+            onClick={close}
+            className="h-11 text-gray-500 transition-colors hover:text-gray-700"
+          >
+            <Text size="body2" weight="medium" className="text-inherit">
+              웹으로 계속하기
+            </Text>
+          </button>
+        </div>
+      </BottomSheetContent>
+    </BottomSheet>
+  );
+}

--- a/src/app.feature/notification/components/NotificationOptInPrompt.tsx
+++ b/src/app.feature/notification/components/NotificationOptInPrompt.tsx
@@ -76,6 +76,7 @@ export function NotificationOptInPrompt({
         friendEnabled: true,
         diaryEnabled: true,
         challengeEnabled: true,
+        chatEnabled: true,
       },
       {
         onSettled: () => {

--- a/src/app.feature/notification/screen/NotificationSettingsScreen.tsx
+++ b/src/app.feature/notification/screen/NotificationSettingsScreen.tsx
@@ -145,6 +145,7 @@ export function NotificationSettingsScreen(): React.ReactElement {
       friendEnabled: true,
       diaryEnabled: true,
       challengeEnabled: true,
+      chatEnabled: true,
     });
   }, [data, status, updatePreferences]);
 
@@ -286,6 +287,14 @@ export function NotificationSettingsScreen(): React.ReactElement {
               value={data.challengeEnabled}
               disabled={!data.pushEnabled}
               onChange={(next) => handleChange('challengeEnabled', next)}
+            />
+            {/* 방별 종 토글 위의 상위 스위치다 — 여기서 끄면 어느 방도 안 온다. */}
+            <ToggleRow
+              label="채팅 알림"
+              description="그룹 채팅 새 메시지 알림을 받습니다"
+              value={data.chatEnabled}
+              disabled={!data.pushEnabled}
+              onChange={(next) => handleChange('chatEnabled', next)}
             />
           </div>
         </section>

--- a/src/app.feature/notification/type/notification.ts
+++ b/src/app.feature/notification/type/notification.ts
@@ -55,6 +55,11 @@ export interface NotificationPreferences {
   friendEnabled: boolean;
   diaryEnabled: boolean;
   challengeEnabled: boolean;
+  /**
+   * 채팅 푸시 전체 스위치. 방별 pushEnabled 와 **다른 층**이라, 끄면 방별
+   * 설정과 무관하게 아무 방도 푸시가 오지 않는다(서버가 AND 로 건다).
+   */
+  chatEnabled: boolean;
 }
 
 export interface NotificationEndpoint {

--- a/src/app.module/hooks/useMobilePlatform.ts
+++ b/src/app.module/hooks/useMobilePlatform.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+export type MobilePlatform = 'ios' | 'android';
+
+const IOS_PATTERN = /iPad|iPhone|iPod/;
+const ANDROID_PATTERN = /Android/;
+
+function detect(): MobilePlatform | null {
+  if (typeof navigator === 'undefined') {
+    return null;
+  }
+  const userAgent = navigator.userAgent;
+  if (ANDROID_PATTERN.test(userAgent)) {
+    return 'android';
+  }
+  // iPadOS 13+ 는 데스크톱 Safari 로 위장한다 — 터치 지원 Mac 으로 가른다.
+  const isIpadOs =
+    userAgent.includes('Macintosh') && navigator.maxTouchPoints > 1;
+  return IOS_PATTERN.test(userAgent) || isIpadOs ? 'ios' : null;
+}
+
+/**
+ * 홈 화면에 설치된 PWA 로 실행 중인가.
+ *
+ * 이미 홈 화면에서 여는 사용자에게 "앱을 받으세요" 는 소음이다.
+ * standalone 은 iOS Safari 의 비표준 속성이라 둘 다 본다.
+ */
+function isStandalone(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const iosStandalone = (
+    window.navigator as Navigator & { standalone?: boolean }
+  ).standalone;
+  return (
+    iosStandalone === true ||
+    window.matchMedia('(display-mode: standalone)').matches
+  );
+}
+
+// UA 와 display-mode 는 페이지 수명 동안 바뀌지 않는다 — 구독할 것이 없다.
+function subscribe(): () => void {
+  return () => {};
+}
+
+/**
+ * 모바일 브라우저 플랫폼. 데스크톱·PWA standalone·SSR 이면 null.
+ *
+ * SSR 스냅샷을 null 로 두어 하이드레이션 미스매치를 피한다 — 앱 유도는
+ * 첫 페인트에 있어야 할 UI 가 아니라, 하이드레이션 뒤에 나타나도 된다.
+ */
+export function useMobilePlatform(): MobilePlatform | null {
+  return useSyncExternalStore(
+    subscribe,
+    () => (isStandalone() ? null : detect()),
+    () => null
+  );
+}

--- a/src/app.module/metadata/seo.test.ts
+++ b/src/app.module/metadata/seo.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchPublicChallengeMeta } from './seo';
+
+function mockResponse(body: unknown, ok = true): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      json: () => Promise.resolve(body),
+    })
+  );
+}
+
+function challengeBody(challengeType: string): unknown {
+  return {
+    data: {
+      challengeSummary: {
+        title: '비밀 스터디',
+        thumbnailImage: 'https://cdn.example.com/a.png',
+        challengeType,
+      },
+      challengeDetail: { description: '초대받은 사람만' },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchPublicChallengeMeta', () => {
+  it('비공개 챌린지는 제목 한 글자도 내보내지 않는다', async () => {
+    // 서버가 잠금을 안 걸고 200 + 상세를 준 상황(SEC-1).
+    mockResponse(challengeBody('PRIVATE'));
+    await expect(fetchPublicChallengeMeta('12')).resolves.toBeNull();
+  });
+
+  it('공개 챌린지는 그대로 OG 에 싣는다', async () => {
+    mockResponse(challengeBody('PUBLIC'));
+    await expect(fetchPublicChallengeMeta('12')).resolves.toEqual({
+      title: '비밀 스터디',
+      description: '초대받은 사람만',
+      thumbnailImage: 'https://cdn.example.com/a.png',
+    });
+  });
+
+  it('서버가 막아 준 경우(403 등)도 그대로 폴백한다', async () => {
+    mockResponse({}, false);
+    await expect(fetchPublicChallengeMeta('12')).resolves.toBeNull();
+  });
+});

--- a/src/app.module/metadata/seo.ts
+++ b/src/app.module/metadata/seo.ts
@@ -87,9 +87,9 @@ export interface PublicChallengeMeta {
 }
 
 // 챌린지 상세는 비인증 GET /challenges/{id} 가 열려 있어(dev tip 248a99d~)
-// 게스트 응답으로 제목·설명·썸네일을 그대로 OG 에 채운다. 비공개(403)·예약 전
-// 공식(404)·네트워크 오류는 null 을 반환해 루트 기본 OG 로 폴백한다(정보
-// 노출 없음).
+// 게스트 응답으로 제목·설명·썸네일을 그대로 OG 에 채운다. 비공개(403 또는
+// 응답의 challengeType=PRIVATE)·예약 전 공식(404)·네트워크 오류는 null 을
+// 반환해 루트 기본 OG 로 폴백한다(정보 노출 없음).
 export async function fetchPublicChallengeMeta(
   id: string
 ): Promise<PublicChallengeMeta | null> {
@@ -109,18 +109,33 @@ export async function fetchPublicChallengeMeta(
     }
     const body = (await res.json()) as {
       data?: {
-        challengeSummary?: { title?: string; thumbnailImage?: string | null };
+        challengeSummary?: {
+          title?: string;
+          thumbnailImage?: string | null;
+          challengeType?: string;
+        };
         challengeDetail?: { description?: string | null };
       };
     };
-    const title = body.data?.challengeSummary?.title;
+    const summary = body.data?.challengeSummary;
+    // 비공개 챌린지는 제목 한 글자도 싣지 않는다(SEC-1).
+    //
+    // 이 요청은 **비인증**이라 서버가 잠금을 안 걸면 200 + 상세가 그대로
+    // 온다. 그걸 OG 에 넣으면 화면의 비밀번호 게이트와 무관하게 제목·설명이
+    // 페이지 소스에 남고, 카톡 등 스크레이퍼가 비공개 챌린지 링크 프리뷰를
+    // 만들며, revalidate 캐시로 5분간 모든 방문자에게 같은 값이 나간다.
+    // 403 만 믿지 않고 응답 내용으로도 한 번 더 막는다.
+    if (summary?.challengeType === 'PRIVATE') {
+      return null;
+    }
+    const title = summary?.title;
     if (!title) {
       return null;
     }
     return {
       title,
       description: body.data?.challengeDetail?.description,
-      thumbnailImage: body.data?.challengeSummary?.thumbnailImage,
+      thumbnailImage: summary?.thumbnailImage,
     };
   } catch {
     return null;

--- a/src/app.module/middleware/auth.ts
+++ b/src/app.module/middleware/auth.ts
@@ -22,6 +22,7 @@ const PROTECTED_ROUTES: ProtectedRoute[] = [
   { pattern: /^\/challenge\/create\/?$/, type: 'login-redirect' },
   { pattern: /^\/mypage(\/.*)?$/, type: 'login-redirect' },
   { pattern: /^\/notification\/?$/, type: 'login-redirect' },
+  { pattern: /^\/chat(\/.*)?$/, type: 'login-redirect' },
 ];
 
 export interface AuthCheckResult {

--- a/src/app.module/middleware/headers.ts
+++ b/src/app.module/middleware/headers.ts
@@ -7,8 +7,9 @@ import { NextResponse } from 'next/server';
  * - Cache-Control: public, max-age=3600
  *
  * @param res NextResponse
+ * @param pathname 요청 경로. 캐시 정책 예외 판정에만 쓴다.
  */
-export function headersMiddleware(res: NextResponse): void {
+export function headersMiddleware(res: NextResponse, pathname = ''): void {
   const envUrls = [
     process.env.NEXT_PUBLIC_ODOS_API_URL,
     process.env.NEXT_PUBLIC_ODOS_IMAGE_URL,
@@ -85,5 +86,13 @@ export function headersMiddleware(res: NextResponse): void {
   // no-cache 는 "캐시하되 매번 재검증" — ETag/304 로 전송량은 그대로 아끼면서
   // 신선도는 항상 보장된다. 정적 에셋(/_next/static)은 matcher 가 제외하므로
   // 영향 없다.
+  //
+  // 예외: `/.well-known/*` 은 HTML 문서가 아니라 Apple·Google 검증기가
+  // 주기적으로 가져가는 기계용 JSON 이다. 개인화될 일이 없고, 매번 재검증을
+  // 강요하면 그 CDN 들이 원본을 계속 두드린다. 라우트 핸들러가 스스로
+  // 선언한 값을 그대로 살린다.
+  if (pathname.startsWith('/.well-known/')) {
+    return;
+  }
   res.headers.set('Cache-Control', 'private, no-cache');
 }

--- a/src/app.module/middleware/middleware.ts
+++ b/src/app.module/middleware/middleware.ts
@@ -55,7 +55,7 @@ export async function proxy(req: NextRequest): Promise<NextResponse> {
     : NextResponse.next();
 
   applyRefreshedCookies(response, auth.setCookies);
-  headersMiddleware(response);
+  headersMiddleware(response, req.nextUrl.pathname);
 
   // 7. 응답 시간 로깅
   console.log(`Response Time: ${Date.now() - start}ms`);

--- a/src/app.module/utils/nativeBridge.ts
+++ b/src/app.module/utils/nativeBridge.ts
@@ -342,6 +342,20 @@ export function isNativeModalAvailable(): boolean {
 }
 
 /**
+ * 네이티브 쉘이 자기 채팅 화면을 갖고 있는가.
+ *
+ * 갖고 있으면 웹은 채팅 진입점을 그리지 않는다 — 같은 기능이 두 벌 노출되면
+ * 사용자는 어느 쪽이 진짜인지 알 수 없고, 웹 소켓 연결까지 겹친다.
+ * 반응형으로 읽어야 한다(useNativeCapability) — 핸드셰이크가 늦으면 게이트가
+ * false 로 굳는다.
+ */
+export function isNativeChatAvailable(): boolean {
+  return (
+    getNativeWindow()?.[CHANNEL_NAME] != null && hasNativeFeature('chat_native')
+  );
+}
+
+/**
  * SPA 데이터 요청이 끝나기 전에 네이티브 화면을 먼저 연다. 앱이 아닌
  * 환경에서는 false를 반환하므로 호출자가 router.push로 폴백할 수 있다.
  */

--- a/src/app/.well-known/apple-app-site-association/route.ts
+++ b/src/app/.well-known/apple-app-site-association/route.ts
@@ -1,0 +1,27 @@
+import { buildAppleAppSiteAssociation } from '@constants/appLinks';
+import { type NextRequest, NextResponse } from 'next/server';
+
+/**
+ * iOS Universal Links 검증 파일.
+ *
+ * **정적 파일이 아니라 라우트 핸들러인 이유**: 이 파일은 확장자가 없어야
+ * 하는데(`apple-app-site-association`), `public/` 에 그대로 두면 Next 정적
+ * 핸들러가 `application/octet-stream` 으로 내보내고 next.config 의
+ * `headers()` 로도 덮이지 않는다(실측 확인). iOS 는 `application/json` 이
+ * 아니면 무시한다.
+ *
+ * 서명(CMS)은 iOS 9 이후 필요 없다. 리다이렉트도 따라가지 않으므로 이
+ * 경로가 200 을 직접 돌려줘야 한다 — apex 도메인에서 www 로 튕기면 검증이
+ * 실패한다.
+ */
+export function GET(request: NextRequest): NextResponse {
+  const host = request.headers.get('host') ?? '';
+  return NextResponse.json(buildAppleAppSiteAssociation(host), {
+    headers: {
+      'content-type': 'application/json',
+      // Apple CDN 이 주기적으로 가져간다. 앱 ID 가 바뀌는 일은 드물지만
+      // 잘못 올라간 값이 하루 종일 박혀 있지 않게 짧게 둔다.
+      'cache-control': 'public, max-age=3600',
+    },
+  });
+}

--- a/src/app/.well-known/assetlinks.json/route.ts
+++ b/src/app/.well-known/assetlinks.json/route.ts
@@ -1,0 +1,22 @@
+import { buildAssetLinks } from '@constants/appLinks';
+import { type NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Android App Links 검증 파일.
+ *
+ * `public/` 에 두어도 확장자 덕분에 Content-Type 은 맞지만, 요청 호스트마다
+ * 패키지가 달라야 해서(prod/dev) 라우트 핸들러로 둔다 — AASA 와 같은 자리에
+ * 있는 편이 나중에 지문을 추가할 때 찾기도 쉽다.
+ *
+ * 검증 주체는 기기다(설치 시 `autoVerify`). 리다이렉트 없이 200 이어야 하고,
+ * 지문이 하나라도 맞으면 통과한다.
+ */
+export function GET(request: NextRequest): NextResponse {
+  const host = request.headers.get('host') ?? '';
+  return NextResponse.json(buildAssetLinks(host), {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'public, max-age=3600',
+    },
+  });
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,7 @@
+import { ChatRoomListScreen } from '@feature/chat/screen/ChatRoomListScreen';
+import React from 'react';
+
+// 인증 가드는 미들웨어(`src/app.module/middleware/auth.ts`)가 처리한다.
+export default function ChatPage(): React.ReactElement {
+  return <ChatRoomListScreen />;
+}

--- a/src/app/chat/rooms/[roomId]/page.tsx
+++ b/src/app/chat/rooms/[roomId]/page.tsx
@@ -1,0 +1,18 @@
+import { ChatRoomScreen } from '@feature/chat/screen/ChatRoomScreen';
+import { notFound } from 'next/navigation';
+import React from 'react';
+
+// 푸시 딥링크가 그대로 이 경로로 온다
+// (서버 ChatPushEvent data = {type: CHAT_MESSAGE, path: /chat/rooms/{id}}).
+export default async function ChatRoomPage({
+  params,
+}: {
+  params: Promise<{ roomId: string }>;
+}): Promise<React.ReactElement> {
+  const { roomId } = await params;
+  const parsed = Number(roomId);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    notFound();
+  }
+  return <ChatRoomScreen roomId={parsed} />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import '@/app.styles/pretendard-subset.css';
 
 import AppLayoutShell from '@component/layout/AppLayoutShell';
 import ScrollToTop from '@component/layout/ScrollToTop';
+import { APP_STORE_ID } from '@constants/appStore';
 import {
   DEFAULT_OG_IMAGE_PATH,
   OG_IMAGE_HEIGHT,
@@ -46,7 +47,7 @@ export const metadata: Metadata = {
   // AASA 배선 후 경로별 딥링크가 필요해지면, 미들웨어에서 x-pathname 을
   // 요청 헤더로 넣고 이 값을 generateMetadata 로 바꾸면 된다.
   itunes: {
-    appId: '6793538373',
+    appId: APP_STORE_ID,
     appArgument: SITE_URL.toString(),
   },
   icons: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,12 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    // api/config 는 브라우저 환경에서 이 값이 없으면 import 시점에 던진다.
+    // jsdom 테스트는 브라우저로 판정되므로 더미 오리진을 넣어 둔다 —
+    // 네트워크는 테스트에서 각자 mock 한다.
+    env: {
+      NEXT_PUBLIC_ODOS_API_URL: 'https://api.test.1day1streak.com',
+    },
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     // @1d1s/design-system 는 `next/image` 를 bare specifier 로 import 한다.
     // Node ESM 외부화 상태로는 subpath 해석이 실패하므로 vite 로 인라인


### PR DESCRIPTION
앱(_1d1s_app)과 같은 서버 계약으로 웹 채팅을 구현합니다. 신고 UI·메시지별 안읽음 수는 후속입니다.

## 채팅
- **데이터 레이어** — 타입/API/쿼리키/캐시 헬퍼 + STOMP 싱글턴. 인증은 **쿠키**다(서버가 `/ws/chat` 을 permitAll 로 열고 `JwtAuthenticationFilter` 가 핸드셰이크에서 쿠키를 우선 파싱 → STOMP principal). 리스너 refcount 라 StrictMode·HMR 로도 연결이 두 개 생기지 않는다.
- **전송은 REST** — 소켓 SEND 와 달리 실패가 응답으로 바로 돌아오고, 소켓이 아직 안 붙었어도 나간다. 앱의 outbox·전송 타임아웃·rate-limit 재전송이 통째로 불필요해졌다.
- **방 리스트(`/chat`)** — 3:2 썸네일(없으면 카테고리 기본 그림), HOST/종료/읽기전용/아카이브 배타 배지, 안읽음 뱃지, 종 토글(낙관적).
- **방 화면(`/chat/rooms/[id]`)** — 역방향 무한스크롤, 날짜 구분선, SYSTEM 칩, 공유 카드, 링크 프리뷰, 이미지 전송, 낙관적 전송·재전송, 읽음 처리. 떠 있는 배너는 **ResizeObserver 실측 높이**만큼 리스트 위를 비운다(상수로 박으면 배너가 바뀔 때마다 어긋난다).
- **아카이빙** — 종료 후 7일 전송 가능, 이후 보관. 잠금은 서버 `canSend`, 태그·필터는 `archived`. **`status` 는 보관돼도 ACTIVE 라 판정에 쓰지 않는다.** 목록 필터는 `GET /chat/rooms?archived=`.
- **진입점** — 헤더 채팅 버튼 + 안읽음 합계 배지, 챌린지 상세 진입. 네이티브 쉘이 `chat_native` 를 선언하면 웹 진입점을 그리지 않는다.

## 보안 (SEC-1)
서버 403 만 믿던 두 지점을 응답 내용으로도 막는다. 서버가 정상이면 잠들어 있다가 회귀 때만 깨어난다.
- 챌린지 상세: `challengeType=PRIVATE && myStatus=NONE` 이면 서버가 200 을 줘도 비밀번호 게이트.
- **OG 메타데이터**: `fetchPublicChallengeMeta` 는 비인증 요청이라, 서버가 안 막으면 제목·설명이 page source 에 남고 스크레이퍼가 비공개 챌린지 링크 프리뷰를 만들고 revalidate 캐시로 5분간 모든 방문자에게 나갔다.

## 앱 유도 / 딥링크
- 모바일 웹 진입 시 앱 유도 바텀시트. Android 는 `intent://` 로 **설치 여부를 브라우저가 판단**(있으면 앱, 없으면 Play). 데스크톱·네이티브 웹뷰·PWA standalone 에서는 안 뜬다.
- `.well-known` AASA + assetlinks 서빙. **호스트로 내용이 갈린다**(prod/dev 패키지·appID 가 다르다). AASA 는 확장자가 없어야 해서 라우트 핸들러다 — `public/` 에 두면 `application/octet-stream` 이 나가고 `headers()` 로도 안 덮인다.

## 검증
`pnpm lint` 0 errors · `tsc --noEmit` · **248 tests passed** · `pnpm build` 성공.
**브라우저 실동작은 미확인** — dev 배포 후 확인 예정.

## 남은 것
- 신고 UI (바로 가능)
- 메시지별 안읽음 수 — 서버가 내 `memberId` 를 내려주는 게 선행. 지금은 "내 메시지" 판정을 닉네임 비교로 하고 있어 동명이인·닉변에 취약하다.
- 프로덕션 도메인 딥링크 파일은 웹 프로덕션 배포 때.

> 브랜치명이 `feat/ODS-{번호}` 규칙과 다릅니다 — 티켓 번호를 몰라 붙이지 못했습니다.