### PR TITLE
fix(chat): 리디자인 피드백 7건 — 썸네일 비율·참여자수·코너·공지·아바타·공유피커

### DIFF
--- a/src/app.feature/chat/components/ChatMessageBubble.tsx
+++ b/src/app.feature/chat/components/ChatMessageBubble.tsx
@@ -234,6 +234,30 @@ function TimeLabel({
   );
 }
 
+/** 아바타 지름과, 그만큼 버블을 들여쓸 폭(아바타 + gap). */
+const AVATAR_SIZE = 'h-10 w-10';
+const AVATAR_INDENT = 'pl-[48px]';
+
+/**
+ * 상대 프로필. 서버가 메시지에 프로필 이미지를 싣지 않아 **닉네임 첫 글자**를
+ * 브랜드 톤 원에 넣는다 — 빈 회색 원보다 누구인지가 읽힌다. 이미지가
+ * 계약에 생기면 이 자리만 바꾸면 된다.
+ */
+function SenderAvatar({ nickname }: { nickname: string }): React.ReactElement {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        AVATAR_SIZE,
+        'from-main-400 to-main-600 flex shrink-0 items-center justify-center',
+        'rounded-full bg-gradient-to-br text-[15px] font-extrabold text-white'
+      )}
+    >
+      {nickname.trim().charAt(0) || '?'}
+    </span>
+  );
+}
+
 const LONG_PRESS_MS = 450;
 
 /** 터치 롱프레스. 스크롤로 손가락이 움직이면 취소한다. */
@@ -321,15 +345,22 @@ export function ChatMessageBubble({
         highlighted && 'bg-main-100/60 -mx-2 rounded-xl px-2 py-1'
       )}
     >
+      {/* 카톡식 — 아바타가 **그룹 좌상단**에 서고 오른쪽에 닉네임,
+          그 아래로 말풍선이 쌓인다. 연속 발화면 첫 줄에만 그린다. */}
       {!isMine && showSender ? (
-        <Text size="caption3" weight="medium" className="pb-1 pl-1 text-gray-600">
-          {message.senderNickname}
-        </Text>
+        <div className="flex items-center gap-2 pb-1">
+          <SenderAvatar nickname={message.senderNickname} />
+          <Text size="caption2" weight="medium" className="text-gray-600">
+            {message.senderNickname}
+          </Text>
+        </div>
       ) : null}
       <div
         className={cn(
           'flex max-w-[86%] items-end gap-1.5',
-          isMine ? 'flex-row' : 'flex-row-reverse'
+          isMine ? 'flex-row' : 'flex-row-reverse',
+          // 말풍선은 아바타 폭만큼 들여써 닉네임 아래 선에 맞춘다.
+          !isMine && AVATAR_INDENT
         )}
       >
         <div className="shrink-0 pb-0.5">

