### PR TITLE
feat(chat): 메시지 신고 UI

### DIFF
--- a/src/app.feature/chat/api/chatApi.ts
+++ b/src/app.feature/chat/api/chatApi.ts
@@ -6,6 +6,7 @@ import {
   ChatImagePresign,
   ChatMessage,
   ChatMessagePage,
+  ChatReportRequest,
   ChatRoomList,
   ChatSendRequest,
   ChatShareResolution,
@@ -106,6 +107,21 @@ export const chatApi = {
   ): Promise<ChatMessage> =>
     requestData<ChatMessage, ChatSendRequest>(apiClient, {
       url: `/chat/rooms/${roomId}/messages`,
+      method: 'POST',
+      data,
+    }),
+
+  /**
+   * 메시지 신고. 서버는 접수만 하고(PENDING) 메시지를 곧바로 가리지 않는다 —
+   * 숨김(HIDDEN)은 관리자가 신고를 승인했을 때만 일어난다. 그래서 화면도
+   * 신고 직후에 말풍선을 바꾸지 않는다.
+   */
+  reportMessage: async (
+    messageId: number,
+    data: ChatReportRequest
+  ): Promise<void> =>
+    requestData<void, ChatReportRequest>(apiClient, {
+      url: `/chat/messages/${messageId}/reports`,
       method: 'POST',
       data,
     }),

--- a/src/app.feature/chat/components/ChatReportSheet.test.tsx
+++ b/src/app.feature/chat/components/ChatReportSheet.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChatReportSheet } from './ChatReportSheet';
+
+function submitButton(): HTMLButtonElement {
+  return screen.getByRole('button', { name: '신고하기' }) as HTMLButtonElement;
+}
+
+// jest-dom 매처를 쓰지 않는 저장소라 disabled 는 속성으로 직접 본다.
+function renderSheet(onSubmit = vi.fn()): ReturnType<typeof vi.fn> {
+  render(
+    <ChatReportSheet
+      messageId={42}
+      isPending={false}
+      onOpenChange={vi.fn()}
+      onSubmit={onSubmit}
+    />
+  );
+  return onSubmit;
+}
+
+describe('ChatReportSheet', () => {
+  it('사유를 고르기 전에는 접수할 수 없다', () => {
+    renderSheet();
+    expect(submitButton().disabled).toBe(true);
+  });
+
+  it('사유만 고르면 상세 없이 접수된다', () => {
+    const onSubmit = renderSheet();
+    fireEvent.click(screen.getByRole('button', { name: /스팸/ }));
+    fireEvent.click(submitButton());
+    expect(onSubmit).toHaveBeenCalledWith(42, {
+      reason: 'SPAM',
+      detail: undefined,
+    });
+  });
+
+  it('"기타" 는 상세가 있어야 접수된다 — 그것만으로는 판단 근거가 없다', () => {
+    const onSubmit = renderSheet();
+    fireEvent.click(screen.getByRole('button', { name: /기타/ }));
+    expect(submitButton().disabled).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText(/상세히/), {
+      target: { value: '  광고 도배  ' },
+    });
+    fireEvent.click(submitButton());
+    // 공백은 다듬어 보낸다.
+    expect(onSubmit).toHaveBeenCalledWith(42, {
+      reason: 'OTHER',
+      detail: '광고 도배',
+    });
+  });
+});

