### PR TITLE
fix(chat): 모바일 공유카드 잘림 · 헤더 밀림 · 챌린지 상세 채팅 진입(FZ-3~5)

### DIFF
--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -706,6 +706,15 @@ export function ChallengeDetailScreen({
           {summary.challengeType === 'OFFICIAL' ? (
             <OfficialChallengeGuideBanner />
           ) : null}
+          {/* 채팅방 진입은 히어로 바로 아래에 둔다. 우측 레일에 두면
+              모바일(1열)에서 탭 콘텐츠 전부 뒤로 밀려, 페이지 맨 끝까지
+              스크롤해야 보였다 — 사실상 없는 버튼이었다. */}
+          <ChallengeChatEntry
+            challengeId={challengeId}
+            enabled={isParticipating && isGroupChallenge}
+            className="mb-4"
+          />
+
           <div
             className={cn(
               'grid grid-cols-1 gap-4',
@@ -965,11 +974,6 @@ export function ChallengeDetailScreen({
                   isLikePending={isActionLoading}
                 />
               </div>
-
-              <ChallengeChatEntry
-                challengeId={challengeId}
-                enabled={isParticipating && isGroupChallenge}
-              />
 
               {isParticipating ? (
                 <button

--- a/src/app.feature/chat/components/ChallengeChatEntry.tsx
+++ b/src/app.feature/chat/components/ChallengeChatEntry.tsx
@@ -20,10 +20,12 @@ import { useChatRoomForChallenge } from '../hooks/useChatQueries';
 export function ChallengeChatEntry({
   challengeId,
   enabled,
+  className,
 }: {
   challengeId: number;
   /** 참여 중인 그룹 챌린지일 때만 방 목록을 조회한다. */
   enabled: boolean;
+  className?: string;
 }): React.ReactElement | null {
   const nativeChat = useNativeCapability(isNativeChatAvailable);
   const roomId = useChatRoomForChallenge(challengeId, {
@@ -40,7 +42,8 @@ export function ChallengeChatEntry({
       className={cn(
         'flex items-center justify-center gap-1.5 rounded-xl border',
         'border-gray-200 bg-white py-2.5 text-gray-700',
-        'transition-colors hover:bg-gray-50'
+        'transition-colors hover:bg-gray-50',
+        className
       )}
     >
       <MessageCircle className="h-4 w-4" />

--- a/src/app.feature/chat/components/ChatComposer.tsx
+++ b/src/app.feature/chat/components/ChatComposer.tsx
@@ -134,7 +134,14 @@ export function ChatComposer({
   const canSend = enabled && !sending && hasContent;
 
   return (
-    <div className="shrink-0 border-t border-gray-200 bg-white px-4 py-2">
+    <div
+      className={cn(
+        'shrink-0 border-t border-gray-200 bg-white px-4 pt-2',
+        // 홈 인디케이터 영역만큼 아래를 더 띄운다. 없는 기기에서는 0 이라
+        // 기존 여백 그대로다.
+        'pb-[calc(0.5rem+env(safe-area-inset-bottom))]'
+      )}
+    >
       {imageFile ? (
         <div className="pb-2">
           <ImageAttachment file={imageFile} onRemove={onRemoveAttachment} />

--- a/src/app.feature/chat/components/ChatRoomThumbnail.tsx
+++ b/src/app.feature/chat/components/ChatRoomThumbnail.tsx
@@ -46,7 +46,10 @@ export function ChatRoomThumbnail({
           src={resolved}
           alt=""
           loading="lazy"
-          className="h-full w-full object-cover"
+          // 비율이 제각각인 원본을 자리에 맞춰 가운데 기준으로 채운다.
+          // object-center 는 기본값이지만, "왜 잘리는가" 가 의도된 동작임을
+          // 남겨 둔다.
+          className="h-full w-full object-cover object-center"
         />
       </div>
     );

--- a/src/app.feature/chat/components/ChatShareCard.tsx
+++ b/src/app.feature/chat/components/ChatShareCard.tsx
@@ -12,7 +12,14 @@ import { ChatRoomThumbnail } from './ChatRoomThumbnail';
 
 // 공유 카드와 링크 미리보기의 폭. 둘이 제각각이면 말풍선 줄이 들쭉날쭉해
 // 보인다 — 한 값을 같이 쓴다.
-const CARD_CLASS = 'w-[232px] overflow-hidden rounded-[10px] border';
+//
+// `max-w-full` 이 핵심이다. 232px 고정만 두면 좁은 화면에서 말풍선
+// 콘텐츠 폭(= 최대 80% 에서 시각 라벨과 좌우 패딩을 뺀 값)보다 카드가
+// 넓어지는데, 말풍선이 `overflow-hidden` 이라 **오른쪽이 잘린 채** 그려진다
+// (모바일에서 카드가 한쪽으로 쏠려 보이던 원인). 232px 는 이제 상한이고,
+// 자리가 모자라면 카드가 말풍선에 맞춰 줄어든다.
+const CARD_CLASS =
+  'w-[232px] max-w-full min-w-0 overflow-hidden rounded-[10px] border';
 
 /**
  * 공유 카드. 볼 수 없는 대상이면 눌리지 않는다 — 보낼 땐 공개였던 일지가
@@ -118,7 +125,7 @@ export function ChatLinkPreviewCard({
           src={image}
           alt=""
           loading="lazy"
-          className="h-[116px] w-full object-cover"
+          className="h-[116px] w-full object-cover object-center"
         />
       ) : null}
       <div className="flex flex-col gap-1 p-2.5">

--- a/src/app.feature/chat/screen/ChatRoomScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomScreen.tsx
@@ -344,7 +344,19 @@ export function ChatRoomScreen({
   };
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-[760px] flex-col bg-gray-50">
+    // 높이를 **여기서 확정한다**. `h-full` 로 두면 부모(AppLayoutShell 의
+    // main)가 `min-h-screen` 기반 auto 높이라 퍼센트가 해석되지 않아 채팅
+    // 화면이 콘텐츠 높이로 늘어나고, 그러면 내부 리스트 대신 **페이지가**
+    // 스크롤되면서 헤더가 같이 밀려 올라갔다(헤더가 안 붙어 보이던 원인).
+    // 100dvh 는 모바일 사파리 주소창 높이 변화까지 따라간다.
+    // 데스크톱(lg)에는 글로벌 TopNav(62px)가 위에 있어 그만큼 뺀다 — 채팅
+    // 라우트는 바텀 네비도, 뒤로가기 바도 없다.
+    <div
+      className={cn(
+        'mx-auto flex w-full max-w-[760px] flex-col bg-gray-50',
+        'h-[100dvh] lg:h-[calc(100dvh-62px)]'
+      )}
+    >
       <header
         className={cn(
           'flex shrink-0 items-center gap-1 border-b border-gray-200',
@@ -456,6 +468,7 @@ export function ChatRoomScreen({
         )}
       </div>
 
+      {/* 홈 인디케이터가 있는 기기에서 입력창이 가려지지 않게. */}
       <ChatComposer
         value={draft}
         onChange={setDraft}


### PR DESCRIPTION
모바일 실뷰(dev)에서 나온 3건. 셋 다 데스크톱 폭에서는 안 드러나고 모바일에서만 깨졌습니다.

## FZ-3 공유 카드 썸네일 쏠림
**원인**: 카드 폭이 `w-[232px]` **고정**. 말풍선 콘텐츠 폭(= 최대 80% − 시각 라벨 − 좌우 패딩)보다 카드가 넓어지는 화면에서, 말풍선의 `overflow-hidden` 에 **오른쪽이 잘린 채** 그려졌습니다. 이미지가 어긋나 보인 게 아니라 카드째로 잘려 있었습니다.

**수정**: 232px 를 **상한**으로 바꿉니다(`max-w-full min-w-0`). 자리가 모자라면 카드가 말풍선에 맞춰 줄어듭니다. 이미지는 `object-cover object-center` 로 crop 기준을 명시했습니다(기본값이지만 "왜 잘리는가"가 의도임을 남김).

## FZ-4 채팅방 헤더가 안 붙음
**원인**: sticky 문제가 아니었습니다. **높이 체인이 끊겨 있었습니다.** 채팅 화면이 `h-full` 인데 부모(`AppLayoutShell` 의 `main`)가 `min-h-screen` 기반 auto 높이라 퍼센트가 해석되지 않습니다. 그래서 화면이 콘텐츠 높이로 늘어나고, **내부 리스트 대신 페이지가** 스크롤되면서 헤더가 같이 밀려 올라갔습니다. 헤더에 `sticky` 를 붙였어도 스크롤 컨테이너가 페이지라 같은 증상이 났을 겁니다.

**수정**: 높이를 채팅 화면에서 확정합니다 — `h-[100dvh]`, 데스크톱은 글로벌 TopNav(62px)만큼 뺀 `lg:h-[calc(100dvh-62px)]`. `dvh` 라 모바일 사파리 주소창 높이 변화를 따라갑니다. 이제 스크롤 컨테이너가 메시지 리스트뿐이라 **헤더·컴포저가 자연히 고정**됩니다(추가 sticky 불필요). 컴포저에는 홈 인디케이터 세이프에어리어(`pb-[calc(0.5rem+env(safe-area-inset-bottom))]`)를 넣었습니다.

## FZ-5 챌린지 상세 채팅 진입 버튼
**원인**: 렌더는 되고 있었습니다. 우측 sticky 레일(`<aside>`)에 넣었는데, 모바일은 그 레일이 **1열 그리드의 마지막**이라 탭 콘텐츠(소개·일지·참여자 + 리더보드) 전부 뒤에 옵니다. 페이지 맨 끝까지 스크롤해야 보이니 사실상 없는 버튼이었습니다.

**수정**: 히어로 바로 아래·탭 위로 올립니다. 조건은 그대로 — 참여 중 + 그룹 + 방 존재. 개인 챌린지·미참여는 방이 없어 안 뜹니다.

## 검증
`pnpm lint` 0 · `tsc` · 252 tests · `knip` 0 · `build` 성공.
**모바일 실뷰는 dev 배포 후 확인 필요** — 특히 FZ-4 는 iOS 사파리 주소창 접힘/펼침 시 높이 반응을 봐야 합니다.