### PR TITLE
feat(chat): 메시지별 안읽음 수 + 내 메시지 판정을 memberId 기준으로

### DIFF
--- a/src/app.feature/chat/api/chatApi.ts
+++ b/src/app.feature/chat/api/chatApi.ts
@@ -6,6 +6,7 @@ import {
   ChatImagePresign,
   ChatMessage,
   ChatMessagePage,
+  ChatReadStates,
   ChatReportRequest,
   ChatRoomList,
   ChatSendRequest,
@@ -124,6 +125,16 @@ export const chatApi = {
       url: `/chat/messages/${messageId}/reports`,
       method: 'POST',
       data,
+    }),
+
+  /**
+   * 방 멤버 전원의 읽음 위치. 방에 들어갈 때 한 번 받아 두고, 이후 갱신은
+   * `/topic/chat/rooms/{id}/read` 구독으로 한 줄씩 받는다.
+   */
+  getReadStates: async (roomId: number): Promise<ChatReadStates> =>
+    requestData<ChatReadStates>(apiClient, {
+      url: `/chat/rooms/${roomId}/read-states`,
+      method: 'GET',
     }),
 
   markRead: async (roomId: number, lastReadMessageId: number): Promise<void> =>

--- a/src/app.feature/chat/components/ChatMessageBubble.tsx
+++ b/src/app.feature/chat/components/ChatMessageBubble.tsx
@@ -161,11 +161,19 @@ export function ChatBubbleBody({
   }
 }
 
