### PR TITLE
fix(install): 앱 유도 시트 버튼을 하나로 통합(FZ-2)

### DIFF
--- a/src/app.constants/appLinks.ts
+++ b/src/app.constants/appLinks.ts
@@ -58,6 +58,17 @@ export function resolveAppleAppId(host: string): string {
   return `${APPLE_TEAM_ID}.${isDevHost(host) ? DEV_PACKAGE : PROD_PACKAGE}`;
 }
 
+/**
+ * 앱이 등록한 커스텀 URL 스킴(iOS `APP_URL_SCHEME`, Android `appAuthScheme`).
+ *
+ * 원래는 OAuth 콜백용이지만 iOS 는 스킴을 **앱 단위로** 등록하므로
+ * `onedayonestreak://` 만으로 앱이 앞으로 나온다 — "앱이 깔려 있는가" 를
+ * JS 로 알 수 없는 iOS 에서 유일하게 쓸 수 있는 신호다.
+ */
+export function resolveAppScheme(host: string): string {
+  return isDevHost(host) ? 'onedayonestreakdev' : 'onedayonestreak';
+}
+
 /** Android App Links 용 패키지명. */
 export function resolveAndroidPackage(host: string): string {
   return isDevHost(host) ? DEV_PACKAGE : PROD_PACKAGE;

--- a/src/app.feature/install/components/AppInstallPrompt.tsx
+++ b/src/app.feature/install/components/AppInstallPrompt.tsx
@@ -7,20 +7,12 @@ import {
   Button,
   Text,
 } from '@1d1s/design-system';
-import {
-  APP_STORE_URL,
-  buildAndroidIntentUrl,
-  isDeepLinkablePath,
-  PLAY_STORE_URL,
-} from '@constants/appStore';
 import { useIsNativeApp } from '@module/hooks/useIsNativeApp';
-import {
-  type MobilePlatform,
-  useMobilePlatform,
-} from '@module/hooks/useMobilePlatform';
-import { cn } from '@module/utils/cn';
+import { useMobilePlatform } from '@module/hooks/useMobilePlatform';
 import { usePathname } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+
+import { openAppOrStore } from '../utils/openApp';
 
 // 한 번 닫으면 이 탭을 닫을 때까지 다시 뜨지 않는다. localStorage 로 영구
 // 저장하면 "앱을 깔았다가 지운" 사용자에게 영영 안 뜬다 — 세션이 맞다.
@@ -50,30 +42,6 @@ function rememberDismissal(): void {
 }
 
 /**
- * 앱을 연다.
- *
- * Android 는 `intent://` 가 **설치 여부를 브라우저가 판단**해 준다 —
- * 있으면 앱, 없으면 스토어. iOS 는 설치 여부를 알아낼 방법이 없어(스킴
- * 시도 + 타이머 트릭은 오탐이 잦고 Safari 가 경고창을 띄운다) 스토어로
- * 보낸다. Universal Links(FR) 가 올라가면 링크 탭 자체가 앱으로 열리므로
- * 이 버튼의 역할은 미설치 사용자 안내로 좁혀진다.
- */
-function openApp(platform: MobilePlatform, pathname: string): void {
-  if (platform === 'android') {
-    const target = new URL(window.location.href);
-    // 앱이 받지 못하는 경로는 앱 홈으로 보낸다 — 앱만 열리고 엉뚱한 화면에
-    // 떨어지는 것보다 낫다.
-    if (!isDeepLinkablePath(pathname)) {
-      target.pathname = '/';
-      target.search = '';
-    }
-    window.location.href = buildAndroidIntentUrl(target);
-    return;
-  }
-  window.location.href = APP_STORE_URL;
-}
-
-/**
  * 모바일 웹으로 들어온 사용자에게 앱을 권하는 바텀시트.
  *
  * 데스크톱·네이티브 웹뷰·홈 화면 PWA 에서는 뜨지 않는다.
@@ -87,6 +55,10 @@ export function AppInstallPrompt({
   const isNativeApp = useIsNativeApp(isNativeAppFromServer);
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  // iOS 폴백 타이머는 시트를 닫거나 언마운트될 때 반드시 걷어야 한다 —
+  // 남겨 두면 앱에서 돌아온 뒤 뒤늦게 App Store 로 튈 수 있다.
+  const cleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => cleanupRef.current?.(), []);
 
   const suppressed =
     isNativeApp ||
@@ -107,10 +79,10 @@ export function AppInstallPrompt({
 
   const close = (): void => {
     rememberDismissal();
+    cleanupRef.current?.();
+    cleanupRef.current = null;
     setOpen(false);
   };
-
-  const storeUrl = platform === 'android' ? PLAY_STORE_URL : APP_STORE_URL;
 
   return (
     <BottomSheet
@@ -132,31 +104,21 @@ export function AppInstallPrompt({
           도와드려요.
         </Text>
 
+        {/* 버튼은 하나다. 깔려 있으면 앱이 열리고 없으면 스토어로 가는데,
+            그 갈림은 사용자가 알 필요도 고를 필요도 없다 — 두 개로 두면
+            (특히 미설치 사용자에게) 무엇을 눌러야 할지 되묻게 된다. */}
         <div className="flex flex-col gap-2 pt-5">
           <Button
             size="lg"
             fullWidth
             onClick={() => {
               rememberDismissal();
-              openApp(platform, pathname);
+              cleanupRef.current?.();
+              cleanupRef.current = openAppOrStore(platform, pathname);
             }}
           >
             앱으로 열기
           </Button>