--- a/src/app.feature/chat/components/ChatRoomListItem.tsx
+++ b/src/app.feature/chat/components/ChatRoomListItem.tsx
@@ -114,11 +114,12 @@ export function ChatRoomListItem({
         className="absolute inset-0 z-0 rounded-2xl"
       />
 
-      {/* 52 정사각. 챌린지 대표 이미지는 3:2 라 가운데를 기준으로 잘린다. */}
+      {/* 챌린지 대표 이미지가 3:2 라 그 비율 그대로 둔다 — 정사각으로
+          자르면 좌우가 잘려 무슨 챌린지인지 알아보기 어려웠다. */}
       <ChatRoomThumbnail
         url={room.challengeThumbnailUrl}
         category={room.category}
-        className="pointer-events-none z-[1] h-13 w-13 rounded-2xl"
+        className="pointer-events-none z-[1] h-13 w-[78px] rounded-2xl"
       />
 
       <div className="pointer-events-none z-[1] flex min-w-0 flex-1 flex-col">
@@ -131,6 +132,13 @@ export function ChatRoomListItem({
           >
             {room.challengeTitle}
           </Text>
+          {/* 참여자 수는 **제목 옆**이다. 썸네일 위 배지로 두면 안 읽은
+              수와 생김새가 겹쳐 서로 헷갈린다. */}
+          {room.memberCount != null && room.memberCount > 0 ? (
+            <Text size="caption3" className="shrink-0 text-gray-400">
+              {`${room.memberCount}명`}
+            </Text>
+          ) : null}
           {room.myRole === 'HOST' ? (
             <RoomChip label="HOST" tone="host" />
           ) : null}

--- a/src/app.feature/chat/components/ChatRoomThumbnail.tsx
+++ b/src/app.feature/chat/components/ChatRoomThumbnail.tsx
@@ -34,6 +34,9 @@ export function ChatRoomThumbnail({
   const FallbackIcon = fallback === 'diary' ? BookOpen : Flag;
   const wrapper = cn(
     'relative shrink-0 overflow-hidden rounded-[10px] bg-gray-100',
+    // 둥근 모서리 안쪽을 확실히 자른다 — 이미지든 줄무늬 폴백이든
+    // 코너가 테두리 밖으로 삐져나오지 않게(사파리 클리핑 보정).
+    '[transform:translateZ(0)]',
     className
   );
 

--- a/src/app.feature/chat/components/ChatShareCard.tsx
+++ b/src/app.feature/chat/components/ChatShareCard.tsx
@@ -20,8 +20,18 @@ import { ChatRoomThumbnail } from './ChatRoomThumbnail';
 // 자리가 모자라면 카드가 말풍선에 맞춰 줄어든다.
 const CARD_CLASS = cn(
   'w-[250px] max-w-full min-w-0 overflow-hidden rounded-[18px] border',
-  'shadow-[0_2px_8px_-4px_rgba(0,0,0,0.10)]'
+  'shadow-[0_2px_8px_-4px_rgba(0,0,0,0.10)]',
+  // 라운드 + 보더 + 자식 이미지 조합에서 코너가 깨져 보이던 것을 막는다.
+  // 사파리는 `overflow:hidden` 만으로는 둥근 모서리 안쪽을 늘 정확히
+  // 자르지 않는다 — 새 합성 레이어를 만들면 클리핑이 확실해진다.
+  '[transform:translateZ(0)]'
 );
+
+/**
+ * 카드 안쪽 상단 이미지에 줄 라운드. 보더 두께(1px)만큼 작아야 테두리와
+ * 이미지 사이에 각진 틈이 안 생긴다.
+ */
+const CARD_TOP_CLIP = 'rounded-t-[17px]';
 
 /**
  * 공유 카드. 볼 수 없는 대상이면 눌리지 않는다 — 보낼 땐 공개였던 일지가
@@ -48,7 +58,7 @@ export function ChatShareCard({
           url={share?.thumbnailUrl}
           category={share?.category}
           fallback={isDiary ? 'diary' : 'challenge'}
-          className="h-[118px] w-full rounded-none"
+          className={cn('h-[118px] w-full rounded-none', CARD_TOP_CLIP)}
         />
       ) : null}
       <div className="flex flex-col px-3.5 pt-3 pb-3">
@@ -157,7 +167,10 @@ export function ChatLinkPreviewCard({
           src={image}
           alt=""
           loading="lazy"
-          className="h-[118px] w-full object-cover object-center"
+          className={cn(
+            'h-[118px] w-full object-cover object-center',
+            CARD_TOP_CLIP
+          )}
         />
       ) : null}
       <div className="flex flex-col gap-1 p-2.5">

--- a/src/app.feature/chat/components/ChatSharePickerSheet.tsx
+++ b/src/app.feature/chat/components/ChatSharePickerSheet.tsx
@@ -6,6 +6,7 @@ import {
   BottomSheetTitle,
   Text,
 } from '@1d1s/design-system';
+import { isChallengeEnded } from '@feature/challenge/board/utils/challengePeriod';
 import { useMyDiariesInfinite } from '@feature/diary/board/hooks/useDiaryQueries';
 import { useSidebar } from '@feature/member/hooks/useMemberQueries';
 import { cn } from '@module/utils/cn';
@@ -82,7 +83,12 @@ export function ChatSharePickerSheet({
   const { data: diaryPages, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useMyDiariesInfinite(20);
 
-  const challenges = sidebar?.challengeList ?? [];
+  // 끝난 챌린지는 공유해도 받는 사람이 할 수 있는 게 없다 — 진행 중인
+  // 것만 고르게 한다. 무기한(종료일이 먼 미래)은 진행 중으로 본다:
+  // isChallengeEnded 가 그 규칙을 이미 갖고 있다.
+  const challenges = (sidebar?.challengeList ?? []).filter(
+    (challenge) => !isChallengeEnded(challenge.endDate)
+  );
   const diaries = diaryPages?.pages.flatMap((page) => page.items) ?? [];
   const isChallenge = kind === 'challenge';
   const empty = isChallenge ? challenges.length === 0 : diaries.length === 0;
@@ -123,7 +129,7 @@ export function ChatSharePickerSheet({
             <div className="py-12 text-center">
               <Text size="body2" className="text-gray-500">
                 {isChallenge
-                  ? '참여 중인 챌린지가 없어요.'
+                  ? '진행 중인 챌린지가 없어요.'
                   : '작성한 일지가 없어요.'}
               </Text>
             </div>

--- a/src/app.feature/chat/components/ChatTopBanners.tsx
+++ b/src/app.feature/chat/components/ChatTopBanners.tsx
@@ -80,8 +80,15 @@ function NoticeTag({
 
 interface ChatNoticeBannerProps {
   notice: ChatMessage;
-  /** 호스트에게만 해제 버튼을 준다. */
+  /** 호스트에게만 해제 액션을 준다. */
   canEdit: boolean;
+  /**
+   * 펼침 상태는 **밖에서 들고 있다**. 리스트 상단 여백(inset)을 접힘 높이로
+   * 묶어 두려면 화면이 이 상태를 알아야 한다 — 펼칠 때마다 여백이 따라
+   * 늘어나면 대화가 통째로 아래로 밀린다.
+   */
+  expanded: boolean;
+  onExpandedChange(expanded: boolean): void;
   onClear(): void;
   /** 원본이 이미 화면에 있으면 그리로 보낸다. 없으면 버튼을 안 그린다. */
   onJumpToOrigin?(): void;
@@ -91,10 +98,11 @@ interface ChatNoticeBannerProps {
 export function ChatNoticeBanner({
   notice,
   canEdit,
+  expanded,
+  onExpandedChange,
   onClear,
   onJumpToOrigin,
 }: ChatNoticeBannerProps): React.ReactElement {
-  const [expanded, setExpanded] = useState(false);
   const text = notice.content?.trim() ?? '';
   // 사진이든 공유 카드든 "글 말고 뭔가 더 있다" 는 표시가 필요하다.
   const hasMedia =
@@ -104,7 +112,7 @@ export function ChatNoticeBanner({
   const Chevron = expanded ? ChevronUp : ChevronDown;
 
   return (
-    <BannerCard onClick={() => setExpanded((value) => !value)}>
+    <BannerCard onClick={() => onExpandedChange(!expanded)}>
       <div
         className={cn(
           'flex gap-1.5 px-3.5 py-3',
@@ -144,38 +152,46 @@ export function ChatNoticeBanner({
                   {text}
                 </Text>
               ) : null}
-              {onJumpToOrigin ? (
-                <button
-                  type="button"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onJumpToOrigin();
-                  }}
-                  className="text-main-700 flex w-fit items-center gap-0.5 pt-1"
-                >
-                  <Text size="caption3" weight="bold" className="text-inherit">
-                    원본 보기
-                  </Text>
-                  <ChevronRight className="h-3 w-3" />
-                </button>
-              ) : null}
+              <div className="flex items-center gap-3 pt-1">
+                {onJumpToOrigin ? (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onJumpToOrigin();
+                    }}
+                    className="text-main-700 flex w-fit items-center gap-0.5"
+                  >
+                    <Text size="caption3" weight="bold" className="text-inherit">
+                      원본 보기
+                    </Text>
+                    <ChevronRight className="h-3 w-3" />
+                  </button>
+                ) : null}
+                {/* 무엇을 하는 버튼인지 말로 밝힌다. 아이콘만 두면 "배너
+                    닫기" 로 읽혀 공지를 실수로 내리게 된다. */}
+                {canEdit ? (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onClear();
+                    }}
+                    className="flex w-fit items-center gap-1 text-gray-500"
+                  >
+                    <X className="h-3 w-3" />
+                    <Text size="caption3" weight="bold" className="text-inherit">
+                      공지 해제하기
+                    </Text>
+                  </button>
+                ) : null}
+              </div>
             </>
           ) : null}
         </div>
+        {/* 접고 펴는 것은 chevron 하나가 맡는다. X 는 "닫기" 로 읽혀
+            공지 해제와 헷갈렸다 — 해제는 아래 라벨 액션으로 뺐다. */}
         <Chevron className="mt-1 h-3.5 w-3.5 shrink-0 text-gray-500" />
-        {canEdit ? (
-          <button
-            type="button"
-            aria-label="공지 해제"
-            onClick={(event) => {
-              event.stopPropagation();
-              onClear();
-            }}
-            className="flex h-7 w-7 shrink-0 items-center justify-center"
-          >
-            <X className="h-3.5 w-3.5 text-gray-600" />
-          </button>
-        ) : null}
       </div>
     </BannerCard>
   );

--- a/src/app.feature/chat/screen/ChatRoomScreen.tsx
+++ b/src/app.feature/chat/screen/ChatRoomScreen.tsx
@@ -132,12 +132,25 @@ export function ChatRoomScreen({
   const [highlightId, setHighlightId] = useState<number | null>(null);
   /** 신고 시트를 연 메시지. null 이면 닫혀 있다. */
   const [reportTarget, setReportTarget] = useState<number | null>(null);
+  /** 공지를 펼쳐 놓았는가. 리스트 여백을 접힘 높이로 묶는 데 쓴다. */
+  const [noticeExpanded, setNoticeExpanded] = useState(false);
+  /** 마지막으로 잰 **접힘 상태** 배너 높이. */
+  const [collapsedInset, setCollapsedInset] = useState(0);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   /** 이미 물어본 링크. 같은 글을 다시 물어보지 않는다. */
   const lastResolvedUrl = useRef<string | null>(null);
 
   const { ref: bannerRef, height: bannerInset } = useMeasuredHeight();
+  // 펼치면 배너가 길어지지만 리스트 여백은 **접힘 높이 그대로** 둔다 —
+  // 여백이 따라 늘면 대화가 통째로 아래로 밀려 읽던 자리를 잃는다.
+  // 펼친 동안 배너는 메시지 위에 겹쳐 있을 뿐이다.
+  useEffect(() => {
+    if (!noticeExpanded) {
+      setCollapsedInset(bannerInset);
+    }
+  }, [bannerInset, noticeExpanded]);
+  const topInset = noticeExpanded ? collapsedInset : bannerInset;
   const { mutate: togglePush } = useToggleChatPush();
   const { mutate: setNotice } = useSetChatNotice();
   const { mutate: clearNotice } = useClearChatNotice();
@@ -438,6 +451,8 @@ export function ChatRoomScreen({
             <ChatNoticeBanner
               notice={notice}
               canEdit={room?.myRole === 'HOST'}
+              expanded={noticeExpanded}
+              onExpandedChange={setNoticeExpanded}
               onClear={() =>
                 clearNotice(
                   { roomId },
@@ -472,7 +487,7 @@ export function ChatRoomScreen({
             hasNextPage={hasNextPage}
             isFetchingNextPage={isFetchingNextPage}
             fetchNextPage={fetchNextPage}
-            topInset={bannerInset}
+            topInset={topInset}
             canSend={canSend}
             archived={archived}
             noticeId={notice?.id}

--- a/src/app.feature/chat/type/chat.ts
+++ b/src/app.feature/chat/type/chat.ts
@@ -98,6 +98,12 @@ export interface ChatRoom {
    * **입력창 잠금은 이 값이 정본이다** — 클라가 조건을 다시 조립하지 않는다.
    */
   canSend?: boolean;
+
+  /**
+   * 방 참여자 수. 목록에서 제목 옆에 "N명" 으로 붙는다.
+   * ⚠️ 서버가 아직 안 준다 — 오면 그대로 켜진다(자리만 잡아 둔 값).
+   */
+  memberCount?: number;
 }
 
 export interface ChatRoomList {

--- a/src/app.feature/chat/utils/sharePickerFilter.test.ts
+++ b/src/app.feature/chat/utils/sharePickerFilter.test.ts
@@ -1,0 +1,31 @@
+import { isChallengeEnded } from '@feature/challenge/board/utils/challengePeriod';
+import { describe, expect, it } from 'vitest';
+
+// 공유 피커는 "참여 중인 챌린지" 를 사이드바에서 그대로 받아 쓰고,
+// 종료된 것만 걸러 낸다. 그 판정을 여기서 잠근다 — 무기한이 잘못
+// 걸러지면 피커가 통째로 비어 보인다.
+const NOW = new Date('2026-08-19T12:00:00');
+
+describe('공유 피커 — 진행 중 챌린지만', () => {
+  it('종료일이 지난 챌린지는 제외한다', () => {
+    expect(isChallengeEnded('2026-08-18', NOW)).toBe(true);
+  });
+
+  it('오늘 끝나는 챌린지는 아직 진행 중이다', () => {
+    expect(isChallengeEnded('2026-08-19', NOW)).toBe(false);
+  });
+
+  it('앞으로 끝나는 챌린지는 진행 중이다', () => {
+    expect(isChallengeEnded('2026-12-31', NOW)).toBe(false);
+  });
+
+  it('무기한(먼 미래 종료일)은 진행 중으로 본다', () => {
+    // 종료일을 아주 먼 해로 두는 것이 무기한 표현이다.
+    expect(isChallengeEnded('2999-12-31', NOW)).toBe(false);
+  });
+
+  it('종료일이 없으면 거르지 않는다', () => {
+    expect(isChallengeEnded(null, NOW)).toBe(false);
+    expect(isChallengeEnded(undefined, NOW)).toBe(false);
+  });
+});


### PR DESCRIPTION
앱에서 나온 피드백을 웹에 같이 맞춥니다. 기능 변경 없이 배치/표시만 조정했습니다.

## HD 조정 3건
| # | 변경 | 왜 |
|---|---|---|
| 1 | 목록 썸네일 **52 정사각 → 3:2(52×78)** center-cover | 정사각으로 자르면 좌우가 잘려 **무슨 챌린지인지 알아보기 어려웠음** |
| 2 | 참여자 수 **썸네일 우하단 배지 → 제목 옆 "N명"** | 배지 자리에 두면 **안 읽은 수와 생김새가 겹쳐** 서로 헷갈림 |
| 3 | 공유 카드 썸네일 **코너 클리핑** | 라운드+보더+자식 이미지 조합에서 모서리가 깨져 보임 |

**3번 처리**: 안쪽 이미지에 **보더 두께만큼 작은 라운드**(`rounded-t-[17px]` = 18−1)를 주고, 사파리가 둥근 모서리 안쪽을 확실히 자르도록 합성 레이어를 만듭니다(`overflow:hidden` 만으로는 사파리가 늘 정확히 자르지 않습니다). **이미지·기본 썸네일(줄무늬 폴백) 둘 다** 적용.

> 참여자 수는 서버 `ChatRoomResponse` 에 아직 필드가 없어 **자리만** 잡았습니다(`memberCount` 오면 그대로 켜짐).

## 공지 배너 2건
1. **상단 여백 유지** — 펼쳐도 리스트 여백은 **접힘 높이 그대로**. 여백이 펼침 높이를 따라가면 대화가 통째로 아래로 밀려 읽던 자리를 잃습니다. 펼친 동안 배너는 메시지 위에 겹쳐 있을 뿐입니다. (펼침 상태를 화면으로 올리고, inset 은 접힘일 때만 갱신)
2. **해제 액션 분리** — X 아이콘 버튼 **제거**. X 는 "배너 닫기" 로 읽혀 공지를 실수로 내리게 했습니다. 접고 펴는 것은 **chevron 하나**가 맡고, 해제는 펼친 상태의 **"공지 해제하기" 라벨 액션**(호스트만)으로 뺐습니다.

## HD-7 아바타
마지막 버블 옆(하단) → **그룹 좌상단, 닉네임 왼쪽**(카톡식). **40px** 로 키우고 연속 발화면 **첫 줄에만**. 말풍선은 아바타 폭만큼 들여써 닉네임 아래 선에 맞춥니다.

> 서버가 메시지에 프로필 이미지를 싣지 않아 **닉네임 첫 글자**를 브랜드 원에 넣습니다 — 빈 회색 원보다 누구인지가 읽힙니다. 이미지가 계약에 생기면 그 자리만 바꾸면 됩니다.

## HE 공유 피커
참여 챌린지에서 **종료된 것 제외**. 끝난 챌린지는 공유해도 받는 사람이 할 수 있는 게 없습니다. **무기한은 진행 중**으로 봅니다 — `isChallengeEnded` 가 이미 그 규칙(먼 미래 종료일=무기한)이라 그대로 씁니다. 검색 정책은 그대로.

## 검증
`pnpm lint` 0 · `tsc` · **261 tests**(+5: 종료/오늘종료/미래/무기한/종료일없음 필터 가드) · `knip` 0 · `build` 성공.
목 데이터 렌더로 확인: 3:2 썸네일 · "12명/4명" 제목 옆 · 공유 카드 코너 · 아바타 좌상단(닉네임 오른쪽) · 공지 접힘(chevron만)/펼침("공지 해제하기").