### PR TITLE
fix(header): 비로그인 헤더 정리(GB) + HD-10 정정 · HD-14

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@1d1s/design-system": "^2.12.1",
+    "@1d1s/design-system": "^2.12.2",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-aspect-ratio": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
   .:
     dependencies:
       '@1d1s/design-system':
-        specifier: ^2.12.1
-        version: 2.12.1(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^2.12.2
+        version: 2.12.2(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.0.1(react-hook-form@7.55.0(react@19.2.4))
@@ -265,8 +265,8 @@ importers:
 
 packages:
 
-  '@1d1s/design-system@2.12.1':
-    resolution: {integrity: sha512-ZzS7vLlcWGWRnNB48BH5wSuUHdNOfXLWTOY7xXFDZ1kO614Hy0HlUe09pM1bNO7G04nmI8aHOTGxv2Ay3uLQ+w==}
+  '@1d1s/design-system@2.12.2':
+    resolution: {integrity: sha512-gUr9xZTYoEmuKZIw5sQoQloaMVHj7Odh3VYShQD4KjDQz5Uj+ppLfAGWsCygiASTqbx+W2WxAZ62H/9T/ZdHhg==}
     peerDependencies:
       next: ^14.0.0 || ^15.0.0
       react: ^19.0.0
@@ -5150,7 +5150,7 @@ packages:
 
 snapshots:
 
-  '@1d1s/design-system@2.12.1(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@1d1s/design-system@2.12.2(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-accordion': 1.2.16(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-checkbox': 1.1.5(@types/react-dom@19.1.5(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/app.component/layout/AppLayoutShell.tsx
+++ b/src/app.component/layout/AppLayoutShell.tsx
@@ -167,7 +167,7 @@ export default function AppLayoutShell({
   // 인증/사이드바 상태는 별도 hook 으로 묶었다. shell 은 라우트 가시성 판단과
   // 핸들러 안정화에만 집중한다.
   const authState = useAuthLayoutState();
-  const { isLoggedIn, isAuthLoading, hasUnread, sidebarData, railChallenges } =
+  const { isLoggedIn, isAuthLoading, sidebarData, railChallenges } =
     authState;
 
   // 전화번호 미입력 시 프로필 아바타에 경고 배지를 띄운다. 사이드바 응답에는
@@ -250,7 +250,6 @@ export default function AppLayoutShell({
           activeId={activeNavId}
           isLoggedIn={isLoggedIn}
           isAuthLoading={isAuthLoading}
-          hasUnread={hasUnread}
           streakDays={sidebarData?.streakCount ?? 0}
           profileImageUrl={sidebarData?.profileUrl}
           showPhoneBadge={showPhoneBadge}

--- a/src/app.component/layout/AppTopNav.tsx
+++ b/src/app.component/layout/AppTopNav.tsx
@@ -6,6 +6,7 @@ import FadeInImage from '@component/FadeInImage';
 import { ProfileAlertBadge } from '@component/ProfileAlertBadge';
 import { Skeleton } from '@component/Skeleton';
 import { ChatEntryButton } from '@feature/chat/components/ChatEntryButton';
+import { NotificationBellButton } from '@feature/notification/components/NotificationBellButton';
 import { cn } from '@module/utils/cn';
 import {
   buildLoginUrl,
@@ -40,7 +41,6 @@ interface AppTopNavProps {
   activeId: string;
   isLoggedIn: boolean;
   isAuthLoading?: boolean;
-  hasUnread: boolean;
   streakDays: number;
   profileImageUrl?: string;
   showPhoneBadge?: boolean;
@@ -52,7 +52,6 @@ export default function AppTopNav({
   activeId,
   isLoggedIn,
   isAuthLoading = false,
-  hasUnread,
   streakDays,
   profileImageUrl,
   showPhoneBadge = false,
@@ -121,28 +120,10 @@ export default function AppTopNav({
       </nav>
 
       <div className="ml-auto flex items-center gap-2">
+        {/* 둘 다 비로그인이면 스스로 사라진다 — 게스트 헤더에 남는
+            액션은 아래 로그인 진입뿐이다. */}
         <ChatEntryButton />
-
-        <Link
-          href="/notification"
-          aria-label="알림"
-          className={cn(
-            'relative flex h-9 w-9 items-center justify-center',
-            'rounded-2 bg-gray-100 text-gray-700',
-            'transition hover:bg-gray-200'
-          )}
-        >
-          <Icon name="Bell" size={16} />
-          {hasUnread ? (
-            <span
-              aria-hidden
-              className={cn(
-                'absolute top-2 right-2 h-1.5 w-1.5',
-                'bg-brand rounded-full'
-              )}
-            />
-          ) : null}
-        </Link>
+        <NotificationBellButton />
 
         {/*
           태블릿 이하에서만 로그인/아바타 클러스터 노출. 데스크탑은

--- a/src/app.feature/chat/components/ChatTopBanners.tsx
+++ b/src/app.feature/chat/components/ChatTopBanners.tsx
@@ -236,12 +236,11 @@ export function ChatEndedBanner({
 
   return (
     <BannerCard>
-      <div
-        className={cn(
-          'flex gap-2 px-3.5 py-3',
-          collapsed ? 'items-center' : 'items-start'
-        )}
-      >
+      {/* 접힘·펼침 모두 items-start 다. collapsed 에서 items-center 로
+          바꾸면 28px 짜리 chevron 버튼이 행 높이를 잡아 제목이 아래로
+          내려앉고, 펼치는 순간 다시 올라와 배너가 삐걱인다. 세로 정렬은
+          아이콘 쪽 마진으로 맞춘다 — 공지 배너와 같은 방식. */}
+      <div className="flex items-start gap-2 px-[13px] py-2.5">
         <PartyPopper className="text-main-600 mt-0.5 h-3.5 w-3.5 shrink-0" />
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <Text size="caption2" weight="bold" className="truncate text-gray-800">
@@ -288,7 +287,11 @@ export function ChatEndedBanner({
           type="button"
           aria-label={collapsed ? '펼치기' : '접기'}
           onClick={() => setCollapsed((value) => !value)}
-          className="flex h-7 w-7 shrink-0 items-center justify-center"
+          className={cn(
+            'flex h-7 w-7 shrink-0 items-center justify-center',
+            // 탭 영역은 28px 로 두되 제목 줄 높이와 중심을 맞춘다.
+            '-mt-1'
+          )}
         >
           <Chevron className="h-3.5 w-3.5 text-gray-500" />
         </button>
@@ -306,7 +309,7 @@ export function ChatEndedBanner({
 export function ChatArchivedBanner(): React.ReactElement {
   return (
     <BannerCard>
-      <div className="flex items-start gap-2 px-3.5 py-3">
+      <div className="flex items-start gap-2 px-[13px] py-2.5">
         <Archive className="mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-500" />
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <Text size="caption2" weight="bold" className="text-gray-800">
@@ -333,7 +336,7 @@ export function ChatNoticeMessageBanner({
 }): React.ReactElement {
   return (
     <BannerCard>
-      <div className="px-3.5 py-2.5">
+      <div className="px-[13px] py-2.5">
         <Text size="caption2" className="text-gray-800">
           {text}
         </Text>

--- a/src/app.feature/home/components/HomeMobileHeader.tsx
+++ b/src/app.feature/home/components/HomeMobileHeader.tsx
@@ -2,17 +2,12 @@
 
 import { Icon } from '@1d1s/design-system';
 import { ChatEntryButton } from '@feature/chat/components/ChatEntryButton';
-import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
-import { useUnreadCount } from '@feature/notification/hooks/useNotificationQueries';
+import { NotificationBellButton } from '@feature/notification/components/NotificationBellButton';
 import { cn } from '@module/utils/cn';
 import Link from 'next/link';
 import React from 'react';
 
 export default function HomeMobileHeader(): React.ReactElement {
-  const isLoggedIn = useIsLoggedIn();
-  const { data: unreadData } = useUnreadCount({ enabled: isLoggedIn });
-  const hasUnread = isLoggedIn && (unreadData?.unreadCount ?? 0) > 0;
-
   return (
     <header
       className={cn(
@@ -39,27 +34,7 @@ export default function HomeMobileHeader(): React.ReactElement {
 
       <div className="flex items-center gap-2">
         <ChatEntryButton />
-
-        <Link
-          href="/notification"
-          aria-label="알림"
-          className={cn(
-            'relative flex h-9 w-9 items-center justify-center',
-            'rounded-2 bg-gray-100 text-gray-700',
-            'transition hover:bg-gray-200'
-          )}
-        >
-          <Icon name="Bell" size={16} />
-          {hasUnread ? (
-            <span
-              aria-hidden
-              className={cn(
-                'absolute top-2 right-2 h-1.5 w-1.5',
-                'bg-brand rounded-full'
-              )}
-            />
-          ) : null}
-        </Link>
+        <NotificationBellButton />
       </div>
     </header>
   );

--- a/src/app.feature/notification/components/NotificationBellButton.tsx
+++ b/src/app.feature/notification/components/NotificationBellButton.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Icon } from '@1d1s/design-system';
+import { useIsLoggedIn } from '@feature/member/hooks/useIsLoggedIn';
+import { cn } from '@module/utils/cn';
+import Link from 'next/link';
+import React from 'react';
+
+import { useUnreadCount } from '../hooks/useNotificationQueries';
+
+/**
+ * 헤더의 알림 진입 버튼. 안 읽은 알림이 있으면 점을 얹는다.
+ *
+ * **비로그인이면 아무것도 그리지 않는다.** 알림함은 로그인해야 열리는
+ * 화면이라, 게스트에게 보이면 눌러도 로그인으로 튕기는 미끼가 된다.
+ * 게스트 헤더에는 로그인 진입만 남는다.
+ *
+ * 숨김 판정을 이 안에 둔 것은 헤더가 둘(데스크탑 AppTopNav · 모바일
+ * HomeMobileHeader)이라서다 — 부르는 쪽에 조건을 두면 한쪽만 고쳐진다.
+ * 채팅 진입(ChatEntryButton)과 같은 방식이다.
+ */
+export function NotificationBellButton({
+  className,
+}: {
+  className?: string;
+}): React.ReactElement | null {
+  const isLoggedIn = useIsLoggedIn();
+  const { data } = useUnreadCount({ enabled: isLoggedIn });
+
+  if (!isLoggedIn) {
+    return null;
+  }
+
+  const hasUnread = (data?.unreadCount ?? 0) > 0;
+
+  return (
+    <Link
+      href="/notification"
+      aria-label={hasUnread ? '알림 (안 읽음 있음)' : '알림'}
+      className={cn(
+        'relative flex h-9 w-9 items-center justify-center',
+        'rounded-2 bg-gray-100 text-gray-700 transition hover:bg-gray-200',
+        className
+      )}
+    >
+      <Icon name="Bell" size={16} />
+      {hasUnread ? (
+        <span
+          aria-hidden
+          className={cn(
+            'absolute top-2 right-2 h-1.5 w-1.5',
+            'bg-brand rounded-full'
+          )}
+        />
+      ) : null}
+    </Link>
+  );
+}


### PR DESCRIPTION
## GB — 비로그인 헤더에서 알림 벨 숨김

게스트에게 알림 벨이 그대로 노출됐다(스샷). 눌러도 로그인으로 튕기는 미끼라
비로그인이면 그리지 않는다. 채팅 아이콘은 이미 그렇게 동작하고 있었다.

**숨김 판정은 벨 컴포넌트 안에 뒀다.** 헤더가 데스크탑(`AppTopNav`)·모바일
(`HomeMobileHeader`) 둘이고 벨 마크업이 두 벌로 복사돼 있던 것이 이번 누락의
원인이다 — 부르는 쪽에 조건을 걸면 다음에 또 한쪽만 고쳐진다.
`ChatEntryButton` 과 같은 형태의 `NotificationBellButton` 으로 합쳤다.

결과: 비로그인 헤더에 남는 액션은 로그인 진입뿐. 로그인하면 원래대로 전부 표시.

## HD-10 정정 — 페이드는 되살리고 그림자 잔상만 제거

전환을 통째로 끈 것은 과했다. 잔상의 정체는 배경 페이드가 아니라 **그림자**다:
`transition-colors` 는 `box-shadow` 를 옮기지 않아 주황 글로만 페이드 밖에서
따로 놀았고, 그게 직전 칸에 남은 테두리처럼 보였다.

- 배경·글자 페이드 복구 — `transition-[background-color,color] duration-150`
- `box-shadow` 는 전환 목록에서 제외 → 즉시 붙고 즉시 사라짐

design-system `2.12.2` 로 반영, 클라 의존성도 함께 올림.

## HD-14 — 종료 배너 접힘↔펼침 삐걱임

접힘에서 `items-center` 였다. 28px chevron 버튼이 행 높이를 잡아 제목이
아래로 내려앉고, 펼치는 순간 다시 올라왔다. 항상 `items-start` 로 두고
세로 정렬은 버튼 마진으로 맞춘다(공지 배너와 같은 방식). 보관·안내 배너도
공지 배너와 같은 패딩(13/10)으로 통일.

## 검증

lint / tsc / knip / build 통과, 테스트 267개 통과. 브라우저 확인은 사용자 몫 —
직접 띄워보지 않았다.