### PR TITLE
fix(chat): 방을 연 채 도착한 메시지에 읽음이 안 올라가던 것 (HD-12·13)

### DIFF
--- a/src/app.feature/chat/components/ChatTopBanners.tsx
+++ b/src/app.feature/chat/components/ChatTopBanners.tsx
@@ -192,7 +192,13 @@ export function ChatNoticeBanner({
                       event.stopPropagation();
                       onClear();
                     }}
-                    className="flex w-fit items-center gap-1 text-gray-500"
+                    className={cn(
+                      // 누를 수 있는 것으로 보이게 테두리와 바탕을 준다 —
+                      // 글자만 있으면 안내문과 구분이 안 돼 지나친다.
+                      'flex w-fit items-center gap-1 rounded-lg border',
+                      'border-gray-200 bg-white px-2.5 py-1.5 text-gray-700',
+                      'transition-colors hover:bg-gray-50'
+                    )}
                   >
                     <X className="h-3 w-3" />
                     <Text size="caption3" weight="bold" className="text-inherit">

--- a/src/app.feature/chat/hooks/useChatRoom.ts
+++ b/src/app.feature/chat/hooks/useChatRoom.ts
@@ -11,6 +11,7 @@ import {
   subscribeChatRoom,
 } from '../socket/chatSocket';
 import {
+  advanceReadState,
   ChatMessage,
   ChatMessageType,
   ChatReadState,
@@ -105,6 +106,13 @@ export function useChatRoom(
     [query.data]
   );
 
+  /**
+   * 읽음 위치를 서버에 올린다.
+   *
+   * **내 위치는 서버가 받아들이는 대로 화면에도 반영한다.** 예전에는
+   * 되쏘는 `/read` 브로드캐스트만 기다렸는데, 그게 늦거나 유실되면 내가
+   * 보고 있는 메시지에 내 안읽음 표시가 그대로 남는다.
+   */
   const markRead = useCallback(
     (messageId: number) => {
       if (messageId <= 0 || messageId <= lastReadSent.current) {
@@ -113,9 +121,22 @@ export function useChatRoom(
       lastReadSent.current = messageId;
       chatApi
         .markRead(roomId, messageId)
-        .then(() =>
-          queryClient.invalidateQueries({ queryKey: CHAT_QUERY_KEYS.rooms() })
-        )
+        .then(() => {
+          // 서버가 받아들인 뒤에 내 위치를 화면에도 반영한다. 되쏘는
+          // 브로드캐스트를 기다리지 않는다 — 그게 늦거나 유실되면 내가
+          // 보고 있는 메시지에 내 안읽음 표시가 그대로 남는다.
+          if (myMemberId != null) {
+            setReadStates((current) =>
+              advanceReadState(current, {
+                memberId: myMemberId,
+                lastReadMessageId: messageId,
+              })
+            );
+          }
+          return queryClient.invalidateQueries({
+            queryKey: CHAT_QUERY_KEYS.rooms(),
+          });
+        })
         .catch(() => {
           // 실패하면 다음 메시지에서 다시 시도할 수 있게 되돌린다.
           if (lastReadSent.current === messageId) {
@@ -123,7 +144,7 @@ export function useChatRoom(
           }
         });
     },
-    [queryClient, roomId]
+    [myMemberId, queryClient, roomId]
   );
 
   // 방에 들어갈 때 읽음 위치를 한 번 받아 둔다. 이후 갱신은 /read 구독이
@@ -148,8 +169,34 @@ export function useChatRoom(
 
   // 방을 열었으면 거기까지는 읽은 것이다. 최신순이라 첫 항목이 최신.
   const latestId = messages.find((message) => message.id > 0)?.id ?? 0;
+
+  /**
+   * 읽음을 올리는 시점은 셋이다.
+   *
+   *   ① 방에 들어왔을 때          — 아래 effect 의 첫 실행
+   *   ② 방을 연 채 새 메시지 도착 — latestId 가 올라가며 다시 실행
+   *   ③ 창으로 돌아왔을 때        — 아래 focus/visibility 구독
+   *
+   * ②가 핵심이다. 이게 없으면 상대가 방을 보고 있어도 안읽음이 그대로
+   * 남는다 — 들어올 때 한 번 올린 위치에서 멈추기 때문이다. 스크롤
+   * 위치까지 따지지는 않는다. 방이 열려 있으면 읽은 것으로 본다.
+   */
   useEffect(() => {
     markRead(latestId);
+  }, [latestId, markRead]);
+
+  useEffect(() => {
+    const markLatest = (): void => {
+      if (!document.hidden) {
+        markRead(latestId);
+      }
+    };
+    window.addEventListener('focus', markLatest);
+    document.addEventListener('visibilitychange', markLatest);
+    return () => {
+      window.removeEventListener('focus', markLatest);
+      document.removeEventListener('visibilitychange', markLatest);
+    };
   }, [latestId, markRead]);
 
   // 실시간 콜백은 매 렌더 바뀌지만 구독은 방마다 한 번만 건다. 최신 콜백을
@@ -190,30 +237,12 @@ export function useChatRoom(
         setSocketError(error);
       },
       onRead: (receipt) => {
-        // 한 줄만 갈아 끼운다. 위치는 앞으로만 간다는 계약이지만, 순서가
-        // 뒤바뀌어 도착해도 뒤로 밀리지 않게 막는다.
-        setReadStates((current) => {
-          const next = current.filter(
-            (state) => state.memberId !== receipt.memberId
-          );
-          const before = current.find(
-            (state) => state.memberId === receipt.memberId
-          );
-          const previous = before?.lastReadMessageId ?? -1;
-          const incoming = receipt.lastReadMessageId ?? -1;
-          next.push(
-            incoming > previous
-              ? {
-                  memberId: receipt.memberId,
-                  lastReadMessageId: receipt.lastReadMessageId,
-                }
-              : (before ?? {
-                  memberId: receipt.memberId,
-                  lastReadMessageId: receipt.lastReadMessageId,
-                })
-          );
-          return next;
-        });
+        setReadStates((current) =>
+          advanceReadState(current, {
+            memberId: receipt.memberId,
+            lastReadMessageId: receipt.lastReadMessageId,
+          })
+        );
       },
       onReconnect: () => {
         chatApi

--- a/src/app.feature/chat/type/advanceReadState.test.ts
+++ b/src/app.feature/chat/type/advanceReadState.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { advanceReadState, type ChatReadState } from './chat';
+
+const states: ChatReadState[] = [
+  { memberId: 1, lastReadMessageId: 10 },
+  { memberId: 2, lastReadMessageId: null },
+];
+
+describe('advanceReadState', () => {
+  it('앞으로 간 위치는 반영한다', () => {
+    const next = advanceReadState(states, {
+      memberId: 1,
+      lastReadMessageId: 12,
+    });
+    expect(next.find((s) => s.memberId === 1)?.lastReadMessageId).toBe(12);
+  });
+
+  it('한 번도 안 읽던 멤버도 반영한다', () => {
+    const next = advanceReadState(states, {
+      memberId: 2,
+      lastReadMessageId: 3,
+    });
+    expect(next.find((s) => s.memberId === 2)?.lastReadMessageId).toBe(3);
+  });
+
+  it('뒤로 가는 통지는 무시한다 — 사라진 안읽음이 되살아나면 안 된다', () => {
+    const next = advanceReadState(states, {
+      memberId: 1,
+      lastReadMessageId: 5,
+    });
+    expect(next).toBe(states);
+  });
+
+  it('같은 위치는 그대로 둔다', () => {
+    expect(
+      advanceReadState(states, { memberId: 1, lastReadMessageId: 10 })
+    ).toBe(states);
+  });
+
+  it('모르는 멤버는 새로 넣는다', () => {
+    const next = advanceReadState(states, {
+      memberId: 9,
+      lastReadMessageId: 1,
+    });
+    expect(next).toHaveLength(3);
+  });
+
+  it('다른 멤버 위치는 건드리지 않는다', () => {
+    const next = advanceReadState(states, {
+      memberId: 1,
+      lastReadMessageId: 20,
+    });
+    expect(next.find((s) => s.memberId === 2)?.lastReadMessageId).toBeNull();
+  });
+});

--- a/src/app.feature/chat/type/chat.ts
+++ b/src/app.feature/chat/type/chat.ts
@@ -178,6 +178,31 @@ export function unreadCountFor(
   }).length;
 }
 
+/**
+ * 한 멤버의 읽음 위치를 앞으로만 옮긴다.
+ *
+ * 위치는 앞으로만 간다는 계약이지만, 통지가 순서를 바꿔 도착하거나 내가
+ * 낙관적으로 올린 값보다 낮은 브로드캐스트가 뒤늦게 와도 **뒤로 밀리지
+ * 않아야** 한다 — 밀리면 이미 사라진 안읽음 숫자가 되살아난다.
+ */
+export function advanceReadState(
+  states: ChatReadState[],
+  next: ChatReadState
+): ChatReadState[] {
+  const before = states.find((state) => state.memberId === next.memberId);
+  if (!before) {
+    return [...states, next];
+  }
+  const previous = before.lastReadMessageId ?? -1;
+  const incoming = next.lastReadMessageId ?? -1;
+  if (incoming <= previous) {
+    return states;
+  }
+  return states.map((state) =>
+    state.memberId === next.memberId ? next : state
+  );
+}
+
 /** 신고 사유(ChatReportReason). 서버 enum 과 순서까지 맞춘다. */
 export const CHAT_REPORT_REASONS = [
   { value: 'SPAM', label: '스팸 / 광고' },


### PR DESCRIPTION
## 웹 버그 — 상대가 보고 있어도 안읽음이 안 사라짐

**원인은 읽음을 *올리는* 쪽이었다.** 수신 경로는 멀쩡했다 — 제보 스크린샷에서
오래된 메시지의 숫자는 이미 사라져 있었고, 그건 상대 읽음 위치가 들어오고 있다는
뜻이다. 서버 계약(`PUT /chat/rooms/{id}/read` → 위치가 실제로 앞으로 갔을 때만
`/topic/chat/rooms/{id}/read` 브로드캐스트)도 확인했고 문제 없었다.

빠진 건 **방을 연 채로 새 메시지가 왔을 때 읽음을 다시 올리지 않던 것**이다.
진입 시 한 번만 올라가니, 보고 있는 사람의 위치는 그 시점에 멈춰 있고 상대
화면의 `1` 은 영원히 남는다.

- 읽음 전송 시점을 셋으로 명시: ①방 진입 ②방을 연 채 새 메시지 수신
  ③창 복귀(`focus` / `visibilitychange`, `document.hidden` 이면 건너뜀)
- 내 위치는 서버 ack 직후 화면에도 반영. 되쏘는 브로드캐스트만 기다리면
  그게 늦거나 유실될 때 **내가 보고 있는 메시지에 내 안읽음이 남는다**
- 위치 병합을 `advanceReadState()` 순수 함수로 분리 — 앞으로만 간다.
  뒤늦은 낮은 값이 뒤로 밀면 사라진 숫자가 되살아난다. 테스트 6개로 잠금

## HD-12 / HD-13

- **HD-12** 공지 배너는 오버레이 그대로다(`absolute` + ResizeObserver inset).
  리디자인에서 인라인으로 회귀하지 않았음 — 변경 없음
- **HD-13** `공지 해제하기` 를 테두리·바탕 있는 보조 버튼으로. 글자만 있으면
  안내문과 구분이 안 돼 지나친다

## 검증

lint / tsc / knip / build 통과, 테스트 267개 통과(신규 6). 브라우저 확인은
사용자 몫 — 직접 띄워보지 않았다.