### PR TITLE
feat(chat): 채팅 리디자인 — 목록·버블·공유카드·셀렉션 그룹(HD)

### DIFF
--- a/src/app.feature/chat/components/ChatComposer.tsx
+++ b/src/app.feature/chat/components/ChatComposer.tsx
@@ -55,7 +55,12 @@ function ShareAttachment({
   const TypeIcon = isDiary ? BookOpen : Flag;
   const url = resolveDiaryImageUrl(share.share?.thumbnailUrl);
   return (
-    <div className="flex items-center gap-2.5 rounded-xl bg-gray-100 p-2">
+    <div
+      className={cn(
+        'mb-2 flex items-center gap-2.5 rounded-[14px] border',
+        'border-gray-200 bg-gray-50 px-2.5 py-2'
+      )}
+    >
       <div
         className={cn(
           'flex h-10 w-10 shrink-0 items-center justify-center',
@@ -81,9 +86,12 @@ function ShareAttachment({
         type="button"
         aria-label="공유 빼기"
         onClick={onRemove}
-        className="flex h-6 w-6 shrink-0 items-center justify-center"
+        className={cn(
+          'flex h-[26px] w-[26px] shrink-0 items-center justify-center',
+          'rounded-full bg-gray-200 text-gray-600'
+        )}
       >
-        <X className="h-3.5 w-3.5 text-gray-600" />
+        <X className="h-3.5 w-3.5" />
       </button>
     </div>
   );
@@ -136,20 +144,16 @@ export function ChatComposer({
   return (
     <div
       className={cn(
-        'shrink-0 border-t border-gray-200 bg-white px-4 pt-2',
+        'shrink-0 border-t border-gray-100 bg-white px-3 pt-[9px]',
         // 홈 인디케이터 영역만큼 아래를 더 띄운다. 없는 기기에서는 0 이라
         // 기존 여백 그대로다.
         'pb-[calc(0.5rem+env(safe-area-inset-bottom))]'
       )}
     >
       {imageFile ? (
-        <div className="pb-2">
-          <ImageAttachment file={imageFile} onRemove={onRemoveAttachment} />
-        </div>
+        <ImageAttachment file={imageFile} onRemove={onRemoveAttachment} />
       ) : share ? (
-        <div className="pb-2">
-          <ShareAttachment share={share} onRemove={onRemoveAttachment} />
-        </div>
+        <ShareAttachment share={share} onRemove={onRemoveAttachment} />
       ) : null}
 
       <div className="flex items-end gap-2">
@@ -159,8 +163,11 @@ export function ChatComposer({
           disabled={!enabled}
           onClick={onOpenShareMenu}
           className={cn(
-            'flex h-10 w-9 shrink-0 items-center justify-center',
-            enabled ? 'text-gray-700' : 'text-gray-400'
+            'flex h-[38px] w-[38px] shrink-0 items-center justify-center',
+            'rounded-full transition-colors',
+            enabled
+              ? 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              : 'bg-gray-100 text-gray-400'
           )}
         >
           <Plus className="h-5 w-5" />
@@ -189,10 +196,10 @@ export function ChatComposer({
           }}
           placeholder={enabled ? '메시지를 입력하세요' : disabledPlaceholder}
           className={cn(
-            'max-h-[120px] min-h-10 flex-1 resize-none rounded-[20px]',
-            'bg-gray-100 px-3.5 py-2.5 leading-normal text-gray-900',
-            'placeholder:text-gray-500 focus:outline-none',
-            'disabled:cursor-not-allowed'
+            'max-h-[120px] min-h-[38px] flex-1 resize-none rounded-full',
+            'border border-gray-200 bg-gray-50 px-3.5 py-2 text-[13px]',
+            'leading-[22px] text-gray-900 placeholder:text-gray-400',
+            'focus:outline-none disabled:cursor-not-allowed'
           )}
         />
 
@@ -202,12 +209,14 @@ export function ChatComposer({
           disabled={!canSend}
           onClick={onSend}
           className={cn(
-            'flex h-10 w-10 shrink-0 items-center justify-center',
-            'rounded-full text-white transition-colors',
-            canSend ? 'bg-main-600' : 'bg-gray-300'
+            'flex h-[38px] w-[38px] shrink-0 items-center justify-center',
+            'rounded-full transition-colors',
+            canSend
+              ? 'bg-main-800 text-white shadow-[0_4px_12px_-4px_rgba(255,87,34,0.6)]'
+              : 'bg-gray-200 text-gray-400'
           )}
         >
-          <ArrowUp className="h-4.5 w-4.5" />
+          <ArrowUp className="h-[19px] w-[19px]" />
         </button>
       </div>
     </div>

--- a/src/app.feature/chat/components/ChatMessageBubble.tsx
+++ b/src/app.feature/chat/components/ChatMessageBubble.tsx
@@ -27,7 +27,9 @@ import {
 function ImageBody({ message }: { message: ChatMessage }): React.ReactElement {
   const [broken, setBroken] = useState(false);
   const url = resolveDiaryImageUrl(message.imageUrl);
-  const frame = 'h-[200px] w-[200px] overflow-hidden rounded-[10px] bg-gray-100';
+  // 디자인 .pic — 190x122 가로 프레임. 비율이 제각각인 원본을 가운데
+  // 기준으로 채운다(원본은 눌러서 본다).
+  const frame = 'h-[122px] w-[190px] overflow-hidden rounded-2xl bg-gray-100';
 
   // 아직 업로드 중이면 URL 이 없다 — 자리를 잡아 두고 진행 표시.
   if (!url) {
@@ -69,7 +71,7 @@ function ImageBody({ message }: { message: ChatMessage }): React.ReactElement {
         src={url}
         alt="채팅 사진"
         loading="lazy"
-        className="h-full w-full object-cover"
+        className="h-full w-full object-cover object-center"
         onError={() => setBroken(true)}
       />
     </button>
@@ -125,11 +127,28 @@ export function ChatBubbleBody({
   }
 
   const caption = message.content?.trim();
+  /**
+   * 사진·공유 카드는 스스로 배경과 테두리를 갖는다. 그래서 말풍선을
+   * 투명하게 두는데(디자인이 걷어내려던 오렌지 띠), 그러면 캡션 글씨가
+   * 배경 없이 뜬다 — 캡션은 **자기 말풍선**을 하나 더 갖는다.
+   */
   const withCaption = (card: React.ReactNode): React.ReactElement => (
-    <div className="flex flex-col items-start">
+    <div
+      className={cn(
+        'flex flex-col gap-1.5',
+        isMine ? 'items-end' : 'items-start'
+      )}
+    >
       {card}
       {caption ? (
-        <div className="px-1 pt-1.5">
+        <div
+          className={cn(
+            'max-w-full rounded-2xl px-3.5 py-2.5',
+            isMine
+              ? 'bg-main-800 text-white'
+              : 'border border-gray-200 bg-white'
+          )}
+        >
           <BubbleText value={caption} isMine={isMine} />
         </div>
       ) : null}
@@ -139,7 +158,7 @@ export function ChatBubbleBody({
   switch (message.type) {
     case 'CHALLENGE_SHARE':
     case 'DIARY_SHARE':
-      return withCaption(<ChatShareCard message={message} />);
+      return withCaption(<ChatShareCard message={message} isMine={isMine} />);
     case 'IMAGE':
       return withCaption(<ImageBody message={message} />);
     case 'TEXT': {
@@ -161,19 +180,17 @@ export function ChatBubbleBody({
   }
 }
 
-/**
- * 안 읽은 수 색 — 카톡 관행대로 노랑. 브랜드 주황과 붙어 있어도 구분된다.
- */
-const UNREAD_COLOR = 'text-[#f5a623]';
-
 function TimeLabel({
   message,
   unread,
+  showTime,
   onRetry,
 }: {
   message: ChatMessage;
   /** 이 메시지를 아직 안 읽은 사람 수. 0 이면 안 그린다. */
   unread: number;
+  /** 연속 발화는 **마지막 말풍선에만** 시간을 붙인다(디자인). */
+  showTime: boolean;
   onRetry?(): void;
 }): React.ReactElement {
   if (message.failed) {
@@ -194,15 +211,25 @@ function TimeLabel({
     );
   }
   return (
-    <div className="flex flex-col items-end">
+    <div className="flex flex-col items-end gap-px pb-0.5">
       {unread > 0 ? (
-        <Text size="caption4" weight="extrabold" className={UNREAD_COLOR}>
+        <Text
+          size="caption4"
+          weight="extrabold"
+          className="text-main-800 leading-none"
+        >
           {unread}
         </Text>
       ) : null}
-      <Text size="caption4" className="text-gray-500">
-        {message.pending ? '보내는 중' : formatBubbleTime(message.createdAt)}
-      </Text>
+      {message.pending ? (
+        <Text size="caption4" className="text-gray-400">
+          보내는 중
+        </Text>
+      ) : showTime ? (
+        <Text size="caption4" className="whitespace-nowrap text-gray-400">
+          {formatBubbleTime(message.createdAt)}
+        </Text>
+      ) : null}
     </div>
   );
 }
@@ -232,11 +259,20 @@ function useLongPress(onLongPress: () => void): {
   };
 }
 
+/**
+ * 연속 발화 안에서의 위치. 말풍선 꼬리를 어디에 붙일지가 이걸로 정해진다 —
+ * 같은 사람이 잇달아 보낸 묶음은 **처음(상대) / 마지막(나)** 한 군데만
+ * 각이 서고 나머지는 둥글다.
+ */
+export type ChatBubbleGroupPosition = 'single' | 'top' | 'mid' | 'last';
+
 interface ChatMessageBubbleProps {
   message: ChatMessage;
   isMine: boolean;
   /** 연속 발화의 첫 줄에만 닉네임을 보여 준다. */
   showSender: boolean;
+  /** 연속 발화 묶음에서의 위치. */
+  group?: ChatBubbleGroupPosition;
   /** 공지로 지정된 메시지는 본문에서도 구분되게 한다. */
   isNotice: boolean;
   /** 원본 이동 직후 잠깐 강조. */
@@ -252,13 +288,25 @@ export function ChatMessageBubble({
   isMine,
   showSender,
   isNotice,
+  group = 'single',
   highlighted = false,
   unread = 0,
   onRetry,
   onOpenActions,
 }: ChatMessageBubbleProps): React.ReactElement {
   const hidden = message.status === 'HIDDEN';
-  const isImage = message.type === 'IMAGE' && !hidden;
+  // 사진·공유 카드는 자기 테두리/라운드를 갖는다 — 말풍선 패딩을 주면
+  // 카드 둘레에 색 띠가 한 겹 더 생긴다(디자인이 걷어내려던 그 테두리).
+  const isMedia =
+    !hidden &&
+    (message.type === 'IMAGE' ||
+      message.type === 'CHALLENGE_SHARE' ||
+      message.type === 'DIARY_SHARE');
+  // 꼬리는 묶음의 바깥쪽 한 군데에만 붙는다. 상대는 맨 위, 나는 맨 아래다.
+  const tail = isMine
+    ? group === 'single' || group === 'last'
+    : group === 'single' || group === 'top';
+  const showTime = group === 'single' || group === 'last';
 
   // 롱프레스(모바일) 와 우클릭(데스크톱) 이 같은 메뉴를 연다.
   const longPress = useLongPress(() => onOpenActions?.(message));
@@ -280,12 +328,17 @@ export function ChatMessageBubble({
       ) : null}
       <div
         className={cn(
-          'flex max-w-[80%] items-end gap-1.5',
+          'flex max-w-[86%] items-end gap-1.5',
           isMine ? 'flex-row' : 'flex-row-reverse'
         )}
       >
         <div className="shrink-0 pb-0.5">
-          <TimeLabel message={message} unread={unread} onRetry={onRetry} />
+          <TimeLabel
+            message={message}
+            unread={unread}
+            showTime={showTime}
+            onRetry={onRetry}
+          />
         </div>
         <div
           role={onOpenActions ? 'button' : undefined}
@@ -299,14 +352,19 @@ export function ChatMessageBubble({
           }}
           {...longPress}
           className={cn(
-            'min-w-0 overflow-hidden rounded-[14px]',
-            isImage ? 'p-1.5' : 'px-3 py-2.5',
+            'min-w-0 overflow-hidden rounded-2xl',
+            isMedia ? 'p-0' : 'px-3.5 py-2.5',
             hidden
               ? 'bg-gray-100'
-              : isMine
-                ? 'bg-main-600'
-                : 'border border-gray-200 bg-white',
-            isNotice && 'border-main-600 border-[1.5px]',
+              : isMedia
+                ? // 카드가 스스로 배경·테두리를 갖는다.
+                  'bg-transparent'
+                : isMine
+                  ? 'bg-main-800 text-white'
+                  : 'border border-gray-200 bg-white',
+            // 꼬리 — 상대는 왼쪽 위, 나는 오른쪽 아래 모서리를 각지게.
+            tail && (isMine ? 'rounded-br-[4px]' : 'rounded-tl-[4px]'),
+            isNotice && 'border-main-800 border-[1.5px]',
             message.pending && 'opacity-70'
           )}
         >

--- a/src/app.feature/chat/components/ChatMessageList.tsx
+++ b/src/app.feature/chat/components/ChatMessageList.tsx
@@ -7,7 +7,10 @@ import React, { useEffect } from 'react';
 
 import { ChatMessage, ChatReadState, unreadCountFor } from '../type/chat';
 import { formatDateDivider, isSameChatDay } from '../utils/chatFormat';
-import { ChatMessageBubble } from './ChatMessageBubble';
+import {
+  type ChatBubbleGroupPosition,
+  ChatMessageBubble,
+} from './ChatMessageBubble';
 
 /** 시스템 안내. 대화가 아니라 표시이므로 가운데 칩으로 그린다. */
 function SystemChip({ text }: { text: string }): React.ReactElement {
@@ -102,6 +105,23 @@ export function ChatMessageList({
     );
   }
 
+  /**
+   * 두 메시지가 한 묶음인가. 같은 사람이 **같은 날** 잇달아 보낸 것만
+   * 묶는다 — 날짜 구분선이 사이에 들어가면 시각적으로 이미 끊긴다.
+   */
+  const grouped = (
+    one: ChatMessage | undefined,
+    two: ChatMessage | undefined
+  ): boolean =>
+    Boolean(
+      one &&
+        two &&
+        one.type !== 'SYSTEM' &&
+        two.type !== 'SYSTEM' &&
+        one.senderId === two.senderId &&
+        isSameChatDay(one.createdAt, two.createdAt)
+    );
+
   const children: React.ReactNode[] = [];
   messages.forEach((message, index) => {
     // 최신순이라 index+1 이 시간상 **이전** 메시지다.
@@ -110,6 +130,17 @@ export function ChatMessageList({
     // 아무것도 없으니 날짜를 보여 준다.
     const startsNewDay =
       !previous || !isSameChatDay(previous.createdAt, message.createdAt);
+    // 최신순 배열이라 index-1 이 시간상 **다음** 메시지다.
+    const next = messages[index - 1];
+    const hasPrevious = grouped(previous, message);
+    const hasNext = grouped(message, next);
+    const group: ChatBubbleGroupPosition = hasPrevious
+      ? hasNext
+        ? 'mid'
+        : 'last'
+      : hasNext
+        ? 'top'
+        : 'single';
 
     children.push(
       message.type === 'SYSTEM' ? (
@@ -120,8 +151,9 @@ export function ChatMessageList({
           message={message}
           isMine={message.senderId === myMemberId}
           unread={unreadCountFor(message, readStates)}
-          // 날짜가 갈리면 같은 사람이어도 닉네임을 다시 보여 준다.
-          showSender={startsNewDay || previous.senderId !== message.senderId}
+          group={group}
+          // 묶음의 첫 줄에만 닉네임을 보여 준다(날짜가 갈리면 다시).
+          showSender={!hasPrevious}
           isNotice={noticeId != null && message.id === noticeId}
           highlighted={highlightId != null && message.id === highlightId}
           onRetry={message.failed ? () => onRetry(message) : undefined}

--- a/src/app.feature/chat/components/ChatRoomListItem.tsx
+++ b/src/app.feature/chat/components/ChatRoomListItem.tsx
@@ -2,7 +2,7 @@
 
 import { Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
-import { Bell, BellOff, BookOpen, Flag, ImageIcon } from 'lucide-react';
+import { BellOff, BookOpen, Flag, ImageIcon } from 'lucide-react';
 import Link from 'next/link';
 import React from 'react';
 
@@ -11,25 +11,42 @@ import { canSendInChatRoom, isChatArchived } from '../utils/chatArchive';
 import { formatRoomTime, roomPreview } from '../utils/chatFormat';
 import { ChatRoomThumbnail } from './ChatRoomThumbnail';
 
-/**
- * 마지막 메시지가 글이 아니면 앞에 작은 아이콘을 둔다 — 무엇이 왔는지
- * 한눈에 보이게. 글이면 아이콘 없이 문구만(과밀 방지).
- */
-function PreviewIcon({ room }: { room: ChatRoom }): React.ReactElement | null {
-  const className = 'h-3 w-3 shrink-0 text-gray-400';
-  switch (room.lastMessage?.type) {
-    case 'IMAGE':
-      return <ImageIcon className={className} />;
-    case 'CHALLENGE_SHARE':
-      return <Flag className={className} />;
-    case 'DIARY_SHARE':
-      return <BookOpen className={className} />;
-    default:
-      return null;
-  }
+function PreviewKindLabel({
+  icon,
+  label,
+}: {
+  icon: React.ReactNode;
+  label: string;
+}): React.ReactElement {
+  return (
+    <span className="text-main-800 flex shrink-0 items-center gap-0.5 text-xs font-bold">
+      {icon}
+      {label}
+    </span>
+  );
 }
 
-/** 방 이름 옆 작은 배지. 방장 표시와 상태 표시가 같은 pill 이다. */
+/**
+ * 마지막 메시지가 글이 아니면 **뒤에** 타입을 밝힌다.
+ *
+ * 예전엔 앞에 회색 아이콘만 뒀는데, 그러면 "무엇이 왔는지" 가 본문에 묻힌다.
+ * 디자인은 브랜드 색 라벨로 뒤에 세워 눈에 들어오게 했다.
+ */
+function PreviewKind({ room }: { room: ChatRoom }): React.ReactElement | null {
+  const kind = room.lastMessage?.type;
+  if (kind === 'IMAGE') {
+    return <PreviewKindLabel icon={<ImageIcon className="h-3 w-3" />} label="사진" />;
+  }
+  if (kind === 'CHALLENGE_SHARE') {
+    return <PreviewKindLabel icon={<Flag className="h-3 w-3" />} label="챌린지" />;
+  }
+  if (kind === 'DIARY_SHARE') {
+    return <PreviewKindLabel icon={<BookOpen className="h-3 w-3" />} label="일지" />;
+  }
+  return null;
+}
+
+/** 방 이름 옆 각진 칩. 알약이 아니라 radius 5 다(디자인). */
 function RoomChip({
   label,
   tone,
@@ -40,10 +57,11 @@ function RoomChip({
   return (
     <span
       className={cn(
-        'shrink-0 rounded-full px-1.5 py-px text-[10px] leading-4',
+        'shrink-0 rounded-[5px] px-1.5 py-[2.5px] text-[9.5px]',
+        'leading-none font-extrabold tracking-[0.03em]',
         tone === 'host'
-          ? 'bg-main-200 text-main-800 font-extrabold'
-          : 'bg-gray-100 font-bold text-gray-600'
+          ? 'bg-main-200 text-main-900'
+          : 'bg-gray-100 text-gray-500'
       )}
     >
       {label}
@@ -55,9 +73,8 @@ function StateChip({ room }: { room: ChatRoom }): React.ReactElement | null {
   // 셋은 배타다. 아카이브는 이미 "종료 + 읽기 전용" 이라, 셋을 나란히
   // 세우면 같은 사실을 세 번 말하게 된다.
   if (isChatArchived(room)) {
-    return <RoomChip label="아카이브됨" tone="state" />;
+    return <RoomChip label="아카이브" tone="state" />;
   }
-  // 종료와 읽기 전용은 다르다 — 종료 후 일주일은 그대로 쓸 수 있다.
   if (room.challengeEnded) {
     return <RoomChip label="종료" tone="state" />;
   }
@@ -77,20 +94,15 @@ export function ChatRoomListItem({
   onToggleNotification,
 }: ChatRoomListItemProps): React.ReactElement {
   const unread = room.unreadCount;
-  const BellIcon = room.pushEnabled ? Bell : BellOff;
   const archived = isChatArchived(room);
 
   return (
     <div
       className={cn(
-        'relative flex items-center gap-3 rounded-2xl border px-3.5 py-3',
-        'transition-colors',
-        // 안 읽은 방은 살짝 물들여 눈에 띄게 한다. 그림자는 쓰지 않는다.
-        unread > 0 && !archived
-          ? 'bg-main-100 border-main-200'
-          : 'border-gray-200 bg-white hover:bg-gray-50',
-        // 보관된 방은 한 단계 물러나 보이게 한다. 내용은 그대로 읽을 수
-        // 있으므로 아주 흐리게 만들지는 않는다.
+        'relative flex items-start gap-3 rounded-2xl px-2 py-3',
+        // 보더 없이 **안 읽은 방만** 물들여 구분한다. 카드 테두리를 걷어낸
+        // 자리를 여백과 배경이 대신한다(디자인).
+        unread > 0 ? 'bg-main-100' : 'hover:bg-gray-50',
         archived && 'opacity-60'
       )}
     >
@@ -102,16 +114,21 @@ export function ChatRoomListItem({
         className="absolute inset-0 z-0 rounded-2xl"
       />
 
-      {/* 어느 챌린지 방인지가 먼저 읽혀야 한다. 3:2 landscape. */}
+      {/* 52 정사각. 챌린지 대표 이미지는 3:2 라 가운데를 기준으로 잘린다. */}
       <ChatRoomThumbnail
         url={room.challengeThumbnailUrl}
         category={room.category}
-        className="pointer-events-none z-[1] h-11 w-[66px]"
+        className="pointer-events-none z-[1] h-13 w-13 rounded-2xl"
       />
 
-      <div className="pointer-events-none z-[1] flex min-w-0 flex-1 flex-col gap-1">
+      <div className="pointer-events-none z-[1] flex min-w-0 flex-1 flex-col">
         <div className="flex min-w-0 items-center gap-1.5">
-          <Text size="body2" weight="bold" className="truncate text-gray-900">
+          <Text
+            as="b"
+            size="caption1"
+            weight="extrabold"
+            className="min-w-0 truncate tracking-[-0.02em] text-gray-900"
+          >
             {room.challengeTitle}
           </Text>
           {room.myRole === 'HOST' ? (
@@ -119,43 +136,48 @@ export function ChatRoomListItem({
           ) : null}
           <StateChip room={room} />
         </div>
-        <div className="flex min-w-0 items-center gap-1">
-          <PreviewIcon room={room} />
-          <Text size="caption2" className="truncate text-gray-600">
+        <div className="mt-1 flex min-w-0 items-center gap-1.5">
+          {room.lastMessage ? (
+            <Text size="caption2" className="shrink-0 text-gray-500">
+              {room.lastMessage.senderNickname}
+            </Text>
+          ) : null}
+          <Text size="caption2" className="min-w-0 truncate text-gray-600">
             {roomPreview(room)}
           </Text>
+          <PreviewKind room={room} />
         </div>
       </div>
 
-      {/* 오른쪽 요소는 한 축에 모은다 — 안읽음 뱃지와 종이 따로 놀면
-          행마다 눈이 흔들린다. */}
-      <div className="z-[1] flex shrink-0 flex-col items-end gap-1.5">
-        <Text size="caption4" className="pointer-events-none text-gray-400">
+      <div className="z-[1] flex min-w-13 shrink-0 flex-col items-end gap-[7px] pt-0.5">
+        <Text size="caption3" className="pointer-events-none text-gray-400">
           {room.lastMessage ? formatRoomTime(room.lastMessage.createdAt) : ''}
         </Text>
         <div className="flex items-center gap-1.5">
           {unread > 0 ? (
             <span
               className={cn(
-                'bg-main-600 pointer-events-none inline-flex min-w-5',
-                'items-center justify-center rounded-full px-1.5 py-0.5',
-                'text-[10px] leading-4 font-extrabold text-white'
+                'bg-main-800 pointer-events-none inline-flex h-[19px]',
+                'min-w-[19px] items-center justify-center rounded-full px-1.5',
+                'text-[11px] font-extrabold text-white'
               )}
             >
               {unread > 99 ? '99+' : unread}
             </span>
           ) : null}
+          {/* 알림이 켜져 있는 것이 기본이라 아이콘을 그리지 않는다 —
+              꺼 둔 방만 표시해야 목록이 조용해진다(디자인). */}
           <button
             type="button"
             onClick={() => onToggleNotification(room)}
             aria-label={room.pushEnabled ? '알림 끄기' : '알림 켜기'}
             className={cn(
-              'flex h-7 w-7 items-center justify-center rounded-full',
+              'flex h-6 w-6 items-center justify-center rounded-full',
               'transition-colors hover:bg-white/70',
-              room.pushEnabled ? 'text-gray-500' : 'text-gray-400'
+              room.pushEnabled ? 'text-transparent' : 'text-gray-300'
             )}
           >
-            <BellIcon className="h-4 w-4" />
+            <BellOff className="h-[15px] w-[15px]" />
           </button>
         </div>
       </div>

--- a/src/app.feature/chat/components/ChatSegmentedTabs.tsx
+++ b/src/app.feature/chat/components/ChatSegmentedTabs.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { cn } from '@module/utils/cn';
+import React from 'react';
+
+export interface ChatSegmentedTabsOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface ChatSegmentedTabsProps<T extends string> {
+  options: ReadonlyArray<ChatSegmentedTabsOption<T>>;
+  value: T;
+  onChange(value: T): void;
+  className?: string;
+}
+
+/**
+ * 채팅 목록의 셀렉션 그룹.
+ *
+ * 디자인의 `.tabs > .tab` 을 그대로 옮긴 것이다 — 가로 균등 분할, 알약형,
+ * 비활성은 회색 바탕, 활성만 브랜드 색 + 따뜻한 그림자.
+ *
+ * **채팅 전용이다.** 생김새는 DS `SegmentedControl` 과 닮았지만 그쪽을
+ * 고치면 챌린지 생성·수정, 통계, 가입까지 한꺼번에 바뀐다. 그 확산은
+ * 별도 결정이라, 여기서는 채팅만 새 스타일을 입는다.
+ */
+export function ChatSegmentedTabs<T extends string>({
+  options,
+  value,
+  onChange,
+  className,
+}: ChatSegmentedTabsProps<T>): React.ReactElement {
+  return (
+    <div role="tablist" className={cn('flex gap-1.5', className)}>
+      {options.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'flex h-9 flex-1 items-center justify-center rounded-full',
+              'text-[13.5px] font-bold transition-colors',
+              active
+                ? 'bg-main-800 text-white shadow-[0_4px_12px_-4px_rgba(255,87,34,0.5)]'
+                : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app.feature/chat/components/ChatShareCard.tsx
+++ b/src/app.feature/chat/components/ChatShareCard.tsx
@@ -3,7 +3,7 @@
 import { Text } from '@1d1s/design-system';
 import { cn } from '@module/utils/cn';
 import { resolveDiaryImageUrl } from '@module/utils/diaryImageUrl';
-import { BookOpen, Flag, Youtube } from 'lucide-react';
+import { BookOpen, ChevronRight, Flag, Youtube } from 'lucide-react';
 import Link from 'next/link';
 import React from 'react';
 
@@ -18,8 +18,10 @@ import { ChatRoomThumbnail } from './ChatRoomThumbnail';
 // 넓어지는데, 말풍선이 `overflow-hidden` 이라 **오른쪽이 잘린 채** 그려진다
 // (모바일에서 카드가 한쪽으로 쏠려 보이던 원인). 232px 는 이제 상한이고,
 // 자리가 모자라면 카드가 말풍선에 맞춰 줄어든다.
-const CARD_CLASS =
-  'w-[232px] max-w-full min-w-0 overflow-hidden rounded-[10px] border';
+const CARD_CLASS = cn(
+  'w-[250px] max-w-full min-w-0 overflow-hidden rounded-[18px] border',
+  'shadow-[0_2px_8px_-4px_rgba(0,0,0,0.10)]'
+);
 
 /**
  * 공유 카드. 볼 수 없는 대상이면 눌리지 않는다 — 보낼 땐 공개였던 일지가
@@ -27,8 +29,10 @@ const CARD_CLASS =
  */
 export function ChatShareCard({
   message,
+  isMine = false,
 }: {
   message: ChatMessage;
+  isMine?: boolean;
 }): React.ReactElement {
   const share = message.share;
   const path = chatSharePath(message);
@@ -44,21 +48,29 @@ export function ChatShareCard({
           url={share?.thumbnailUrl}
           category={share?.category}
           fallback={isDiary ? 'diary' : 'challenge'}
-          className="h-[116px] w-full rounded-none"
+          className="h-[118px] w-full rounded-none"
         />
       ) : null}
-      <div className="flex flex-col gap-1 p-2.5">
-        <div className="text-main-700 flex items-center gap-1">
-          <TypeIcon className="h-3 w-3" />
-          <Text size="caption4" weight="extrabold" className="text-inherit">
-            {isDiary ? '일지' : '챌린지'}
-          </Text>
-        </div>
-        <Text
-          size="caption2"
-          weight="bold"
+      <div className="flex flex-col px-3.5 pt-3 pb-3">
+        <span
           className={cn(
-            'line-clamp-2',
+            'inline-flex w-fit items-center gap-1 rounded-md px-1.5 py-[3px]',
+            'text-[10.5px] leading-none font-extrabold',
+            // 일지는 브랜드, 챌린지는 보라 — 두 종류를 색으로 먼저 가른다.
+            isDiary
+              ? 'bg-main-200 text-main-900'
+              : 'bg-[#ede7f6] text-[#5e35b1]'
+          )}
+        >
+          <TypeIcon className="h-3 w-3" />
+          {isDiary ? '일지' : '챌린지'}
+        </span>
+        <Text
+          as="h4"
+          size="caption1"
+          weight="extrabold"
+          className={cn(
+            'mt-[7px] line-clamp-2 tracking-[-0.02em]',
             available ? 'text-gray-900' : 'text-gray-500'
           )}
         >
@@ -73,15 +85,35 @@ export function ChatShareCard({
               : '볼 수 없는 게시물이에요'}
         </Text>
         {available && share?.subtitle ? (
-          <Text size="caption3" className="truncate text-gray-500">
+          <Text size="caption2" className="mt-1 line-clamp-2 text-gray-600">
             {share.subtitle}
           </Text>
         ) : null}
       </div>
+      {/* 하단 CTA — 카드가 눌러서 가는 것임을 말로 밝힌다(디자인). */}
+      {available ? (
+        <div
+          className={cn(
+            'text-main-800 flex items-center justify-between border-t',
+            'border-gray-100 px-3.5 py-2.5'
+          )}
+        >
+          <Text size="caption2" weight="extrabold" className="text-inherit">
+            {isDiary ? '일지 보기' : '챌린지 보기'}
+          </Text>
+          <ChevronRight className="h-3.5 w-3.5" />
+        </div>
+      ) : null}
     </>
   );
 
-  const className = cn(CARD_CLASS, 'border-gray-200 bg-white text-left');
+  // 내 메시지에서만 테두리에 브랜드 기를 준다 — 예전처럼 카드를 통째로
+  // 오렌지로 감싸지 않는다(디자인이 지목한 그 테두리).
+  const className = cn(
+    CARD_CLASS,
+    'bg-white text-left',
+    isMine ? 'border-main-400' : 'border-gray-200'
+  );
   if (!path) {
     return <div className={className}>{body}</div>;
   }
@@ -125,7 +157,7 @@ export function ChatLinkPreviewCard({
           src={image}
           alt=""
           loading="lazy"
-          className="h-[116px] w-full object-cover object-center"
+          className="h-[118px] w-full object-cover object-center"
         />
       ) : null}
       <div className="flex flex-col gap-1 p-2.5">

--- a/src/app.feature/chat/components/ChatSheets.tsx
+++ b/src/app.feature/chat/components/ChatSheets.tsx
@@ -68,7 +68,44 @@ function Sheet({
   );
 }
 
-/** + 버튼 — 무엇을 붙일지 먼저 고른다. */
+/** 첨부 시트의 한 칸 — 아이콘 타일 + 라벨(디자인 .sh). */
+function SheetTile({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick(): void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col items-center gap-[7px]"
+    >
+      <span
+        className={cn(
+          'bg-main-200 text-main-900 flex h-[54px] w-[54px] items-center',
+          'justify-center rounded-[18px] transition-colors',
+          'hover:bg-main-300'
+        )}
+      >
+        {icon}
+      </span>
+      <Text size="caption3" weight="bold" className="text-gray-700">
+        {label}
+      </Text>
+    </button>
+  );
+}
+
+/**
+ * + 버튼 — 무엇을 붙일지 먼저 고른다.
+ *
+ * 세로 목록이 아니라 **4열 그리드 타일**이다(디자인). 항목이 셋뿐이라
+ * 목록으로 두면 시트가 세로로 길고 손가락 이동도 멀다.
+ */
 export function ChatShareMenuSheet({
   open,
   onOpenChange,
@@ -83,23 +120,28 @@ export function ChatShareMenuSheet({
     onSelect(kind);
   };
   return (
-    <Sheet open={open} onOpenChange={onOpenChange} title="보낼 것 고르기">
-      <SheetRow
-        icon={<ImageIcon className="h-5 w-5" />}
-        label="사진"
-        onClick={pick('photo')}
-      />
-      <SheetRow
-        icon={<Flag className="h-5 w-5" />}
-        label="챌린지 공유"
-        onClick={pick('challenge')}
-      />
-      <SheetRow
-        icon={<BookOpen className="h-5 w-5" />}
-        label="일지 공유"
-        onClick={pick('diary')}
-      />
-    </Sheet>
+    <BottomSheet open={open} onOpenChange={onOpenChange}>
+      <BottomSheetContent className="px-3 pt-4 pb-5">
+        <BottomSheetTitle className="sr-only">보낼 것 고르기</BottomSheetTitle>
+        <div className="grid grid-cols-4 gap-2.5">
+          <SheetTile
+            icon={<ImageIcon className="h-6 w-6" />}
+            label="사진"
+            onClick={pick('photo')}
+          />
+          <SheetTile
+            icon={<Flag className="h-6 w-6" />}
+            label="챌린지"
+            onClick={pick('challenge')}
+          />
+          <SheetTile
+            icon={<BookOpen className="h-6 w-6" />}
+            label="일지"
+            onClick={pick('diary')}
+          />
+        </div>
+      </BottomSheetContent>
+    </BottomSheet>
   );
 }
 

--- a/src/app.feature/chat/components/ChatTopBanners.tsx
+++ b/src/app.feature/chat/components/ChatTopBanners.tsx
@@ -28,9 +28,11 @@ function BannerCard({
   children: React.ReactNode;
   onClick?(): void;
 }): React.ReactElement {
+  // 디자인: main-100 바탕 + main-200 테두리, radius 14. 하드코딩 색을
+  // 걷어내고 토큰으로 되돌린다.
   const className = cn(
-    'border-main-300 mx-3 mt-2.5 mb-0.5 overflow-hidden rounded-2xl',
-    'border bg-[#fff4e5] text-left'
+    'border-main-200 bg-main-100 mx-3 mt-2.5 mb-0.5 overflow-hidden',
+    'rounded-[14px] border text-left'
   );
   if (!onClick) {
     return <div className={className}>{children}</div>;
@@ -64,10 +66,10 @@ function NoticeTag({
   return (
     <span
       className={cn(
-        'shrink-0 rounded-full px-1.5 py-px text-[10px] leading-5',
+        'shrink-0 rounded-md px-1.5 py-px text-[11px] leading-5',
         'font-extrabold',
         brand
-          ? 'bg-main-600 text-white'
+          ? 'bg-main-800 text-white'
           : 'border border-gray-200 bg-white text-gray-600'
       )}
     >
@@ -110,11 +112,15 @@ export function ChatNoticeBanner({
         )}
       >
         <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-          <div className="flex min-w-0 items-center gap-1.5">
+          <div className="flex min-w-0 items-center gap-[9px]">
             <NoticeTag label="공지" brand />
             {hasMedia ? <NoticeTag label="미디어" /> : null}
             {text && !expanded ? (
-              <Text size="caption2" className="truncate text-gray-800">
+              <Text
+                size="caption2"
+                weight="semibold"
+                className="min-w-0 flex-1 truncate text-gray-800"
+              >
                 {text.replace(/\n/g, ' ')}
               </Text>
             ) : null}

--- a/src/app.feature/chat/screen/ChatRoomListScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomListScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FilterChip, Text } from '@1d1s/design-system';
+import { Text } from '@1d1s/design-system';
 import EmptyState from '@component/EmptyState';
 import { SubPageShell } from '@component/layout/SubPageShell';
 import { Skeleton } from '@component/Skeleton';
@@ -12,6 +12,7 @@ import { useMinimumLoading } from '@module/utils/useMinimumLoading';
 import React, { useState } from 'react';
 
 import { ChatRoomListItem } from '../components/ChatRoomListItem';
+import { ChatSegmentedTabs } from '../components/ChatSegmentedTabs';
 import { useToggleChatPush } from '../hooks/useChatMutations';
 import { useChatRooms } from '../hooks/useChatQueries';
 import { ChatRoom } from '../type/chat';
@@ -23,12 +24,9 @@ function ListSkeleton(): React.ReactElement {
       {Array.from({ length: 5 }).map((_, index) => (
         <div
           key={index}
-          className={cn(
-            'flex items-center gap-3 rounded-2xl border border-gray-200',
-            'px-3.5 py-3'
-          )}
+          className={cn('flex items-center gap-3 rounded-2xl px-2 py-3')}
         >
-          <Skeleton shape="rounded" className="h-11 w-[66px] rounded-[10px]" />
+          <Skeleton shape="rounded" className="h-13 w-13 rounded-2xl" />
           <div className="flex min-w-0 flex-1 flex-col gap-2">
             <Skeleton shape="text" className="h-3.5 w-[55%]" />
             <Skeleton shape="text" className="h-3 w-[75%]" />
@@ -104,18 +102,14 @@ export function ChatRoomListScreen(): React.ReactElement {
       ) : (
         <div className="flex flex-col gap-3">
           {showFilters ? (
-            <div className="flex items-center gap-2">
-              {FILTERS.map((option) => (
-                <FilterChip
-                  key={option.key}
-                  size="sm"
-                  active={filterKey === option.key}
-                  onClick={() => setFilterKey(option.key)}
-                >
-                  {option.label}
-                </FilterChip>
-              ))}
-            </div>
+            <ChatSegmentedTabs<ChatRoomFilterKey>
+              options={FILTERS.map((option) => ({
+                value: option.key,
+                label: option.label,
+              }))}
+              value={filterKey}
+              onChange={setFilterKey}
+            />
           ) : null}
 
           {rooms.length === 0 ? (
@@ -135,8 +129,9 @@ export function ChatRoomListScreen(): React.ReactElement {
               }
             />
           ) : (
-            // 카드 사이 간격이 구분 역할을 하므로 divider 를 두지 않는다.
-            <div className="flex flex-col gap-2.5">
+            // 행이 스스로 패딩을 갖고, 안 읽은 방만 배경으로 구분된다 —
+            // 카드 테두리도 divider 도 없다(디자인).
+            <div className="flex flex-col gap-0.5">
               {rooms.map((room) => (
                 <ChatRoomListItem
                   key={room.roomId}

--- a/src/app.feature/chat/utils/chatFormat.ts
+++ b/src/app.feature/chat/utils/chatFormat.ts
@@ -70,7 +70,8 @@ export function isSameChatDay(left: string, right: string): boolean {
 export function roomPreview(room: ChatRoom): string {
   const last = room.lastMessage;
   if (last && last.preview.trim()) {
-    return `${last.senderNickname}: ${last.preview.replace(/\n/g, ' ')}`;
+    // 보낸 사람은 행이 따로 그린다 — 여기서 또 붙이면 "노근 노근: …" 이 된다.
+    return last.preview.replace(/\n/g, ' ');
   }
   const notice = room.notice?.content;
   if (notice && notice.trim()) {


### PR DESCRIPTION
디자인 HTML은 **번들 페이로드를 런타임에 푸는 구조**라 통독이 무의미했습니다. 페이로드를 디코드해 **마크업 42KB + CSS 19KB** 를 확보했고, 아래 수치는 전부 그 CSS 실값입니다. 렌더 스크린샷으로도 대조했습니다.

**룩만 교체했습니다.** `chatApi` · `chatSocket` · `useChatRoom` · `chatCache` · `chatArchive` · 타입은 한 줄도 안 건드렸습니다.

## 셀렉션 그룹 — `ChatSegmentedTabs` (신규, 채팅 전용)
`FilterChip` → 가로 균등 알약(h36 · r999 · gray-100), 활성만 `main-800` + warm shadow. **DS `SegmentedControl` 은 건드리지 않았습니다** — 그쪽을 바꾸면 챌린지 생성·수정(12) · 통계(3) · 가입까지 번져서, 확산 여부는 별도 결정으로 남겨 둡니다.

## 목록 행
3:2(66×44) → **52 정사각 · r16**(챌린지 3:2 이미지는 center-crop) · 카드 테두리 제거 · **안 읽은 방만 배경**으로 구분 · 칩은 알약 대신 **각진 r5** · 프리뷰는 `보낸사람 / 본문` 을 나누고 **공유 타입을 브랜드 색으로 뒤에** 세움 · 종은 **꺼 둔 방에만** 표시 · 배지 `main-800`.

## 말풍선 — 그룹핑 + 꼬리
같은 사람이 같은 날 잇달아 보낸 묶음을 `top/mid/last` 로 계산해 **꼬리를 묶음 바깥 한 군데에만** 붙입니다(상대=맨 위 `tl:4px`, 나=맨 아래 `br:4px`). **시간은 마지막 말풍선에만.** 미읽음 수는 노랑 → `main-800`.

렌더 실측으로 확인했습니다:
```
내 3연속:   너도 얼른 하자(br 4px) / 오늘 목표(16) / 테스트(16)
상대 4연속: 공유카드(tl 4px) / 테스트(16) / ㅋㅋㅋ(16) / 30분만(16)
```

## 사진 · 공유 카드
미디어는 **말풍선 패딩을 없애** 카드 자기 테두리만 남깁니다 — 디자인이 지목한 "두꺼운 오렌지 테두리" 제거. 그래서 **캡션은 자기 말풍선을 하나 더** 갖습니다(안 그러면 투명 배경에 글씨가 뜹니다).

공유 카드: 250폭 `r18` · 썸네일 118 · 타입 칩 각지게(**일지=브랜드 / 챌린지=보라 `#5e35b1`**) · 하단 **"일지 보기 →" CTA 줄** · 내 메시지만 `border-main-400`.

## 그 외
공지 배너 하드코딩 `#fff4e5` → `main-100`/`main-200` 토큰 · 컴포저 38px 원형 + 알약 입력 + warm shadow · 첨부 시트 목록 → **4열 그리드 타일** · 사진 프레임 `.pic` 190×122.

## 의도적 미적용 2가지
- **상대 30px 아바타**: 메시지 계약에 프로필 이미지가 없습니다. 정보 없는 색 원만 그리게 되고, 채우려면 제가 N+1 이유로 뺐던 members API 가 필요합니다. 닉네임이 이미 그 역할을 합니다.
- **목록 아바타 참여자 수 배지 / 다중 사진 그리드**: 서버 계약 없음(멤버 수 필드 없음, 메시지 이미지 1장). 확정대로 자리만/단일만.

## 검증
`pnpm lint` 0 · `tsc` · **256 tests 그대로 통과**(전부 로직 테스트 = 이번 변경의 회귀 가드) · `knip` 0 · `build` 성공 · 목 데이터 렌더 스크린샷 + 계산값 실측(탭 h36/bg, 아바타 52·r16, 꼬리 radius).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added segmented tabs for filtering chat rooms.
  * Added grouped message bubbles with improved sender labels, tails, and timestamp behavior.
  * Added a grid-style attachment menu for challenges and diary entries.
  * Enhanced shared content cards with availability actions and visual indicators.

* **Improvements**
  * Refined chat composer controls, attachment previews, banners, room listings, badges, and loading states.
  * Improved image thumbnails, message previews, spacing, typography, borders, and responsive styling.
  * Simplified room previews by removing redundant sender-name prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->