-          <a
-            href={storeUrl}
-            target="_blank"
-            rel="noreferrer noopener"
-            onClick={rememberDismissal}
-            className={cn(
-              'flex h-11 items-center justify-center rounded-xl',
-              'text-gray-600 transition-colors hover:bg-gray-50'
-            )}
-          >
-            <Text size="body2" weight="medium" className="text-inherit">
-              {platform === 'android' ? 'Play 스토어' : 'App Store'}에서 보기
-            </Text>
-          </a>
           <button
             type="button"
             onClick={close}

--- a/src/app.feature/install/utils/openApp.test.ts
+++ b/src/app.feature/install/utils/openApp.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  APP_OPEN_TIMEOUT_MS,
+  shouldFallbackToStore,
+  SUSPEND_DRIFT_MS,
+} from './openApp';
+
+// 오판의 대가가 비대칭이다 — 안 보내면 한 번 더 누르면 되지만, 잘못
+// 보내면 이미 열린 앱을 App Store 가 덮는다. 그래서 "앱이 열렸다" 신호가
+// 하나라도 있으면 보내지 않는지를 각각 잠근다.
+describe('shouldFallbackToStore', () => {
+  const onTime = { elapsedMs: APP_OPEN_TIMEOUT_MS };
+
+  it('앱이 안 열렸으면(화면 그대로, 제시간) 스토어로 보낸다', () => {
+    expect(
+      shouldFallbackToStore({ wentHidden: false, hiddenNow: false, ...onTime })
+    ).toBe(true);
+  });
+
+  it('중간에 화면이 숨겨졌으면 보내지 않는다 — 앱이 앞으로 나온 것이다', () => {
+    expect(
+      shouldFallbackToStore({ wentHidden: true, hiddenNow: false, ...onTime })
+    ).toBe(false);
+  });
+
+  it('지금 숨겨져 있으면 보내지 않는다', () => {
+    expect(
+      shouldFallbackToStore({ wentHidden: false, hiddenNow: true, ...onTime })
+    ).toBe(false);
+  });
+
+  it('타이머가 늦게 돌았으면 보내지 않는다 — 그동안 페이지가 정지돼 있었다', () => {
+    // 앱에서 한참 있다가 돌아와 뒤늦게 콜백이 실행된 경우.
+    expect(
+      shouldFallbackToStore({
+        wentHidden: false,
+        hiddenNow: false,
+        elapsedMs: APP_OPEN_TIMEOUT_MS + SUSPEND_DRIFT_MS + 1,
+      })
+    ).toBe(false);
+    // 반대로 오차 범위 안이면 정상 타임아웃으로 본다.
+    expect(
+      shouldFallbackToStore({
+        wentHidden: false,
+        hiddenNow: false,
+        elapsedMs: APP_OPEN_TIMEOUT_MS + SUSPEND_DRIFT_MS - 1,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/app.feature/install/utils/openApp.ts
+++ b/src/app.feature/install/utils/openApp.ts
@@ -1,0 +1,124 @@
+import { resolveAppScheme } from '@constants/appLinks';
+import {
+  APP_STORE_URL,
+  buildAndroidIntentUrl,
+  isDeepLinkablePath,
+} from '@constants/appStore';
+import type { MobilePlatform } from '@module/hooks/useMobilePlatform';
+
+/**
+ * 앱이 뜨기를 기다리는 시간.
+ *
+ * 짧으면 앱이 막 올라오는 중에 스토어로 튀고, 길면 미설치 사용자가 아무
+ * 반응 없는 화면을 그만큼 본다. iOS 가 스킴을 처리해 앱을 전면으로
+ * 올리는 데 보통 0.3~0.8초가 걸려서 그 위에 여유를 얹은 값이다.
+ */
+export const APP_OPEN_TIMEOUT_MS = 1200;
+
+/**
+ * 타이머가 이만큼 늦게 돌았으면 그 사이 페이지가 정지돼 있었다고 본다.
+ *
+ * 앱이 전면으로 올라오면 Safari 는 백그라운드가 되고 타이머가 throttle
+ * 되거나 아예 멈춘다. 돌아왔을 때 뒤늦게 실행된 콜백이 스토어로 보내면
+ * "앱에서 나왔더니 App Store 가 떠 있는" 오작동이 된다.
+ */
+export const SUSPEND_DRIFT_MS = 400;
+
+export interface FallbackDecision {
+  /** 그 사이 페이지가 숨겨진 적이 있는가(=앱이 전면으로 올라왔다). */
+  wentHidden: boolean;
+  /** 지금 페이지가 숨겨져 있는가. */
+  hiddenNow: boolean;
+  /** 스킴을 던진 뒤 실제로 흐른 시간(ms). */
+  elapsedMs: number;
+}
+
+/**
+ * 스토어로 보내야 하는가 — **타임아웃 폴백의 판단부만** 떼어낸 순수 함수.
+ *
+ * 셋 중 하나라도 "앱이 열렸다" 를 가리키면 보내지 않는다. 오판의 대가가
+ * 비대칭이기 때문이다: 안 보내면 사용자가 버튼을 한 번 더 누르면 되지만,
+ * 잘못 보내면 이미 열린 앱을 두고 App Store 가 덮어쓴다.
+ */
+export function shouldFallbackToStore({
+  wentHidden,
+  hiddenNow,
+  elapsedMs,
+}: FallbackDecision): boolean {
+  if (wentHidden || hiddenNow) {
+    return false;
+  }
+  return elapsedMs < APP_OPEN_TIMEOUT_MS + SUSPEND_DRIFT_MS;
+}
+
+/** 앱에 넘길 경로. 앱이 못 받는 경로면 앱 홈으로 보낸다. */
+function resolveTargetUrl(pathname: string): URL {
+  const target = new URL(window.location.href);
+  if (!isDeepLinkablePath(pathname)) {
+    target.pathname = '/';
+    target.search = '';
+  }
+  return target;
+}
+
+/**
+ * 앱을 열고, 안 열리면 스토어로 보낸다 — 버튼 하나가 두 경우를 다 맡는다.
+ *
+ * **Android** 는 `intent://` 가 설치 여부를 브라우저에게 물어 준다. 있으면
+ * 앱, 없으면 `browser_fallback_url`(Play). 타이머가 필요 없고 오판도 없다.
+ *
+ * **iOS** 는 설치 여부를 알아낼 API 가 없다. 커스텀 스킴을 던져 보고,
+ * 정해진 시간 안에 화면이 그대로면 안 열린 것으로 보고 App Store 로
+ * 보낸다. 그 판단은 `shouldFallbackToStore` 가 한다.
+ *
+ * @returns 정리 함수. 시트가 닫히는 등으로 중간에 그만둘 때 호출한다.
+ */
+export function openAppOrStore(
+  platform: MobilePlatform,
+  pathname: string
+): () => void {
+  if (platform === 'android') {
+    window.location.href = buildAndroidIntentUrl(resolveTargetUrl(pathname));
+    return () => undefined;
+  }
+
+  let wentHidden = false;
+  let timer = 0;
+  const startedAt = Date.now();
+
+  const onVisibilityChange = (): void => {
+    if (document.hidden) {
+      wentHidden = true;
+    }
+  };
+  const cleanup = (): void => {
+    window.clearTimeout(timer);
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+    window.removeEventListener('pagehide', onVisibilityChange);
+  };
+
+  document.addEventListener('visibilitychange', onVisibilityChange);
+  // iOS 가 앱으로 넘어갈 때 visibilitychange 대신 pagehide 만 오는 경우가 있다.
+  window.addEventListener('pagehide', onVisibilityChange);
+
+  timer = window.setTimeout(() => {
+    cleanup();
+    if (
+      shouldFallbackToStore({
+        wentHidden,
+        hiddenNow: document.hidden,
+        elapsedMs: Date.now() - startedAt,
+      })
+    ) {
+      window.location.href = APP_STORE_URL;
+    }
+  }, APP_OPEN_TIMEOUT_MS);
+
+  // 스킴은 경로 없이 던진다. 앱의 커스텀 스킴 intent-filter 는 OAuth 콜백
+  // (host=auth) 만 받으므로 경로를 실어도 그 화면으로 가지 않는다 — 앱을
+  // 앞으로 불러내는 것까지가 이 스킴의 역할이고, 경로 라우팅은 유니버설
+  // 링크(AASA)가 맡는다.
+  window.location.href = `${resolveAppScheme(window.location.host)}://`;
+
+  return cleanup;
+}


### PR DESCRIPTION
## 문제
"앱으로 열기" + "App Store에서 보기" 두 버튼이라, 특히 **미설치 사용자**가 무엇을 눌러야 할지 되묻게 됐습니다. 앱이 깔렸는지 아닌지는 사용자가 알 필요도 고를 필요도 없는 정보입니다.

## 변경
버튼 하나("앱으로 열기")가 두 경우를 다 맡습니다. "웹으로 계속하기"는 유지, "App Store에서 보기" 단독 항목은 제거하고 스토어 이동은 **폴백으로만** 남깁니다.

| 플랫폼 | 앱 설치됨 | 미설치 |
|---|---|---|
| Android | `intent://` → 앱 (딥링크 경로 유지) | `browser_fallback_url` → Play |
| iOS | 커스텀 스킴 → 앱 | 타임아웃 폴백 → App Store |

**Android 는 타이머가 없습니다** — `intent://` 가 설치 여부를 브라우저에게 물어 주므로 오판 자체가 없습니다. 기존 동작 그대로입니다.

**iOS 만 타임아웃**입니다. 설치 여부를 알아낼 API 가 없어, 커스텀 스킴(`onedayonestreak://`, dev 는 `onedayonestreakdev://`)을 던져 보고 정해진 시간 안에 화면이 그대로면 App Store 로 보냅니다.

## 오작동 방지
오판의 대가가 비대칭입니다 — 안 보내면 사용자가 한 번 더 누르면 되지만, **잘못 보내면 이미 열린 앱을 App Store 가 덮습니다.** 그래서 "앱이 열렸다" 신호가 하나라도 있으면 보내지 않습니다:

- `visibilitychange` / `pagehide` 로 화면이 숨겨진 적이 있으면 취소 (앱이 전면으로 올라온 것)
- 콜백 시점에 `document.hidden` 이면 취소
- **타이머가 예정보다 늦게 돌았으면 취소** — 앱이 열리면 Safari 가 백그라운드가 되어 타이머가 정지하고, 돌아왔을 때 뒤늦게 실행됩니다. 이걸 안 막으면 "앱에서 나왔더니 App Store 가 떠 있는" 증상이 됩니다.
- 시트를 닫거나 언마운트되면 타이머를 걷습니다.

타이밍은 1200ms + 400ms 오차 허용입니다(iOS 가 스킴을 처리해 앱을 올리는 데 보통 0.3~0.8초).

판단부는 순수 함수 `shouldFallbackToStore` 로 떼어내 네 갈래를 전부 테스트로 잠갔습니다 — DOM 타이밍에 의존하지 않고 회귀를 잡습니다.

## 검증
`pnpm lint` 0 · `tsc` · **252 tests passed** (+4) · `knip` 0 · `build` 성공.
**iOS 실기기 동작은 미확인** — dev 배포 후 확인이 필요합니다(설치/미설치 두 경우).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified “Open in App” experience for Android and iOS.
  * Preserves supported deep-link paths when opening the app.
  * Automatically redirects to the appropriate app store when the app isn’t installed.
  * Uses the correct development or production app link based on the request environment.

* **Bug Fixes**
  * Improved fallback handling when returning from or switching away from the browser.
  * Added cleanup to prevent stale timers and listeners during repeated attempts or dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->