### PR TITLE
feat(challenge/diary): 일지 양식 웹 parity (GA)

### DIFF
--- a/src/app.feature/challenge/board/type/challenge.ts
+++ b/src/app.feature/challenge/board/type/challenge.ts
@@ -97,8 +97,20 @@ export interface ChallengeListItem {
   randomParticipants?: RandomParticipant[];
 }
 
+/**
+ * 일지 양식(diaryTemplate) HTML 상한. 서버 400 은 이 값 초과일 때만 난다.
+ * 서버 허용 태그는 p br strong em u ul ol li pre code 뿐이고 나머지는
+ * 저장 시 스트립된다 — 양식 에디터는 이 목록 밖 노드를 만들지 않는다.
+ */
+export const DIARY_TEMPLATE_MAX_LENGTH = 50000;
+
 export interface ChallengeDetail {
   description: string;
+  /**
+   * 호스트가 정해 둔 일지 양식(HTML). 새 일지 본문의 출발점이 된다.
+   * 없거나 해제된 챌린지는 null/부재다.
+   */
+  diaryTemplate?: string | null;
   allowMidJoin?: boolean;
   // 인증샷(사진) 필수 여부(서버 JSON 키: photoRequired).
   photoRequired?: boolean;
@@ -178,6 +190,8 @@ export interface CreateChallengeRequest {
   challengeType: ChallengeType;
   // PRIVATE 일 때만 동봉하는 참여 비밀번호.
   password?: string;
+  // 일지 양식(HTML). 비워 두면 보내지 않는다.
+  diaryTemplate?: string;
 }
 
 // 변경할 필드만 포함 (생략 시 기존 값 유지, null 명시 시 삭제)
@@ -189,6 +203,8 @@ export interface UpdateChallengeRequest {
   allowMidJoin?: boolean;
   maxParticipantCnt?: number;
   goals?: string[];
+  /** 부재=미변경, null=양식 해제. 빈 문자열로 지우지 않는다. */
+  diaryTemplate?: string | null;
 }
 
 export interface CreateChallengeResponse {

--- a/src/app.feature/challenge/detail/components/ChallengeDiaryTemplateCard.tsx
+++ b/src/app.feature/challenge/detail/components/ChallengeDiaryTemplateCard.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { DiaryContentRenderer } from '@feature/diary/shared/components/DiaryContentRenderer';
+import { cn } from '@module/utils/cn';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import React, { useState } from 'react';
+
+/**
+ * 호스트가 정해 둔 일지 양식 미리보기.
+ *
+ * 기본은 접힘이다. 양식은 길 수 있어 펼친 채 두면 개요의 목표·정보
+ * 카드가 화면 밖으로 밀린다.
+ *
+ * 서버가 저장 시 허용목록으로 새니타이즈하지만, 렌더는
+ * DiaryContentRenderer 를 거친다 — 저장 이후에 들어온 값이나 캐시된
+ * 옛 값까지 신뢰하지 않기 위해 DOMPurify 를 한 번 더 태운다.
+ */
+export function ChallengeDiaryTemplateCard({
+  template,
+}: {
+  template: string;
+}): React.ReactElement {
+  const [expanded, setExpanded] = useState(false);
+  const Chevron = expanded ? ChevronUp : ChevronDown;
+
+  return (
+    <section
+      className={cn(
+        'rounded-[14px] border border-gray-200 bg-white',
+        'p-4 sm:p-5 lg:p-6'
+      )}
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center justify-between gap-2 text-left"
+      >
+        <Text
+          as="h2"
+          size="heading2"
+          weight="extrabold"
+          className="tracking-[-0.3px] text-gray-900"
+        >
+          일지 양식
+        </Text>
+        <Chevron className="h-4 w-4 shrink-0 text-gray-500" />
+      </button>
+
+      {expanded ? (
+        <div className="mt-3 border-t border-gray-100 pt-3">
+          <DiaryContentRenderer html={template} />
+        </div>
+      ) : (
+        <Text size="body2" className="mt-1 block text-gray-500">
+          이 챌린지는 일지 양식이 있어요. 새 일지를 쓰면 본문에 채워집니다.
+        </Text>
+      )}
+    </section>
+  );
+}

--- a/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
+++ b/src/app.feature/challenge/detail/screen/ChallengeDetailScreen.tsx
@@ -47,6 +47,7 @@ import { ChallengeDetailMobileHeader } from '../components/ChallengeDetailMobile
 import { ChallengeDiaryCalendar } from '../components/ChallengeDiaryCalendar';
 import { ChallengeDiaryDateFilter } from '../components/ChallengeDiaryDateFilter';
 import { ChallengeDiaryList } from '../components/ChallengeDiaryList';
+import { ChallengeDiaryTemplateCard } from '../components/ChallengeDiaryTemplateCard';
 import { ChallengeGoalModals } from '../components/ChallengeGoalModals';
 import { ChallengeInfoCard } from '../components/ChallengeInfoCard';
 import { ChallengeLeaderboardCard } from '../components/ChallengeLeaderboardCard';
@@ -791,6 +792,12 @@ export function ChallengeDetailScreen({
                       editLabel={rulesEditLabel}
                       onEdit={rulesOnEdit}
                     />
+
+                    {detail.diaryTemplate?.trim() ? (
+                      <ChallengeDiaryTemplateCard
+                        template={detail.diaryTemplate}
+                      />
+                    ) : null}
 
                     <ChallengeInfoCard
                       dateRangeText={dateRangeText}

--- a/src/app.feature/challenge/write/components/ChallengeDiaryTemplateSection.tsx
+++ b/src/app.feature/challenge/write/components/ChallengeDiaryTemplateSection.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Text } from '@1d1s/design-system';
+import { cn } from '@module/utils/cn';
+import dynamic from 'next/dynamic';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { DIARY_TEMPLATE_MAX_LENGTH } from '../../board/type/challenge';
+import { ChallengeCreateSectionCard } from './ChallengeCreateSectionCard';
+
+// tiptap 은 무겁다. 일지 작성 화면과 같은 이유로 동적 import 한다.
+const DiaryContentEditor = dynamic(
+  () =>
+    import('@feature/diary/write/components/DiaryContentEditor').then(
+      (mod) => mod.DiaryContentEditor
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className={cn(
+          'rounded-3 min-h-[220px] w-full animate-pulse border',
+          'border-gray-200 bg-gray-50'
+        )}
+        aria-hidden
+      />
+    ),
+  }
+);
+
+/**
+ * 호스트가 정하는 일지 양식. 생성·수정 화면이 같이 쓴다.
+ *
+ * 두 폼의 스키마는 갈라져 있지만 이 필드만은 이름·타입이 같아서 하나로
+ * 둘 수 있다. 섹션을 두 벌로 복사하면 다음 문구 수정이 한쪽에만 반영된다.
+ */
+export function ChallengeDiaryTemplateSection({
+  step,
+}: {
+  step: number;
+}): React.ReactElement {
+  const { watch, setValue } = useFormContext<{ diaryTemplate?: string }>();
+  const value = watch('diaryTemplate') ?? '';
+  const tooLong = value.length > DIARY_TEMPLATE_MAX_LENGTH;
+
+  return (
+    <ChallengeCreateSectionCard
+      step={step}
+      title="일지 양식"
+      hint="선택"
+    >
+      <Text size="caption2" className="mb-3 block text-gray-500">
+        참여자가 새 일지를 쓸 때 본문에 기본으로 채워집니다. 비워 두면
+        양식 없이 시작합니다.
+      </Text>
+      <DiaryContentEditor
+        variant="template"
+        content={value}
+        onChange={(html) =>
+          setValue('diaryTemplate', html, {
+            shouldDirty: true,
+            shouldValidate: true,
+          })
+        }
+      />
+      {tooLong ? (
+        <Text size="caption3" className="mt-2 block text-red-500">
+          일지 양식이 너무 깁니다. {DIARY_TEMPLATE_MAX_LENGTH}자 이하로
+          줄여주세요.
+        </Text>
+      ) : null}
+    </ChallengeCreateSectionCard>
+  );
+}

--- a/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
+++ b/src/app.feature/challenge/write/hooks/useChallengeCreateForm.ts
@@ -4,6 +4,8 @@ import { startOfToday } from 'date-fns';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
+import { DIARY_TEMPLATE_MAX_LENGTH } from '../../board/type/challenge';
+
 function isWholeNumberString(value?: string): boolean {
   return Boolean(value && /^\d+$/.test(value));
 }
@@ -52,6 +54,14 @@ export const challengeCreateFormSchema = z
     password: z.string().optional(),
     thumbnailImageKey: z.string().optional(),
     thumbnailPreviewUrl: z.string().optional(),
+    // 일지 양식(HTML). 상한만 막는다 — 태그 제한은 에디터가 맡는다.
+    diaryTemplate: z
+      .string()
+      .max(
+        DIARY_TEMPLATE_MAX_LENGTH,
+        `일지 양식은 ${DIARY_TEMPLATE_MAX_LENGTH}자 이하로 입력해주세요.`
+      )
+      .optional(),
     goals: z.array(
       z.object({
         value: z
@@ -175,6 +185,7 @@ export function useChallengeCreateForm(): ReturnType<
       postEndWriteAllowed: true,
       challengeType: 'PUBLIC',
       password: '',
+      diaryTemplate: '',
       goals: [],
     },
   });

--- a/src/app.feature/challenge/write/hooks/useChallengeEditForm.ts
+++ b/src/app.feature/challenge/write/hooks/useChallengeEditForm.ts
@@ -3,10 +3,11 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, type UseFormReturn } from 'react-hook-form';
 import { z } from 'zod';
 
-import type {
-  ChallengeCategory,
-  GoalType,
-  ParticipationType,
+import {
+  type ChallengeCategory,
+  DIARY_TEMPLATE_MAX_LENGTH,
+  type GoalType,
+  type ParticipationType,
 } from '../../board/type/challenge';
 
 function isWholeNumberString(value?: string): boolean {
@@ -45,6 +46,13 @@ export const challengeEditFormSchema = z
     thumbnailImageKey: z.string().optional(),
     thumbnailPreviewUrl: z.string().optional(),
     thumbnailRemoved: z.boolean(),
+    diaryTemplate: z
+      .string()
+      .max(
+        DIARY_TEMPLATE_MAX_LENGTH,
+        `일지 양식은 ${DIARY_TEMPLATE_MAX_LENGTH}자 이하로 입력해주세요.`
+      )
+      .optional(),
     goals: z.array(
       z.object({
         value: z
@@ -107,6 +115,7 @@ export interface ChallengeEditFormDefaults {
   allowMidJoin: boolean;
   thumbnailImageKey?: string;
   thumbnailPreviewUrl?: string;
+  diaryTemplate: string;
   goals: string[];
   participationType: ParticipationType;
   goalType: GoalType;
@@ -130,6 +139,7 @@ export function useChallengeEditForm(
       thumbnailImageKey: defaults.thumbnailImageKey,
       thumbnailPreviewUrl: defaults.thumbnailPreviewUrl,
       thumbnailRemoved: false,
+      diaryTemplate: defaults.diaryTemplate,
       goals: defaults.goals.map((value) => ({ value })),
       isGroup: defaults.participationType === 'GROUP',
       isFixedGoal: defaults.goalType === 'FIXED',

--- a/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeCreateScreen.tsx
@@ -24,6 +24,7 @@ import { ChallengeCreatePostEndWriteSection } from '@feature/challenge/write/com
 import { ChallengeCreatePreviewCard } from '@feature/challenge/write/components/ChallengeCreatePreviewCard';
 import { ChallengeCreateSuccessDialog } from '@feature/challenge/write/components/ChallengeCreateSuccessDialog';
 import { ChallengeCreateVisibilitySection } from '@feature/challenge/write/components/ChallengeCreateVisibilitySection';
+import { ChallengeDiaryTemplateSection } from '@feature/challenge/write/components/ChallengeDiaryTemplateSection';
 import {
   ChallengeCreateFormValues,
   useChallengeCreateForm,
@@ -207,6 +208,7 @@ export default function ChallengeCreateScreen(): React.ReactElement {
               <ChallengeCreateVisibilitySection />
               <ChallengeCreatePhotoSection />
               <ChallengeCreatePostEndWriteSection />
+              <ChallengeDiaryTemplateSection step={8} />
             </div>
 
             <aside className="hidden lg:block">

--- a/src/app.feature/challenge/write/screen/ChallengeEditScreen.tsx
+++ b/src/app.feature/challenge/write/screen/ChallengeEditScreen.tsx
@@ -16,6 +16,7 @@ import { Form } from '@component/ui/Form';
 import { useChallengeDetail } from '@feature/challenge/board/hooks/useChallengeQueries';
 import { isChallengeOngoing } from '@feature/challenge/board/utils/challengePeriod';
 import { useUpdateChallenge } from '@feature/challenge/detail/hooks/useChallengeMutations';
+import { ChallengeDiaryTemplateSection } from '@feature/challenge/write/components/ChallengeDiaryTemplateSection';
 import { ChallengeEditBannerSection } from '@feature/challenge/write/components/ChallengeEditBannerSection';
 import { ChallengeEditDialog } from '@feature/challenge/write/components/ChallengeEditDialog';
 import { ChallengeEditGoalSection } from '@feature/challenge/write/components/ChallengeEditGoalSection';
@@ -29,6 +30,7 @@ import {
   type EditableChallengeCategory,
   useChallengeEditForm,
 } from '@feature/challenge/write/hooks/useChallengeEditForm';
+import { hasTemplateContent } from '@feature/challenge/write/utils/challengeCreatePayload';
 import { getChallengeEditCtaHint } from '@feature/challenge/write/utils/challengeCtaHint';
 import { useAuthStatus } from '@module/hooks/useAuthStatus';
 import { useNativeSubmitBar } from '@module/hooks/useNativeSubmitBar';
@@ -88,6 +90,7 @@ function buildEditDefaults(
     memberCount: memberDefaults.memberCount,
     memberCountNumber: memberDefaults.memberCountNumber,
     allowMidJoin: detail.allowMidJoin ?? false,
+    diaryTemplate: detail.diaryTemplate ?? '',
     thumbnailImageKey: undefined,
     thumbnailPreviewUrl: summary.thumbnailImage ?? undefined,
     goals: (goals ?? []).map((goal) => goal.content),
@@ -149,6 +152,19 @@ function buildUpdatePayload(
       payload.goals = nextGoals;
     }
   }
+  // 양식은 비운 것과 안 건드린 것이 다르다. 지웠으면 null 로 해제를
+  // 명시한다 — 빈 문자열이나 <p></p> 를 보내면 빈 양식이 남는다.
+  const nextTemplate = values.diaryTemplate ?? '';
+  const hadTemplate = hasTemplateContent(defaults.diaryTemplate);
+  const hasTemplate = hasTemplateContent(nextTemplate);
+  if (hasTemplate) {
+    if (nextTemplate !== defaults.diaryTemplate) {
+      payload.diaryTemplate = nextTemplate;
+    }
+  } else if (hadTemplate) {
+    payload.diaryTemplate = null;
+  }
+
   if (values.thumbnailRemoved) {
     payload.thumbnailImage = null;
   } else if (values.thumbnailImageKey) {
@@ -265,6 +281,7 @@ function ChallengeEditScreenContent({
                 startDate={startDate}
                 endDate={endDate}
               />
+              <ChallengeDiaryTemplateSection step={5} />
             </div>
 
             <aside className="hidden lg:block">

--- a/src/app.feature/challenge/write/utils/challengeCreatePayload.test.ts
+++ b/src/app.feature/challenge/write/utils/challengeCreatePayload.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { ChallengeCreateFormValues } from '../hooks/useChallengeCreateForm';
 import {
   formatFormValues,
+  hasTemplateContent,
   resolveChallengeDurationDays,
   resolveMaxParticipantCnt,
 } from './challengeCreatePayload';
@@ -162,5 +163,33 @@ describe('formatFormValues', () => {
   it('defaults an empty description to an empty string', () => {
     const payload = formatFormValues(makeValues({ description: undefined }));
     expect(payload.description).toBe('');
+  });
+
+  it('omits an untouched diary template', () => {
+    // 빈 에디터가 내는 껍데기. 그대로 보내면 참여자 일지가 빈 양식으로
+    // 시작하고 개요에도 빈 섹션이 뜬다.
+    const payload = formatFormValues(makeValues({ diaryTemplate: '<p></p>' }));
+    expect(payload.diaryTemplate).toBeUndefined();
+  });
+
+  it('sends a diary template that has text', () => {
+    const values = makeValues({ diaryTemplate: '<p>오늘 한 일</p>' });
+    expect(formatFormValues(values).diaryTemplate).toBe('<p>오늘 한 일</p>');
+  });
+});
+
+describe('hasTemplateContent', () => {
+  it.each([
+    ['', false],
+    [undefined, false],
+    [null, false],
+    ['<p></p>', false],
+    ['<p><br></p>', false],
+    ['<p>&nbsp;</p>', false],
+    ['<ul><li></li></ul>', false],
+    ['<p>목표</p>', true],
+    ['<ul><li>운동</li></ul>', true],
+  ])('%s -> %s', (html, expected) => {
+    expect(hasTemplateContent(html)).toBe(expected);
   });
 });

--- a/src/app.feature/challenge/write/utils/challengeCreatePayload.ts
+++ b/src/app.feature/challenge/write/utils/challengeCreatePayload.ts
@@ -5,6 +5,20 @@ import { ChallengeCreateFormValues } from '../hooks/useChallengeCreateForm';
 
 const ENDLESS_CHALLENGE_END_DATE = '9999-12-31';
 
+/**
+ * 일지 양식에 실제로 쓸 내용이 있는가.
+ *
+ * 리치텍스트 에디터는 아무것도 안 써도 `<p></p>` 같은 빈 껍데기를 낸다.
+ * 그대로 보내면 참여자 일지가 빈 양식으로 시작하고, 개요에도 빈 섹션이
+ * 뜬다 — 태그를 걷어낸 실제 글자가 있을 때만 양식으로 친다.
+ */
+export function hasTemplateContent(html?: string | null): boolean {
+  if (!html) {
+    return false;
+  }
+  return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim().length > 0;
+}
+
 export function resolveChallengeDurationDays(
   values: ChallengeCreateFormValues
 ): number {
@@ -73,5 +87,9 @@ export function formatFormValues(
       values.challengeType === 'PRIVATE'
         ? values.password?.trim()
         : undefined,
+    // 빈 에디터는 <p></p> 를 내므로 길이로 판정하지 않는다.
+    diaryTemplate: hasTemplateContent(values.diaryTemplate)
+      ? values.diaryTemplate
+      : undefined,
   };
 }

--- a/src/app.feature/diary/write/components/DiaryContentEditor.tsx
+++ b/src/app.feature/diary/write/components/DiaryContentEditor.tsx
@@ -29,6 +29,13 @@ const lowlight = createLowlight(common);
 interface DiaryContentEditorProps {
   content: string;
   onChange(html: string): void;
+  /**
+   * 'template' 은 챌린지 일지 양식용이다. 서버가 양식에서 허용하는 태그는
+   * p br strong em u ul ol li pre code 뿐이라, 툴바에 없더라도 입력 규칙
+   * (`# `·`> `·`---`)으로 만들어지는 제목·인용·구분선을 **아예 끈다**.
+   * 켜 두면 호스트가 제목을 넣어 저장한 뒤 서버가 스트립해 조용히 사라진다.
+   */
+  variant?: 'diary' | 'template';
 }
 
 // 코드 블록이 문서 맨 위에 있고 첫 줄에 커서가 있을 때 ArrowUp을 누르면
@@ -143,12 +150,24 @@ function toggleCodeBlockMerged(editor: Editor): void {
 export function DiaryContentEditor({
   content,
   onChange,
+  variant = 'diary',
 }: DiaryContentEditorProps): React.ReactElement {
+  const isTemplate = variant === 'template';
   const lastSyncedHtmlRef = useRef('');
   const editor = useEditor({
     extensions: [
       // underline 은 StarterKit v3 에 포함 — 별도 등록 시 중복 경고
-      StarterKit.configure({ codeBlock: false }),
+      StarterKit.configure({
+        codeBlock: false,
+        ...(isTemplate
+          ? {
+              heading: false as const,
+              blockquote: false as const,
+              horizontalRule: false as const,
+              link: false as const,
+            }
+          : {}),
+      }),
       CodeBlockWithEscape.configure({ lowlight, defaultLanguage: 'plaintext' }),
       // TiptapImage, // 본문 이미지 삽입 기능은 임시 비활성화
     ],
@@ -242,14 +261,17 @@ export function DiaryContentEditor({
           </ToolbarButton>
         </div>
 
-        <div className="min-h-[420px] p-4">
+        <div className={cn(isTemplate ? 'min-h-[220px]' : 'min-h-[420px]', 'p-4')}>
           <EditorContent
             editor={editor}
             className={cn(
               'prose prose-sm max-w-none text-gray-700 outline-none',
               // prose 무효 → <p> 마진 0. 작성 화면도 본문과 같은 문단 간격.
               '[&_.tiptap>p]:my-2 [&_.tiptap>p:empty]:min-h-[1.5em]',
-              '[&_.tiptap]:min-h-[380px] [&_.tiptap]:outline-none',
+              isTemplate
+                ? '[&_.tiptap]:min-h-[180px]'
+                : '[&_.tiptap]:min-h-[380px]',
+              '[&_.tiptap]:outline-none',
               '[&_.tiptap_img]:max-h-80 [&_.tiptap_img]:rounded-lg',
               '[&_li]:mb-1 [&_ol]:list-decimal [&_ol]:pl-5',
               '[&_ul]:list-disc [&_ul]:pl-5',

--- a/src/app.feature/diary/write/hooks/useDiaryCreateForm.ts
+++ b/src/app.feature/diary/write/hooks/useDiaryCreateForm.ts
@@ -30,6 +30,7 @@ import { useAchievedDateGuard } from './useAchievedDateGuard';
 import { useDiaryEditInitializer } from './useDiaryEditInitializer';
 import { useDiaryImagePicker } from './useDiaryImagePicker';
 import { useDiarySubmit } from './useDiarySubmit';
+import { useDiaryTemplateInitializer } from './useDiaryTemplateInitializer';
 
 const EMPTY_GOALS: ChallengeGoal[] = [];
 
@@ -58,6 +59,9 @@ interface UseDiaryCreateFormResult {
   thumbnailIndex: number;
   /** 선택한 챌린지가 인증샷(사진) 필수인지 여부. */
   isPhotoRequired: boolean;
+  /** 본문이 주입된 일지 양식 그대로일 때만 true. */
+  canRemoveTemplate: boolean;
+  removeTemplate(): void;
   submitButtonLabel: string;
   canSubmit: boolean;
   isSubmitting: boolean;
@@ -320,6 +324,16 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
     setThumbnailImageUrl: imagePicker.setThumbnailImageUrl,
   });
 
+  // 새 일지에만 챌린지 양식을 채운다. challengeDetail 은 위에서 이미
+  // 받아 오고 있으므로 쿼리를 더 늘리지 않는다.
+  const { canRemoveTemplate, removeTemplate } = useDiaryTemplateInitializer({
+    isEditMode,
+    template: challengeDetail?.challengeDetail?.diaryTemplate,
+    challengeId: selectedChallenge?.challengeId,
+    content,
+    setContent,
+  });
+
   useEffect(() => {
     if (
       isEditMode ||
@@ -413,6 +427,8 @@ export function useDiaryCreateForm(): UseDiaryCreateFormResult {
     imagePreviewUrls: imagePicker.imagePreviewUrls,
     thumbnailIndex: imagePicker.thumbnailIndex,
     isPhotoRequired,
+    canRemoveTemplate,
+    removeTemplate,
     submitButtonLabel,
     canSubmit,
     isSubmitting,

--- a/src/app.feature/diary/write/hooks/useDiaryTemplateInitializer.ts
+++ b/src/app.feature/diary/write/hooks/useDiaryTemplateInitializer.ts
@@ -1,0 +1,73 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** 본문에 글자가 있는가. 빈 에디터는 `<p></p>` 같은 껍데기를 낸다. */
+function hasText(html: string): boolean {
+  return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim().length > 0;
+}
+
+interface UseDiaryTemplateInitializerParams {
+  /** 수정 모드에는 주입하지 않는다 — 쓰던 글을 양식이 덮어쓴다. */
+  isEditMode: boolean;
+  /** 선택된 챌린지의 일지 양식(HTML). 없으면 undefined/null. */
+  template?: string | null;
+  /** 챌린지를 바꾸면 다시 주입할 수 있게 기준이 된다. */
+  challengeId?: number | null;
+  content: string;
+  setContent: Dispatch<SetStateAction<string>>;
+}
+
+interface UseDiaryTemplateInitializerResult {
+  /** 본문이 주입된 양식 그대로일 때만 true — 제거 버튼 활성 조건. */
+  canRemoveTemplate: boolean;
+  removeTemplate(): void;
+}
+
+/**
+ * 새 일지에 챌린지 일지 양식을 채워 넣는다.
+ *
+ * 덮어쓰지 않는 것이 핵심이다. 이미 쓴 글이 있으면 건드리지 않고,
+ * 챌린지당 한 번만 주입한다 — 양식을 지우고 쓰기 시작했는데 쿼리가
+ * 다시 도착했다고 되살아나면 쓰던 글을 잃는다.
+ */
+export function useDiaryTemplateInitializer({
+  isEditMode,
+  template,
+  challengeId,
+  content,
+  setContent,
+}: UseDiaryTemplateInitializerParams): UseDiaryTemplateInitializerResult {
+  // 주입한 원문. 본문이 이것과 글자 하나까지 같을 때만 "손대지 않은
+  // 양식" 이다. 사용자가 한 글자라도 고치면 에디터가 정규화한 HTML 을
+  // 내보내 값이 갈라지므로, 그 시점부터 제거 버튼이 꺼진다.
+  const [injected, setInjected] = useState<string | null>(null);
+  const filledForChallengeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (isEditMode || !challengeId || !template || !hasText(template)) {
+      return;
+    }
+    if (filledForChallengeRef.current === challengeId) {
+      return;
+    }
+    filledForChallengeRef.current = challengeId;
+    if (hasText(content)) {
+      return;
+    }
+    setContent(template);
+    setInjected(template);
+    // content 는 "지금 비어 있나" 를 보는 값이라 의존성에 넣지 않는다.
+    // 넣으면 사용자가 타이핑할 때마다 이 effect 가 다시 돈다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [challengeId, isEditMode, setContent, template]);
+
+  const removeTemplate = useCallback(() => {
+    setContent('');
+    setInjected(null);
+  }, [setContent]);
+
+  return {
+    canRemoveTemplate: injected !== null && content === injected,
+    removeTemplate,
+  };
+}

--- a/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
+++ b/src/app.feature/diary/write/screen/DiaryCreateScreen.tsx
@@ -51,6 +51,8 @@ export default function DiaryCreateScreen(): React.ReactElement {
     setTitle,
     content,
     setContent,
+    canRemoveTemplate,
+    removeTemplate,
     selectedMood,
     setSelectedMood,
     achievedDate,
@@ -283,13 +285,23 @@ export default function DiaryCreateScreen(): React.ReactElement {
           <section>{thumbnailSlot}</section>
 
           <section>
-            <Text
-              size="caption1"
-              weight="bold"
-              className="mb-2 block text-gray-600"
-            >
-              오늘 이야기
-            </Text>
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <Text size="caption1" weight="bold" className="text-gray-600">
+                오늘 이야기
+              </Text>
+              {/* 양식을 손대기 전에만 켜진다. 한 글자라도 쓰고 나면 이
+                  버튼이 그 글까지 지우게 되므로 꺼진다. */}
+              {canRemoveTemplate ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={removeTemplate}
+                >
+                  양식 제거하기
+                </Button>
+              ) : null}
+            </div>
             <DiaryContentEditor content={content} onChange={setContent} />
           </section>
         </div>


### PR DESCRIPTION
앱에 들어간 일지 양식을 웹에도 붙였다. 서버 계약은 프로덕션 라이브.

## 웹 현황(작업 전)

| 항목 | 상태 |
|---|---|
| 챌린지 생성/수정 폼 | 있음. 단 두 폼 스키마가 갈라져 있어 필드를 양쪽에 각각 추가 |
| 리치텍스트 에디터 | 있음(`DiaryContentEditor`, Tiptap). 툴바가 서버 허용목록과 거의 일치 |
| HTML 렌더 | 있음(`DiaryContentRenderer`, DOMPurify + SSR 가드) |
| `diaryTemplate` | 웹에 전무 |
| 일지 작성 시 챌린지 상세 | 이미 조회 중 → 양식 주입에 새 쿼리 불필요 |

## 변경

**계약** — `ChallengeDetail.diaryTemplate`, `CreateChallengeRequest.diaryTemplate`,
`UpdateChallengeRequest.diaryTemplate`(부재=미변경, null=해제), 상한 50000.

**에디터** — 기존 에디터에 `variant='template'` 추가. 툴바에 없어도 입력 규칙으로
제목·인용·구분선이 만들어지는데 서버 허용목록 밖이라 저장 시 스트립된다. 호스트가
제목을 넣고 저장한 뒤 조용히 사라지는 것을 막으려 양식 모드에서는 해당 노드를 끈다.

**호스트 폼** — 생성·수정이 한 섹션을 공유. 빈 에디터가 내는 빈 문단 껍데기는 양식으로
치지 않는다. 수정에서 지웠으면 null 로 해제를 명시한다(빈 문자열은 해제가 아님).

**일지 작성** — 새 일지에만, 챌린지당 한 번만 주입. 이미 쓴 글이 있으면 안 건드린다.
"양식 제거하기"는 본문이 주입 원문 그대로일 때만 활성 — 한 글자라도 고치면 에디터가
정규화한 HTML 을 내보내 값이 갈라지고, 그때부턴 이 버튼이 사용자가 쓴 글까지 지우게
되므로 꺼진다.

**개요** — 기본 접힘 아코디언. 렌더는 `DiaryContentRenderer`(DOMPurify)를 거친다.

## 검증

lint / tsc / knip / build 통과, 테스트 278개 통과(신규 11). 브라우저 확인은
사용자 몫 — 직접 띄워보지 않았다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Challenge creators can add an optional diary template, with a 50,000-character limit.
  * Diary templates are displayed in challenge details through a collapsible preview.
  * New diaries automatically start with the selected challenge’s template.
  * Writers can remove an unchanged template before adding their own content.
  * Template editing provides a streamlined editor experience.

* **Bug Fixes**
  * Empty or whitespace-only templates are excluded from saved challenge data.
  * Clearing an existing template is handled correctly during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->