+/**
+ * 안 읽은 수 색 — 카톡 관행대로 노랑. 브랜드 주황과 붙어 있어도 구분된다.
+ */
+const UNREAD_COLOR = 'text-[#f5a623]';
+
 function TimeLabel({
   message,
+  unread,
   onRetry,
 }: {
   message: ChatMessage;
+  /** 이 메시지를 아직 안 읽은 사람 수. 0 이면 안 그린다. */
+  unread: number;
   onRetry?(): void;
 }): React.ReactElement {
   if (message.failed) {
@@ -186,9 +194,16 @@ function TimeLabel({
     );
   }
   return (
-    <Text size="caption4" className="text-gray-500">
-      {message.pending ? '보내는 중' : formatBubbleTime(message.createdAt)}
-    </Text>
+    <div className="flex flex-col items-end">
+      {unread > 0 ? (
+        <Text size="caption4" weight="extrabold" className={UNREAD_COLOR}>
+          {unread}
+        </Text>
+      ) : null}
+      <Text size="caption4" className="text-gray-500">
+        {message.pending ? '보내는 중' : formatBubbleTime(message.createdAt)}
+      </Text>
+    </div>
   );
 }
 
@@ -226,6 +241,8 @@ interface ChatMessageBubbleProps {
   isNotice: boolean;
   /** 원본 이동 직후 잠깐 강조. */
   highlighted?: boolean;
+  /** 이 메시지를 아직 안 읽은 사람 수. */
+  unread?: number;
   onRetry?(): void;
   onOpenActions?(message: ChatMessage): void;
 }
@@ -236,6 +253,7 @@ export function ChatMessageBubble({
   showSender,
   isNotice,
   highlighted = false,
+  unread = 0,
   onRetry,
   onOpenActions,
 }: ChatMessageBubbleProps): React.ReactElement {
@@ -267,7 +285,7 @@ export function ChatMessageBubble({
         )}
       >
         <div className="shrink-0 pb-0.5">
-          <TimeLabel message={message} onRetry={onRetry} />
+          <TimeLabel message={message} unread={unread} onRetry={onRetry} />
         </div>
         <div
           role={onOpenActions ? 'button' : undefined}

--- a/src/app.feature/chat/components/ChatMessageList.tsx
+++ b/src/app.feature/chat/components/ChatMessageList.tsx
@@ -5,7 +5,7 @@ import { useInViewObserver } from '@module/hooks/useInViewObserver';
 import { cn } from '@module/utils/cn';
 import React, { useEffect } from 'react';
 
-import { ChatMessage } from '../type/chat';
+import { ChatMessage, ChatReadState, unreadCountFor } from '../type/chat';
 import { formatDateDivider, isSameChatDay } from '../utils/chatFormat';
 import { ChatMessageBubble } from './ChatMessageBubble';
 
@@ -40,8 +40,10 @@ function DateDivider({ value }: { value: string }): React.ReactElement {
 
 interface ChatMessageListProps {
   messages: ChatMessage[];
-  /** 내 것인지 판정할 닉네임. 웹은 자기 memberId 를 받지 않는다. */
-  myNickname?: string;
+  /** 내 회원 id. 좌우 정렬과 안 읽은 수 계산이 모두 이 값을 기준으로 한다. */
+  myMemberId?: number;
+  /** 방 멤버 전원의 읽음 위치. */
+  readStates: ChatReadState[];
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   fetchNextPage(): void;
@@ -64,7 +66,8 @@ interface ChatMessageListProps {
  */
 export function ChatMessageList({
   messages,
-  myNickname,
+  myMemberId,
+  readStates,
   hasNextPage,
   isFetchingNextPage,
   fetchNextPage,
@@ -115,10 +118,8 @@ export function ChatMessageList({
         <ChatMessageBubble
           key={message.clientMessageId ?? `m-${message.id}-${index}`}
           message={message}
-          isMine={
-            Boolean(message.pending) ||
-            (Boolean(myNickname) && message.senderNickname === myNickname)
-          }
+          isMine={message.senderId === myMemberId}
+          unread={unreadCountFor(message, readStates)}
           // 날짜가 갈리면 같은 사람이어도 닉네임을 다시 보여 준다.
           showSender={startsNewDay || previous.senderId !== message.senderId}
           isNotice={noticeId != null && message.id === noticeId}

--- a/src/app.feature/chat/hooks/useChatRoom.ts
+++ b/src/app.feature/chat/hooks/useChatRoom.ts
@@ -13,6 +13,7 @@ import {
 import {
   ChatMessage,
   ChatMessageType,
+  ChatReadState,
   ChatShareResolution,
   ChatSocketError,
 } from '../type/chat';
@@ -66,6 +67,8 @@ export interface UseChatRoomResult {
   kickedOut: boolean;
   /** 실시간으로 받은 공지 id. null 이면 해제, undefined 면 통지 없음. */
   noticeUpdate: number | null | undefined;
+  /** 방 멤버 전원의 읽음 위치. 메시지별 안 읽은 수를 여기서 센다. */
+  readStates: ChatReadState[];
   sendText(content: string): Promise<void>;
   sendImage(file: File, caption?: string): Promise<void>;
   sendShare(
@@ -84,15 +87,16 @@ export interface UseChatRoomResult {
  */
 export function useChatRoom(
   roomId: number,
-  options: { myNickname?: string; challengeEnded?: boolean } = {}
+  options: { myMemberId?: number; challengeEnded?: boolean } = {}
 ): UseChatRoomResult {
-  const { myNickname, challengeEnded = false } = options;
+  const { myMemberId, challengeEnded = false } = options;
   const queryClient = useQueryClient();
   const query = useChatMessages(roomId);
   const [socketError, setSocketError] = useState<ChatSocketError | null>(null);
   const [noticeUpdate, setNoticeUpdate] = useState<number | null | undefined>(
     undefined
   );
+  const [readStates, setReadStates] = useState<ChatReadState[]>([]);
   /** 서버에 올린 마지막 읽음 위치. 같은 값을 반복해 올리지 않는다. */
   const lastReadSent = useRef(0);
 
@@ -121,6 +125,26 @@ export function useChatRoom(
     },
     [queryClient, roomId]
   );
+
+  // 방에 들어갈 때 읽음 위치를 한 번 받아 둔다. 이후 갱신은 /read 구독이
+  // 한 줄씩 실어 온다 — 여기서 주기적으로 다시 받지 않는다.
+  useEffect(() => {
+    if (!Number.isFinite(roomId) || roomId <= 0) {
+      return undefined;
+    }
+    let alive = true;
+    chatApi
+      .getReadStates(roomId)
+      .then((states) => {
+        if (alive) {
+          setReadStates(states.members);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, [roomId]);
 
   // 방을 열었으면 거기까지는 읽은 것이다. 최신순이라 첫 항목이 최신.
   const latestId = messages.find((message) => message.id > 0)?.id ?? 0;
@@ -165,10 +189,41 @@ export function useChatRoom(
         }
         setSocketError(error);
       },
+      onRead: (receipt) => {
+        // 한 줄만 갈아 끼운다. 위치는 앞으로만 간다는 계약이지만, 순서가
+        // 뒤바뀌어 도착해도 뒤로 밀리지 않게 막는다.
+        setReadStates((current) => {
+          const next = current.filter(
+            (state) => state.memberId !== receipt.memberId
+          );
+          const before = current.find(
+            (state) => state.memberId === receipt.memberId
+          );
+          const previous = before?.lastReadMessageId ?? -1;
+          const incoming = receipt.lastReadMessageId ?? -1;
+          next.push(
+            incoming > previous
+              ? {
+                  memberId: receipt.memberId,
+                  lastReadMessageId: receipt.lastReadMessageId,
+                }
+              : (before ?? {
+                  memberId: receipt.memberId,
+                  lastReadMessageId: receipt.lastReadMessageId,
+                })
+          );
+          return next;
+        });
+      },
       onReconnect: () => {
         chatApi
           .getMessages(roomId)
           .then((page) => mergeLatestMessages(queryClient, roomId, page.items))
+          .catch(() => undefined);
+        // 끊긴 동안의 읽음 통지는 다시 오지 않는다 — 위치를 통째로 다시 받는다.
+        chatApi
+          .getReadStates(roomId)
+          .then((states) => setReadStates(states.members))
           .catch(() => undefined);
       },
     };
@@ -182,6 +237,7 @@ export function useChatRoom(
       onMessage: (message) => handlersRef.current.onMessage?.(message),
       onNotice: (update) => handlersRef.current.onNotice?.(update),
       onUpdate: (update) => handlersRef.current.onUpdate?.(update),
+      onRead: (receipt) => handlersRef.current.onRead?.(receipt),
       onError: (error) => handlersRef.current.onError?.(error),
       onReconnect: () => handlersRef.current.onReconnect?.(),
     });
@@ -217,10 +273,10 @@ export function useChatRoom(
     ): ChatMessage => ({
       id: 0,
       roomId,
-      // senderId 는 알 수 없다 — 웹은 자기 memberId 를 받지 않는다. 내 것인지는
-      // 닉네임으로 가른다(가입 시 유일성이 보장된다).
-      senderId: 0,
-      senderNickname: myNickname ?? '',
+      // 내 id 로 채운다 — 화면이 senderId 로 좌우를 가르므로 낙관적
+      // 말풍선도 같은 기준을 따라야 보내는 순간부터 오른쪽에 선다.
+      senderId: myMemberId ?? 0,
+      senderNickname: '',
       clientMessageId,
       type,
       content: content ?? null,
@@ -229,7 +285,7 @@ export function useChatRoom(
       createdAt: new Date().toISOString(),
       pending: true,
     }),
-    [myNickname, roomId]
+    [myMemberId, roomId]
   );
 
   const sendText = useCallback(
@@ -322,6 +378,7 @@ export function useChatRoom(
       : null,
     kickedOut: socketError?.code === 'CHAT-002',
     noticeUpdate,
+    readStates,
     sendText,
     sendImage,
     sendShare,

--- a/src/app.feature/chat/screen/ChatRoomScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomScreen.tsx
@@ -90,7 +90,10 @@ export function ChatRoomScreen({
   const { data: sidebar } = useSidebar();
   const { data: roomList } = useChatRooms();
   const room = roomList?.rooms.find((item) => item.roomId === roomId);
-  const myNickname = sidebar?.nickname;
+  // 서버가 side-bar 에 memberId 를 싣기 전에는 닉네임 비교로 버텼다.
+  // 이제 내 회원 id 하나로 좌우 정렬·안 읽은 수·신고 가능 여부가 모두
+  // 정해진다.
+  const myMemberId = sidebar?.memberId;
 
   const {
     messages,
@@ -105,8 +108,9 @@ export function ChatRoomScreen({
     sendImage,
     sendShare,
     retry,
+    readStates,
   } = useChatRoom(roomId, {
-    myNickname,
+    myMemberId,
     challengeEnded: room?.challengeEnded,
   });
 
@@ -298,11 +302,8 @@ export function ChatRoomScreen({
     }
     const text = message.content?.trim() ?? '';
     const canEditNotice = room?.myRole === 'HOST';
-    // 웹은 자기 memberId 를 못 받아 닉네임으로 내 것을 가른다. 서버가
-    // memberId 를 내려주면 senderId 비교로 바꾼다(같은 선행조건을
-    // 메시지별 안읽음 수와 공유한다).
-    const isMine = Boolean(myNickname) && message.senderNickname === myNickname;
-    const canReport = !isMine;
+    // 내 메시지는 신고 대상이 아니다.
+    const canReport = message.senderId !== myMemberId;
     if (!text && !canEditNotice && !canReport) {
       return;
     }
@@ -466,7 +467,8 @@ export function ChatRoomScreen({
         ) : (
           <ChatMessageList
             messages={messages}
-            myNickname={myNickname}
+            myMemberId={myMemberId}
+            readStates={readStates}
             hasNextPage={hasNextPage}
             isFetchingNextPage={isFetchingNextPage}
             fetchNextPage={fetchNextPage}

--- a/src/app.feature/chat/socket/chatSocket.ts
+++ b/src/app.feature/chat/socket/chatSocket.ts
@@ -6,6 +6,7 @@ import {
   ChatMessage,
   ChatMessageUpdate,
   ChatNoticeUpdate,
+  ChatReadReceipt,
   ChatSocketError,
 } from '../type/chat';
 
@@ -26,6 +27,7 @@ import {
  *   수신  /topic/chat/rooms/{roomId}            본문
  *         /topic/chat/rooms/{roomId}/notice     공지 설정·해제
  *         /topic/chat/rooms/{roomId}/updates    링크 프리뷰 지연 완성
+ *         /topic/chat/rooms/{roomId}/read       읽음 위치 갱신(한 줄)
  *   에러  /user/queue/chat-errors  {code,message} + x-failed-destination
  *
  * 전송은 소켓이 아니라 REST(POST /chat/rooms/{id}/messages)다 — 소켓이 아직
@@ -40,6 +42,8 @@ export interface ChatRoomHandlers {
   onMessage?(message: ChatMessage): void;
   onNotice?(update: ChatNoticeUpdate): void;
   onUpdate?(update: ChatMessageUpdate): void;
+  /** 누군가의 읽음 위치가 옮겨졌다. 그 한 줄만 갈아 끼우면 된다. */
+  onRead?(receipt: ChatReadReceipt): void;
   /** 이 방과 관련된 구독 거절. 방과 무관한 에러는 오지 않는다. */
   onError?(error: ChatSocketError): void;
   /**
@@ -49,9 +53,9 @@ export interface ChatRoomHandlers {
   onReconnect?(): void;
 }
 
-type RoomChannel = '' | '/notice' | '/updates';
+type RoomChannel = '' | '/notice' | '/updates' | '/read';
 
-const ROOM_CHANNELS: RoomChannel[] = ['', '/notice', '/updates'];
+const ROOM_CHANNELS: RoomChannel[] = ['', '/notice', '/updates', '/read'];
 
 const roomListeners = new Map<number, Set<ChatRoomHandlers>>();
 const subscriptions = new Map<string, StompSubscription>();
@@ -145,6 +149,13 @@ function subscribeChannel(roomId: number, channel: RoomChannel): void {
         const update = parseJson<ChatNoticeUpdate>(frame);
         if (update) {
           notifyRoom(roomId, (entry) => entry.onNotice?.(update));
+        }
+        return;
+      }
+      if (channel === '/read') {
+        const receipt = parseJson<ChatReadReceipt>(frame);
+        if (receipt) {
+          notifyRoom(roomId, (entry) => entry.onRead?.(receipt));
         }
         return;
       }

--- a/src/app.feature/chat/type/chat.ts
+++ b/src/app.feature/chat/type/chat.ts
@@ -125,6 +125,53 @@ export interface ChatShareResolution {
   share?: ChatShare | null;
 }
 
+/** 멤버 한 명의 읽음 위치(ChatReadStatesResponse.MemberReadState). */
+export interface ChatReadState {
+  memberId: number;
+  /** null 이면 이 방에서 한 번도 안 읽었다. */
+  lastReadMessageId?: number | null;
+}
+
+export interface ChatReadStates {
+  roomId: number;
+  /** 지금 방에 있는 멤버 전원. 나간 멤버는 빠진다. */
+  members: ChatReadState[];
+}
+
+/** 읽음 위치가 옮겨졌다는 통지(/topic/chat/rooms/{id}/read). */
+export interface ChatReadReceipt {
+  roomId: number;
+  memberId: number;
+  lastReadMessageId?: number | null;
+}
+
+/**
+ * 이 메시지를 아직 안 읽은 사람 수.
+ *
+ * **발신자는 빼고 센다.** 메시지마다 발신자가 다르므로 서버가 미리 빼 줄 수
+ * 없어(서버 DTO 주석의 계약) 클라가 계산한다. 서버는 멤버별 읽음 "위치"
+ * 하나만 주고, 갱신도 그 한 줄만 온다 — 메시지마다 개수를 실으면 비용도
+ * 크고 찍는 순간 낡는다.
+ *
+ * 0 이면 모두 읽은 것이므로 화면에서 숨긴다.
+ */
+export function unreadCountFor(
+  message: Pick<ChatMessage, 'id' | 'senderId'>,
+  states: ChatReadState[]
+): number {
+  // 아직 서버 id 가 없는 낙관적 말풍선은 셀 기준이 없다.
+  if (message.id <= 0) {
+    return 0;
+  }
+  return states.filter((state) => {
+    if (state.memberId === message.senderId) {
+      return false;
+    }
+    const read = state.lastReadMessageId;
+    return read == null || read < message.id;
+  }).length;
+}
+
 /** 신고 사유(ChatReportReason). 서버 enum 과 순서까지 맞춘다. */
 export const CHAT_REPORT_REASONS = [
   { value: 'SPAM', label: '스팸 / 광고' },

--- a/src/app.feature/chat/type/unreadCount.test.ts
+++ b/src/app.feature/chat/type/unreadCount.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { type ChatReadState, unreadCountFor } from './chat';
+
+// 방에 나(1)·상대(2)·상대(3) 셋. 메시지 10 은 내가 보냈다.
+const MESSAGE = { id: 10, senderId: 1 };
+
+function states(...entries: Array<[number, number | null]>): ChatReadState[] {
+  return entries.map(([memberId, lastReadMessageId]) => ({
+    memberId,
+    lastReadMessageId,
+  }));
+}
+
+describe('unreadCountFor', () => {
+  it('발신자는 빼고 센다 — 내가 보낸 걸 내가 안 읽었다고 세지 않는다', () => {
+    // 나는 아직 이 메시지를 읽음 위치에 올리지 않았지만 세면 안 된다.
+    const all = states([1, null], [2, 10], [3, 10]);
+    expect(unreadCountFor(MESSAGE, all)).toBe(0);
+  });
+
+  it('읽음 위치가 뒤면 안 읽은 것으로 센다', () => {
+    expect(unreadCountFor(MESSAGE, states([1, 10], [2, 9], [3, 10]))).toBe(1);
+    expect(unreadCountFor(MESSAGE, states([1, 10], [2, 9], [3, 5]))).toBe(2);
+  });
+
+  it('한 번도 안 읽은 멤버(null)도 안 읽은 것이다', () => {
+    expect(unreadCountFor(MESSAGE, states([1, 10], [2, null]))).toBe(1);
+  });
+
+  it('읽음 위치가 그 메시지 이상이면 읽은 것이다', () => {
+    expect(unreadCountFor(MESSAGE, states([1, 10], [2, 10], [3, 42]))).toBe(0);
+  });
+
+  it('아직 서버 id 가 없는 낙관적 말풍선은 세지 않는다', () => {
+    expect(
+      unreadCountFor({ id: 0, senderId: 1 }, states([2, null], [3, null]))
+    ).toBe(0);
+  });
+});

--- a/src/app.feature/member/type/member.ts
+++ b/src/app.feature/member/type/member.ts
@@ -24,6 +24,11 @@ export interface SidebarChallenge {
 }
 
 export interface SidebarData {
+  /**
+   * 내 회원 id. 채팅이 "내 메시지" 와 "메시지별 안 읽은 수" 를 계산하는
+   * 유일한 근거다 — 이 값이 없어 한동안 닉네임 비교로 버텼다.
+   */
+  memberId: number;
   nickname: string;
   profileUrl: string;
   streakCount: number;


### PR DESCRIPTION
서버가 `GET /members/side-bar` 에 `memberId` 를 실어 주면서 미뤄뒀던 두 건이 한 번에 풀렸습니다.

## ① 내 메시지 좌우 정렬 — 닉네임 → memberId
`senderId === myMemberId` 로 교체했습니다. 동명이인·닉네임 변경에 흔들리던 판정이 사라집니다. 낙관적 말풍선도 `senderId` 를 내 id 로 채워, **보내는 순간부터 같은 기준으로** 오른쪽에 섭니다(전에는 `pending` 플래그로 우회했습니다).

## ② 메시지별 안읽음 수
- 방 진입 시 `GET /chat/rooms/{id}/read-states` 로 멤버별 위치를 한 번 받고
- `/topic/chat/rooms/{id}/read` 구독으로 한 줄씩 갱신
- 개수는 **클라가 셉니다** — 발신자를 빼야 하는데 메시지마다 발신자가 달라 서버가 미리 빼 줄 수 없습니다(서버 DTO 주석이 명시한 계약). 서버는 위치만 주고, 그래서 "찍는 순간 낡는" 문제도 없습니다.
- 0 이면 감춥니다. 시각 위에 노란 숫자(카톡 관행).

**소켓에 `/read` 채널을 추가**했습니다 — 기존 `/notice`·`/updates` 와 같은 자리에 붙어 refcount·재구독 로직을 그대로 씁니다.

## 순서·재연결 처리
- 읽음 위치는 앞으로만 갑니다. 통지가 순서를 바꿔 도착해도 **뒤로 밀리지 않게** 막습니다.
- 재연결 시 끊긴 동안의 통지는 다시 오지 않으므로 **위치를 통째로 다시 받습니다**(메시지 갭 보충과 같은 자리).

## 그 외
신고 가능 여부(내 메시지 제외)도 닉네임 → `memberId` 기준으로 바뀝니다.

## 검증
`pnpm lint` 0 · `tsc` · **256 tests** (+5: 발신자 제외 / 위치가 뒤면 카운트 / null 은 안 읽음 / 위치가 같거나 앞이면 읽음 / 낙관적 말풍선 제외) · `knip` 0 · `build` 성공.
**실동작(두 계정으로 읽음 숫자가 줄어드는지)은 dev 배포 후 확인 필요합니다.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-message unread counts in chat.
  * Added read receipts and synchronized read positions for room members.
  * Chat now reliably identifies message ownership using member IDs.

* **Bug Fixes**
  * Improved unread tracking after reconnecting and receiving read receipts.
  * Prevented unread counts from being shown for a message’s sender or unsent messages.

* **Tests**
  * Added coverage for unread-count calculations and read-state edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->