### PR TITLE
fix(chat): 링크 프리뷰 카드 URL 스킴 검증

### DIFF
--- a/src/app.feature/chat/components/ChatShareCard.tsx
+++ b/src/app.feature/chat/components/ChatShareCard.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import React from 'react';
 
 import { ChatLinkPreview, ChatMessage, chatSharePath } from '../type/chat';
+import { isSafeHttpUrl } from '../utils/chatShareLink';
 import { ChatRoomThumbnail } from './ChatRoomThumbnail';
 
 // 공유 카드와 링크 미리보기의 폭. 둘이 제각각이면 말풍선 줄이 들쭉날쭉해
@@ -146,20 +147,19 @@ export function ChatLinkPreviewCard({
 }): React.ReactElement {
   const image = resolveDiaryImageUrl(preview.imageUrl);
   const siteName = preview.siteName ?? '';
+  // 스킴이 수상하면 카드는 그려도 링크로 만들지 않는다. 미리보기 내용을
+  // 지워 버리면 멀쩡한 프리뷰까지 잃는다.
+  const href = isSafeHttpUrl(preview.url) ? preview.url : null;
   // 유튜브 표시는 **배지에만** 빨강을 쓴다. 글씨나 테두리를 칠하지 않는다.
   const isYoutube = siteName.toLowerCase() === 'youtube';
 
-  return (
-    <a
-      href={preview.url}
-      target="_blank"
-      rel="noreferrer noopener"
-      onClick={(event) => event.stopPropagation()}
-      className={cn(
-        CARD_CLASS,
-        'block border-gray-200 bg-white transition-colors hover:bg-gray-50'
-      )}
-    >
+  const className = cn(
+    CARD_CLASS,
+    'block border-gray-200 bg-white',
+    href ? 'transition-colors hover:bg-gray-50' : null
+  );
+  const body = (
+    <>
       {image ? (
         // 외부 OG 이미지라 next/image remotePatterns 로 호스트를 고정할 수 없다.
         // eslint-disable-next-line @next/next/no-img-element
@@ -204,6 +204,21 @@ export function ChatLinkPreviewCard({
           </Text>
         ) : null}
       </div>
+    </>
+  );
+
+  if (!href) {
+    return <div className={className}>{body}</div>;
+  }
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      onClick={(event) => event.stopPropagation()}
+      className={className}
+    >
+      {body}
     </a>
   );
 }

--- a/src/app.feature/chat/utils/chatShareLink.ts
+++ b/src/app.feature/chat/utils/chatShareLink.ts
@@ -49,6 +49,27 @@ export function chatShareLinkIn(text: string): string | null {
 /** 본문 안의 URL. 링크가 없으면 대부분의 메시지처럼 그냥 글로 그린다. */
 export const CHAT_URL_PATTERN = /(https?:\/\/[^\s<>"]+)/gi;
 
+/**
+ * 눌러도 되는 주소인가. http(s) 만 통과시킨다.
+ *
+ * 서버가 링크 프리뷰를 만들 때 실제로 가져온 주소만 내려주므로 현실에서는
+ * 늘 http(s) 지만, 그 값이 그대로 `href` 로 들어가는 자리라 스킴을 여기서
+ * 한 번 확인한다 — `javascript:` 가 href 에 닿으면 클릭 한 번이 스크립트
+ * 실행이다. 본문 링크화는 정규식이 http(s) 로 시작하는 것만 잡아 이미
+ * 안전하고, 서버를 그대로 믿는 자리는 프리뷰 카드뿐이다.
+ */
+export function isSafeHttpUrl(value?: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 /** 링크 끝에 붙은 문장부호는 주소가 아니다 — "…watch?v=abc." 의 마침표. */
 export function trimUrlTail(url: string): string {
   const trailing = '.,;:!?)]}\'"';

--- a/src/app.feature/chat/utils/isSafeHttpUrl.test.ts
+++ b/src/app.feature/chat/utils/isSafeHttpUrl.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSafeHttpUrl } from './chatShareLink';
+
+describe('isSafeHttpUrl', () => {
+  it.each([
+    ['https://1day1streak.com', true],
+    ['http://example.com/a?b=1', true],
+    ['javascript:alert(1)', false],
+    ['JavaScript:alert(1)', false],
+    ['data:text/html,<script>alert(1)</script>', false],
+    ['vbscript:msgbox(1)', false],
+    ['/relative/path', false],
+    ['example.com', false],
+    ['', false],
+    [undefined, false],
+    [null, false],
+  ])('%s -> %s', (value, expected) => {
+    expect(isSafeHttpUrl(value)).toBe(expected);
+  });
+});


### PR DESCRIPTION
프로덕션 승격 전 XSS 점검에서 나온 유일한 미검증 sink. 프리뷰 카드가 `preview.url` 을 그대로 `href` 로 썼다.

현실에서는 서버가 실제로 가져온 주소만 내려주므로 늘 http(s) 지만, 서버 값을 그대로 믿는 자리는 여기뿐이라 스킴을 확인한다. 스킴이 수상하면 카드는 그리고 링크만 뗀다.

다른 경로는 이미 안전함을 확인했다 — 본문 링크화는 정규식이 http(s) 만 잡고, 공유 카드 링크는 숫자 id 로 조립하며, 일지 HTML 은 DOMPurify 를 지난다(`dangerouslySetInnerHTML` 은 코드 전체에서 그 한 곳).

테스트 289개 통과(신규 11), lint/tsc/knip/build 통과.