### PR TITLE
fix(chat): 셀렉션 그룹 전환 잔상 · 공지 배너 색·패딩 (HD-10·HD-11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@1d1s/design-system": "^2.12.0",
+    "@1d1s/design-system": "^2.12.1",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-aspect-ratio": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
   .:
     dependencies:
       '@1d1s/design-system':
-        specifier: ^2.12.0
-        version: 2.12.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^2.12.1
+        version: 2.12.1(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.0.1(react-hook-form@7.55.0(react@19.2.4))
@@ -265,8 +265,8 @@ importers:
 
 packages:
 
-  '@1d1s/design-system@2.12.0':
-    resolution: {integrity: sha512-pRQidxkz/aEz8fW2Zegz9hctOwan6xBPiyVi2GeHi0WJJLcahKHcvB8zOH7a3Lj+KvZ0W0hhcYRceF3SE6KQmQ==}
+  '@1d1s/design-system@2.12.1':
+    resolution: {integrity: sha512-ZzS7vLlcWGWRnNB48BH5wSuUHdNOfXLWTOY7xXFDZ1kO614Hy0HlUe09pM1bNO7G04nmI8aHOTGxv2Ay3uLQ+w==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0
       react: ^19.0.0
@@ -5150,7 +5150,7 @@ packages:
 
 snapshots:
 
-  '@1d1s/design-system@2.12.0(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@1d1s/design-system@2.12.1(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.16(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-checkbox': 1.1.5(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/app.feature/chat/components/ChatTopBanners.tsx
+++ b/src/app.feature/chat/components/ChatTopBanners.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   ChevronUp,
   PartyPopper,
+  Pin,
   X,
 } from 'lucide-react';
 import Link from 'next/link';
@@ -55,22 +56,30 @@ function BannerCard({
   );
 }
 
-/** 배너 앞머리 태그 — [공지] / [미디어]. */
-function NoticeTag({
-  label,
-  brand = false,
-}: {
-  label: string;
-  brand?: boolean;
-}): React.ReactElement {
+/**
+ * 배너 앞머리 표시 — 공지(핀 + 브랜드 색 글자)와 [미디어] 보조 태그.
+ *
+ * 공지는 디자인의 `.nb` 그대로 **채우지 않고 글자 색만** 브랜드다. 채운
+ * 칩으로 두면 같은 배너 안의 HOST 칩·해제 액션과 무게가 겹쳐 어디를
+ * 봐야 할지 흩어진다.
+ */
+function NoticeLabel(): React.ReactElement {
+  return (
+    <span className="text-main-800 flex shrink-0 items-center gap-[5px]">
+      <Pin className="text-main-900 h-4 w-4" />
+      <Text size="caption4" weight="extrabold" className="text-inherit">
+        공지
+      </Text>
+    </span>
+  );
+}
+
+function NoticeSubTag({ label }: { label: string }): React.ReactElement {
   return (
     <span
       className={cn(
-        'shrink-0 rounded-md px-1.5 py-px text-[11px] leading-5',
-        'font-extrabold',
-        brand
-          ? 'bg-main-800 text-white'
-          : 'border border-gray-200 bg-white text-gray-600'
+        'shrink-0 rounded-md border border-gray-200 bg-white px-1.5',
+        'py-px text-[11px] leading-5 font-extrabold text-gray-600'
       )}
     >
       {label}
@@ -115,14 +124,20 @@ export function ChatNoticeBanner({
     <BannerCard onClick={() => onExpandedChange(!expanded)}>
       <div
         className={cn(
-          'flex gap-1.5 px-3.5 py-3',
-          expanded ? 'items-start' : 'items-center'
+          // 디자인 .notice — padding 10 13, 칸 사이 9(접힘)·7(펼침).
+          'flex px-[13px] py-2.5',
+          expanded ? 'items-start gap-[7px]' : 'items-center gap-[9px]'
         )}
       >
-        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div
+          className={cn(
+            'flex min-w-0 flex-1 flex-col',
+            expanded ? 'gap-[7px]' : 'gap-0'
+          )}
+        >
           <div className="flex min-w-0 items-center gap-[9px]">
-            <NoticeTag label="공지" brand />
-            {hasMedia ? <NoticeTag label="미디어" /> : null}
+            <NoticeLabel />
+            {hasMedia ? <NoticeSubTag label="미디어" /> : null}
             {text && !expanded ? (
               <Text
                 size="caption2"
@@ -146,8 +161,8 @@ export function ChatNoticeBanner({
                 </div>
               ) : text ? (
                 <Text
-                  size="caption2"
-                  className="whitespace-pre-wrap text-gray-800"
+                  size="caption3"
+                  className="leading-[1.55] whitespace-pre-wrap text-gray-700"
                 >
                   {text}
                 </Text>


### PR DESCRIPTION
## HD-10 셀렉션 그룹 전환 잔상 — DS 2.12.1
탭을 바꿀 때 **직전 활성의 주황이 잠깐 남았다 사라지는** 잔상.

**원인**: `transition-colors duration-200` 이 `background-color` 를 페이드시켜, **나가는 칸이 아직 주황인 채로 들어오는 칸이 주황**이 됩니다(200ms 동안 두 칸이 동시에 켜진 것처럼 보임). 게다가 `box-shadow` 는 `transition-colors` 대상이 **아니라** 혼자 즉시 사라져, "그림자는 없는데 주황은 남은" 중간 프레임이 테두리·그림자 잔상으로 읽혔습니다.

**수정**: 고르는 것은 켜짐/꺼짐 두 상태뿐이라 사이 구간이 있을 이유가 없습니다 — 전환 제거(`transition-none`). [design-system#23](https://github.com/1D1S/1D1S-design-system/pull/23) → **2.12.1**

렌더 실측: `transitionProperty: none` · `transitionDuration: 0s` (선택/비선택 양쪽) → 배경과 그림자가 **같은 프레임**에 바뀝니다.

## HD-11 공지 배너 색·패딩
디자인 CSS 실값(`.notice`)에 맞췄습니다.

| 항목 | 이전 | 이후 |
|---|---|---|
| 패딩 | `px-3.5 py-3` (14/12) | **10 / 13** |
| 칸 사이 | 1.5 고정 | **9(접힘) · 7(펼침)** |
| "공지" 라벨 | 채운 주황 칩 | **핀 + 브랜드 색 글자** (`.nb`) |
| 펼침 본문 | gray-800 | **gray-700**, 12.5 / line-height 1.55 (`.open p`) |
| 접힘 본문 | 13 / 600 gray-800 | 그대로 (`.nt`) |
| 작성자 | gray-500 | 그대로 |

"공지" 를 채운 칩으로 두면 같은 배너 안의 HOST 칩·해제 액션과 **무게가 겹쳐** 어디를 봐야 할지 흩어집니다. 디자인이 글자 색만 브랜드로 둔 이유입니다.

## 검증
`pnpm lint` 0 · `tsc` · **261 tests** · `knip` 0 · `build` 성공. 렌더로 접힘/펼침 두 상태 확인.

## 영향
DS 변경이라 `1D1S-client`(챌린지 생성/수정·통계·가입·채팅) 전반에서 잔상이 사라집니다. `1D1S-admin` 은 의존성을 올리는 시점에 같이 적용됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated pin icon and notice label for chat banners.
  - Improved notice banner layout, spacing, and expanded-state presentation.

- **Style**
  - Refined expanded notice typography with improved sizing, line height, and text color.
  - Separated media labels from notice indicators for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->