--- a/src/app.feature/chat/components/ChatReportSheet.tsx
+++ b/src/app.feature/chat/components/ChatReportSheet.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import {
+  BottomSheet,
+  BottomSheetContent,
+  BottomSheetTitle,
+  Button,
+  Text,
+  TextArea,
+} from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import React, { useState } from 'react';
+
+import {
+  CHAT_REPORT_REASONS,
+  type ChatReportReason,
+  type ChatReportRequest,
+} from '../type/chat';
+
+/** 서버 @Size(max = 500). */
+const DETAIL_MAX = 500;
+
+interface ReportFormProps {
+  messageId: number;
+  isPending: boolean;
+  onCancel(): void;
+  onSubmit(messageId: number, data: ChatReportRequest): void;
+}
+
+interface ChatReportSheetProps {
+  /** 신고할 메시지 id. null 이면 닫혀 있다. */
+  messageId: number | null;
+  isPending: boolean;
+  onOpenChange(open: boolean): void;
+  onSubmit(messageId: number, data: ChatReportRequest): void;
+}
+
+/**
+ * 메시지 신고 시트.
+ *
+ * 사유는 서버 enum 그대로다. 상세는 선택이지만 **기타 사유일 때만 필수**로
+ * 받는다 — "기타" 는 그 자체로 아무것도 설명하지 않아서, 그대로 접수하면
+ * 관리자가 판단할 근거가 없다.
+ */
+function ReportForm({
+  messageId,
+  isPending,
+  onCancel,
+  onSubmit,
+}: ReportFormProps): React.ReactElement {
+  const [reason, setReason] = useState<ChatReportReason | null>(null);
+  const [detail, setDetail] = useState('');
+
+  const trimmedDetail = detail.trim();
+  const needsDetail = reason === 'OTHER';
+  const canSubmit =
+    reason !== null && (!needsDetail || trimmedDetail.length > 0) && !isPending;
+
+  return (
+    <>
+      <BottomSheetTitle>
+        <Text size="body1" weight="bold" className="text-gray-900">
+          메시지 신고하기
+        </Text>
+      </BottomSheetTitle>
+        <Text size="caption1" className="pt-1 text-gray-500">
+          신고 사유를 선택해 주세요. 접수된 신고는 관리자가 확인합니다.
+        </Text>
+
+        <div className="flex flex-col gap-1.5 pt-4">
+          {CHAT_REPORT_REASONS.map((option) => {
+            const selected = reason === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setReason(option.value)}
+                aria-pressed={selected}
+                className={cn(
+                  'flex items-center gap-2.5 rounded-xl border px-3.5 py-3',
+                  'text-left transition-colors',
+                  selected
+                    ? 'border-main-600 bg-main-100'
+                    : 'border-gray-200 bg-white hover:bg-gray-50'
+                )}
+              >
+                <span
+                  className={cn(
+                    'flex h-4 w-4 shrink-0 items-center justify-center',
+                    'rounded-full border-2',
+                    selected ? 'border-main-600' : 'border-gray-300'
+                  )}
+                >
+                  {selected ? (
+                    <span className="bg-main-600 h-2 w-2 rounded-full" />
+                  ) : null}
+                </span>
+                <Text
+                  size="body2"
+                  weight={selected ? 'bold' : 'regular'}
+                  className={selected ? 'text-main-800' : 'text-gray-800'}
+                >
+                  {option.label}
+                </Text>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="pt-3">
+          <TextArea
+            value={detail}
+            onChange={(event) => setDetail(event.target.value)}
+            rows={3}
+            count
+            max={DETAIL_MAX}
+            label="상세 내용"
+            labelHint={needsDetail ? '필수' : '선택'}
+            placeholder="신고 사유를 상세히 적어주세요."
+          />
+        </div>
+
+        <div className="flex gap-2 pt-4">
+          <Button variant="secondary" size="lg" fullWidth onClick={onCancel}>
+            취소
+          </Button>
+          <Button
+            variant="danger"
+            size="lg"
+            fullWidth
+            disabled={!canSubmit}
+            onClick={() => {
+              if (reason === null) {
+                return;
+              }
+              onSubmit(messageId, {
+                reason,
+                detail: trimmedDetail || undefined,
+              });
+            }}
+          >
+            {isPending ? '접수 중…' : '신고하기'}
+          </Button>
+        </div>
+    </>
+  );
+}
+
+export function ChatReportSheet({
+  messageId,
+  isPending,
+  onOpenChange,
+  onSubmit,
+}: ChatReportSheetProps): React.ReactElement {
+  return (
+    <BottomSheet
+      open={messageId != null}
+      onOpenChange={(next) => {
+        if (!next) {
+          onOpenChange(false);
+        }
+      }}
+    >
+      <BottomSheetContent className="px-5 pb-4">
+        {/* key 로 폼을 새로 마운트한다 — 다음 신고가 지난 선택을 물려받지
+            않게 하는 데 effect 로 상태를 되돌릴 이유가 없다. */}
+        {messageId != null ? (
+          <ReportForm
+            key={messageId}
+            messageId={messageId}
+            isPending={isPending}
+            onCancel={() => onOpenChange(false)}
+            onSubmit={onSubmit}
+          />
+        ) : null}
+      </BottomSheetContent>
+    </BottomSheet>
+  );
+}

--- a/src/app.feature/chat/components/ChatSheets.tsx
+++ b/src/app.feature/chat/components/ChatSheets.tsx
@@ -14,6 +14,7 @@ import {
   ImageIcon,
   Pin,
   PinOff,
+  Siren,
   SquareArrowOutUpRight,
 } from 'lucide-react';
 import React from 'react';
@@ -132,6 +133,8 @@ export interface ChatMessageActionsState {
   /** 호스트만 공지를 걸고 푼다(서버도 403 CHAT-009 로 막는다). */
   canEditNotice: boolean;
   isNotice: boolean;
+  /** 내 메시지는 신고 대상이 아니다. */
+  canReport: boolean;
 }
 
 /** 말풍선 롱프레스·우클릭 메뉴. */
@@ -140,11 +143,13 @@ export function ChatMessageActionsSheet({
   onOpenChange,
   onCopy,
   onToggleNotice,
+  onReport,
 }: {
   state: ChatMessageActionsState | null;
   onOpenChange(open: boolean): void;
   onCopy(text: string): void;
   onToggleNotice(isNotice: boolean): void;
+  onReport(): void;
 }): React.ReactElement {
   const NoticeIcon = state?.isNotice ? PinOff : Pin;
   return (
@@ -170,6 +175,16 @@ export function ChatMessageActionsSheet({
           onClick={() => {
             onOpenChange(false);
             onToggleNotice(state.isNotice);
+          }}
+        />
+      ) : null}
+      {state?.canReport ? (
+        <SheetRow
+          icon={<Siren className="h-5 w-5 text-red-500" />}
+          label="신고하기"
+          onClick={() => {
+            onOpenChange(false);
+            onReport();
           }}
         />
       ) : null}

--- a/src/app.feature/chat/hooks/useChatMutations.ts
+++ b/src/app.feature/chat/hooks/useChatMutations.ts
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { chatApi } from '../api/chatApi';
 import { CHAT_QUERY_KEYS } from '../consts/queryKeys';
-import { ChatRoomList } from '../type/chat';
+import { ChatReportRequest, ChatRoomList } from '../type/chat';
 
 /**
  * 방별 푸시 알림 토글 — 낙관적.
@@ -81,5 +81,24 @@ export function useClearChatNotice(): UseMutationResult<
         queryKey: CHAT_QUERY_KEYS.rooms(),
       });
     },
+  });
+}
+
+/**
+ * 메시지 신고. 서버는 접수(PENDING)만 하고 메시지를 곧바로 가리지 않으므로
+ * 캐시를 건드리지 않는다 — 숨김(HIDDEN)은 관리자가 승인했을 때 브로드캐스트/
+ * 재조회로 따라 들어온다.
+ */
+export function useReportChatMessage(): UseMutationResult<
+  void,
+  Error,
+  { messageId: number; data: ChatReportRequest }
+> {
+  return useMutation({
+    mutationFn: ({ messageId, data }) =>
+      chatApi.reportMessage(messageId, data),
+    // 신고 실패는 사유가 갈린다(중복 CHAT-010 / 한도 CHAT-013) — 호출부가
+    // 코드를 보고 문구를 정한다. 전역 토스트가 먼저 끼어들지 않게 한다.
+    meta: { skipGlobalErrorToast: true },
   });
 }

--- a/src/app.feature/chat/screen/ChatRoomScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomScreen.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { chatApi, chatImageContentType } from '../api/chatApi';
 import { ChatComposer } from '../components/ChatComposer';
 import { ChatMessageList } from '../components/ChatMessageList';
+import { ChatReportSheet } from '../components/ChatReportSheet';
 import { ChatSharePickerSheet } from '../components/ChatSharePickerSheet';
 import {
   ChatMessageActionsSheet,
@@ -33,6 +34,7 @@ import {
 import { CHAT_QUERY_KEYS } from '../consts/queryKeys';
 import {
   useClearChatNotice,
+  useReportChatMessage,
   useSetChatNotice,
   useToggleChatPush,
 } from '../hooks/useChatMutations';
@@ -88,6 +90,7 @@ export function ChatRoomScreen({
   const { data: sidebar } = useSidebar();
   const { data: roomList } = useChatRooms();
   const room = roomList?.rooms.find((item) => item.roomId === roomId);
+  const myNickname = sidebar?.nickname;
 
   const {
     messages,
@@ -103,7 +106,7 @@ export function ChatRoomScreen({
     sendShare,
     retry,
   } = useChatRoom(roomId, {
-    myNickname: sidebar?.nickname,
+    myNickname,
     challengeEnded: room?.challengeEnded,
   });
 
@@ -123,6 +126,8 @@ export function ChatRoomScreen({
   const [actions, setActions] = useState<ChatMessageActionsState | null>(null);
   const [actionTarget, setActionTarget] = useState<ChatMessage | null>(null);
   const [highlightId, setHighlightId] = useState<number | null>(null);
+  /** 신고 시트를 연 메시지. null 이면 닫혀 있다. */
+  const [reportTarget, setReportTarget] = useState<number | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   /** 이미 물어본 링크. 같은 글을 다시 물어보지 않는다. */
@@ -132,6 +137,8 @@ export function ChatRoomScreen({
   const { mutate: togglePush } = useToggleChatPush();
   const { mutate: setNotice } = useSetChatNotice();
   const { mutate: clearNotice } = useClearChatNotice();
+  const { mutate: reportMessage, isPending: isReporting } =
+    useReportChatMessage();
   // 보관 = 종료 + 7일 경과 읽기 전용. 판정은 chatArchive 한 곳에서만 한다.
   const archived = room ? isChatArchived(room) : false;
   // 종료 배너는 아직 보낼 수 있는 동안만 — 보관되면 보관 배너가 대신한다.
@@ -291,7 +298,12 @@ export function ChatRoomScreen({
     }
     const text = message.content?.trim() ?? '';
     const canEditNotice = room?.myRole === 'HOST';
-    if (!text && !canEditNotice) {
+    // 웹은 자기 memberId 를 못 받아 닉네임으로 내 것을 가른다. 서버가
+    // memberId 를 내려주면 senderId 비교로 바꾼다(같은 선행조건을
+    // 메시지별 안읽음 수와 공유한다).
+    const isMine = Boolean(myNickname) && message.senderNickname === myNickname;
+    const canReport = !isMine;
+    if (!text && !canEditNotice && !canReport) {
       return;
     }
     setActionTarget(message);
@@ -299,6 +311,7 @@ export function ChatRoomScreen({
       text,
       canEditNotice,
       isNotice: notice?.id === message.id,
+      canReport,
     });
   };
 
@@ -453,7 +466,7 @@ export function ChatRoomScreen({
         ) : (
           <ChatMessageList
             messages={messages}
-            myNickname={sidebar?.nickname}
+            myNickname={myNickname}
             hasNextPage={hasNextPage}
             isFetchingNextPage={isFetchingNextPage}
             fetchNextPage={fetchNextPage}
@@ -532,6 +545,44 @@ export function ChatRoomScreen({
             .catch(() => toast.error('복사하지 못했습니다.'));
         }}
         onToggleNotice={handleToggleNotice}
+        onReport={() => {
+          if (actionTarget) {
+            setReportTarget(actionTarget.id);
+          }
+        }}
+      />
+      <ChatReportSheet
+        messageId={reportTarget}
+        isPending={isReporting}
+        onOpenChange={(open) => {
+          if (!open) {
+            setReportTarget(null);
+          }
+        }}
+        onSubmit={(messageId, data) =>
+          reportMessage(
+            { messageId, data },
+            {
+              onSuccess: () => {
+                setReportTarget(null);
+                toast.success('신고가 접수되었습니다.');
+              },
+              onError: (error) => {
+                const code = getApiErrorCode(error);
+                if (code === 'CHAT-010') {
+                  setReportTarget(null);
+                  toast.info('이미 신고한 메시지예요.');
+                  return;
+                }
+                toast.error(
+                  code === 'CHAT-013'
+                    ? '신고가 몰렸어요. 잠시 후 다시 시도해 주세요.'
+                    : '신고하지 못했습니다.'
+                );
+              },
+            }
+          )
+        }
       />
     </div>
   );

--- a/src/app.feature/chat/type/chat.ts
+++ b/src/app.feature/chat/type/chat.ts
@@ -125,6 +125,23 @@ export interface ChatShareResolution {
   share?: ChatShare | null;
 }
 
+/** 신고 사유(ChatReportReason). 서버 enum 과 순서까지 맞춘다. */
+export const CHAT_REPORT_REASONS = [
+  { value: 'SPAM', label: '스팸 / 광고' },
+  { value: 'ABUSE', label: '욕설 / 괴롭힘' },
+  { value: 'SEXUAL', label: '선정적인 내용' },
+  { value: 'HATE', label: '혐오 표현' },
+  { value: 'OTHER', label: '기타 사유' },
+] as const;
+
+export type ChatReportReason = (typeof CHAT_REPORT_REASONS)[number]['value'];
+
+export interface ChatReportRequest {
+  reason: ChatReportReason;
+  /** 서버 @Size(max = 500). 기타 사유일 때만 필수로 받는다. */
+  detail?: string;
+}
+
 export interface ChatSendRequest {
   clientMessageId: string;
   type: ChatMessageType;


### PR DESCRIPTION
후속으로 미뤄뒀던 신고 UI. 액션 시트(롱프레스·우클릭)에 "신고하기" 를 붙이고, 사유 선택 시트를 엽니다.

## 서버 계약 (origin/dev 실확인)
`POST /chat/messages/{messageId}/reports` — `{ reason, detail? }`
- `reason`: `SPAM | ABUSE | SEXUAL | HATE | OTHER` (필수)
- `detail`: 최대 500자

## 신고 후 처리 — 앱과 동일하게 "아무것도 안 한다"
`ChatModerationService.report()` 는 **접수(PENDING)만** 합니다. 숨김(HIDDEN)은 관리자가 `resolve` 로 승인했을 때만 일어납니다. 그래서 화면도 신고 직후에 말풍선을 바꾸지 않고, 캐시도 건드리지 않습니다 — 낙관적으로 가려 버리면 신고자에게만 사라진 메시지가 남의 화면엔 그대로 보여 "가려졌다" 는 잘못된 확신을 줍니다. 실제 HIDDEN 은 브로드캐스트/재조회로 따라 들어옵니다.

## 실패를 사유별로 갈라 말합니다
| 코드 | 상황 | 문구 |
|---|---|---|
| `CHAT-010` | 이미 신고함 | "이미 신고한 메시지예요." (시트 닫음, info) |
| `CHAT-013` | 신고 한도(분당) | "신고가 몰렸어요. 잠시 후 다시 시도해 주세요." |
| 그 외 | — | "신고하지 못했습니다." |

전역 에러 토스트가 먼저 끼어들지 않게 `meta.skipGlobalErrorToast` 를 겁니다.

## 그 외
- **'기타' 사유는 상세 필수**. 그것만으로는 관리자가 판단할 근거가 없습니다. 나머지는 선택.
- **내 메시지에는 신고 항목이 안 뜹니다.**
- 폼 상태는 `key` 로 새로 마운트해 초기화합니다 — 다음 신고가 지난 선택을 물려받지 않게 하는 데 effect 로 되돌릴 이유가 없습니다.

## 검증
`pnpm lint` 0 · `tsc` · **251 tests** (+3: 사유 미선택 시 접수 불가 / 사유만으로 접수 / '기타' 는 상세 필수 + 공백 트림) · `knip` 0 · `build` 성공.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to report messages sent by other users.
  - Users can select a report reason and optionally provide additional details.
  - “Other” reports require nonblank details, limited to 500 characters.
  - Added confirmation, cancellation, loading, and error handling for report submissions.

- **Tests**
  - Added coverage for validation, successful submission, and detail requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->