### PR TITLE
fix(diary): 본문 줄 간격이 문단 간격보다 넓던 것 (DIARY-typo)

### DIFF
--- a/src/app.feature/challenge/write/utils/challengeCreatePayload.ts
+++ b/src/app.feature/challenge/write/utils/challengeCreatePayload.ts
@@ -1,3 +1,4 @@
+import { hasHtmlText } from '@module/utils/html';
 import { add, format } from 'date-fns';
 
 import { CreateChallengeRequest } from '../../board/type/challenge';
@@ -12,12 +13,7 @@ const ENDLESS_CHALLENGE_END_DATE = '9999-12-31';
  * 그대로 보내면 참여자 일지가 빈 양식으로 시작하고, 개요에도 빈 섹션이
  * 뜬다 — 태그를 걷어낸 실제 글자가 있을 때만 양식으로 친다.
  */
-export function hasTemplateContent(html?: string | null): boolean {
-  if (!html) {
-    return false;
-  }
-  return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim().length > 0;
-}
+export const hasTemplateContent = hasHtmlText;
 
 export function resolveChallengeDurationDays(
   values: ChallengeCreateFormValues

--- a/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
+++ b/src/app.feature/diary/detail/screen/DiaryDetailScreen.tsx
@@ -352,7 +352,9 @@ function DiaryDetailView({
                   >
                     <DiaryContentRenderer
                       html={diaryData.contentHtml}
-                      className="text-[15px] leading-[1.9]"
+                      // 줄 간격은 렌더러가 정한다. 여기서 1.9 를 덮어쓰던
+                      // 탓에 줄 사이가 문단 사이보다 넓어 보였다.
+                      className="text-[15px]"
                     />
                   </div>
                 ) : null}

--- a/src/app.feature/diary/shared/components/DiaryContentRenderer.tsx
+++ b/src/app.feature/diary/shared/components/DiaryContentRenderer.tsx
@@ -69,7 +69,16 @@ export function DiaryContentRenderer({
         'prose prose-sm max-w-none text-gray-700',
         // typography 플러그인이 없어 prose 가 무효 → <p> 마진이 0이 되어
         // 문단 줄바꿈이 사라진다. 문단 간격과 빈 줄을 직접 복원한다.
-        '[&>p]:my-2 [&>p:empty]:min-h-[1.5em]',
+        //
+        // 세 간격이 서로 구분돼야 읽힌다. 줄 사이(0.5em) < 한 칸 개행
+        // (1.05em) < 두 칸 개행(2.6em). 예전엔 줄 사이가 0.9em 인데 문단
+        // 사이는 겨우 0.5em 더해져서, 문단이 바뀐 것인지 줄이 넘어간
+        // 것인지 구분이 안 됐다 — 줄 간격을 조이고 문단 간격을 키웠다.
+        'leading-[1.5]',
+        '[&>p]:my-[0.55em]',
+        // 빈 문단은 딱 한 줄 높이다. 본문 문단과 같은 여백까지 두면 두 칸
+        // 개행 한 번에 세 줄 가까이 벌어져 글이 뚝뚝 끊긴다.
+        '[&>p:empty]:my-0 [&>p:empty]:h-[1em]',
         '[&_img]:max-h-80 [&_img]:rounded-lg',
         '[&_li]:mb-1 [&_ol]:list-decimal [&_ol]:pl-5',
         '[&_ul]:list-disc [&_ul]:pl-5',

--- a/src/app.feature/diary/write/components/DiaryContentEditor.tsx
+++ b/src/app.feature/diary/write/components/DiaryContentEditor.tsx
@@ -267,7 +267,10 @@ export function DiaryContentEditor({
             className={cn(
               'prose prose-sm max-w-none text-gray-700 outline-none',
               // prose 무효 → <p> 마진 0. 작성 화면도 본문과 같은 문단 간격.
-              '[&_.tiptap>p]:my-2 [&_.tiptap>p:empty]:min-h-[1.5em]',
+              // 값이 갈리면 쓰면서 본 간격과 저장 후 간격이 달라진다.
+              'leading-[1.5]',
+              '[&_.tiptap>p]:my-[0.55em]',
+              '[&_.tiptap>p:empty]:my-0 [&_.tiptap>p:empty]:h-[1em]',
               isTemplate
                 ? '[&_.tiptap]:min-h-[180px]'
                 : '[&_.tiptap]:min-h-[380px]',

--- a/src/app.feature/diary/write/hooks/useDiaryTemplateInitializer.ts
+++ b/src/app.feature/diary/write/hooks/useDiaryTemplateInitializer.ts
@@ -1,10 +1,6 @@
+import { hasHtmlText } from '@module/utils/html';
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-
-/** 본문에 글자가 있는가. 빈 에디터는 `<p></p>` 같은 껍데기를 낸다. */
-function hasText(html: string): boolean {
-  return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim().length > 0;
-}
 
 interface UseDiaryTemplateInitializerParams {
   /** 수정 모드에는 주입하지 않는다 — 쓰던 글을 양식이 덮어쓴다. */
@@ -44,14 +40,14 @@ export function useDiaryTemplateInitializer({
   const filledForChallengeRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (isEditMode || !challengeId || !template || !hasText(template)) {
+    if (isEditMode || !challengeId || !template || !hasHtmlText(template)) {
       return;
     }
     if (filledForChallengeRef.current === challengeId) {
       return;
     }
     filledForChallengeRef.current = challengeId;
-    if (hasText(content)) {
+    if (hasHtmlText(content)) {
       return;
     }
     setContent(template);

--- a/src/app.module/utils/html.ts
+++ b/src/app.module/utils/html.ts
@@ -1,0 +1,7 @@
+/** 태그를 걷어낸 실제 글자가 있는가. */
+export function hasHtmlText(html?: string | null): boolean {
+  if (!html) {
+    return false;
+  }
+  return html.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim().length > 0;
+}


### PR DESCRIPTION
## 원인

`DiaryDetailScreen` 이 렌더러에 `leading-[1.9]` 를 덮어쓰고 있었다. 15px 본문에서
줄 사이가 약 0.9em 인데 문단 사이는 `my-2`(약 0.5em)만 더해졌다 — **줄이 넘어간
것이 문단이 바뀐 것보다 더 벌어져 보였다.** 한 칸/두 칸 개행이 구분 안 되던 이유다.

## 수정

세 간격이 서로 배수로 벌어지게 잡았다.

| | 이전(15px 기준) | 이후 |
|---|---|---|
| 줄 사이 | 0.9em | 0.5em |
| 한 칸 개행 | 0.5em 추가 | 1.05em |
| 두 칸 개행 | 약 2.5em | 2.6em |

- 렌더러 기본 `leading-[1.5]` (호출부의 `leading-[1.9]` 제거)
- 문단 마진 `my-2` → `my-[0.55em]` — 글자 크기를 따라간다
- 빈 문단은 `min-h-[1.5em]` + 문단 마진 → `h-[1em]` + 마진 0. 두 칸 개행이
  딱 한 줄 빈 칸이 된다(예전엔 본문 문단과 같은 여백까지 붙어 부풀었다)
- 작성 에디터도 같은 값으로 맞췄다 — 쓰면서 본 간격과 저장 후 간격이 갈리면 안 된다

## 범위

HTML 을 실제로 렌더하는 곳은 `DiaryContentRenderer` **하나**다(코드 전체에서
`dangerouslySetInnerHTML` 은 여기 한 곳뿐). 일지 상세 · 공지 상세 · 챌린지 일지
양식이 모두 이걸 쓰므로 한 곳 수정으로 전부 반영된다.

피드 카드(`DiaryCard`)와 채팅 공유 카드는 HTML 을 렌더하지 않고 태그를 걷어낸
평문만 보여준다 — 줄 간격 이슈가 없어 손대지 않았다.

## 덤

직전 GA 커밋에서 내가 같은 "태그 걷어내고 글자 있나" 헬퍼를 두 벌 복사해 뒀다.
`@module/utils/html` 의 `hasHtmlText` 하나로 합쳤다.

## 검증

lint / tsc / knip / build 통과, 테스트 278개 통과. 브라우저 확인은 사용자 몫 —
직접 띄워보지 않았다.
